### PR TITLE
fix mismatching checks

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-ARG kube_bench_tag=0.1.0
+ARG kube_bench_tag=0.2.2
 ARG sonobuoy_version=0.16.3
 
 RUN apt-get update \

--- a/package/cfg/cis-1.4/master.yaml
+++ b/package/cfg/cis-1.4/master.yaml
@@ -1506,7 +1506,7 @@ groups:
     remediation: |
      [Manual test]
      Create a PSP as described in the Kubernetes documentation, ensuring that the .spec.hostPID field is omitted or set to false.
-    scored: false
+    scored: true
 
   - id: 1.7.3
     text: "Do not admit containers wishing to share the host IPC namespace (Scored)"
@@ -1514,7 +1514,7 @@ groups:
     remediation: |
       [Manual test]
       Create a PSP as described in the Kubernetes documentation, ensuring that the .spec.hostIPC field is omitted or set to false.
-    scored: false
+    scored: true
 
   - id: 1.7.4
     text: "Do not admit containers wishing to share the host network namespace (Scored)"
@@ -1522,7 +1522,7 @@ groups:
     remediation: |
       [Manual test]
       Create a PSP as described in the Kubernetes documentation, ensuring that the .spec.hostNetwork field is omitted or set to false.
-    scored: false
+    scored: true
 
   - id: 1.7.5
     text: " Do not admit containers with allowPrivilegeEscalation (Scored)"
@@ -1530,7 +1530,7 @@ groups:
     remediation: |
       [Manual test]
       Create a PSP as described in the Kubernetes documentation, ensuring that the .spec.allowPrivilegeEscalation field is omitted or set to false.
-    scored: false
+    scored: true
 
   - id: 1.7.6
     text: "Do not admit root containers (Not Scored)"

--- a/package/cfg/cis-1.4/master.yaml
+++ b/package/cfg/cis-1.4/master.yaml
@@ -497,6 +497,21 @@ groups:
     scored: true
 
   - id: 1.1.30
+    text: "Ensure that the --etcd-cafile argument is set as appropriate (Scored)"
+    audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+    tests:
+      test_items:
+        - flag: "--etcd-cafile"
+          set: true
+    remediation: |
+      Follow the Kubernetes documentation and set up the TLS connection between the
+      apiserver and etcd. Then, edit the API server pod specification file
+      $apiserverconf on the master node and set the etcd
+      certificate authority file parameter.
+      --etcd-cafile=<path/to/ca-file>
+    scored: true
+
+  - id: 1.1.31
     text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Not Scored)"
     audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
     tests:
@@ -511,21 +526,6 @@ groups:
       on the master node and set the below parameter.
       --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
     scored: false
-
-  - id: 1.1.31
-    text: "Ensure that the --etcd-cafile argument is set as appropriate (Scored)"
-    audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
-    tests:
-      test_items:
-      - flag: "--etcd-cafile"
-        set: true
-    remediation: |
-      Follow the Kubernetes documentation and set up the TLS connection between the
-      apiserver and etcd. Then, edit the API server pod specification file
-      $apiserverconf on the master node and set the etcd
-      certificate authority file parameter.
-      --etcd-cafile=<path/to/ca-file>
-    scored: true
 
   - id: 1.1.32
     text: "Ensure that the --authorization-mode argument is set to Node (Scored)"
@@ -1501,7 +1501,7 @@ groups:
     scored: false
 
   - id: 1.7.2
-    text: "Do not admit containers wishing to share the host process ID namespace (Not Scored)"
+    text: "Do not admit containers wishing to share the host process ID namespace (Scored)"
     type: "manual"
     remediation: |
      [Manual test]
@@ -1509,7 +1509,7 @@ groups:
     scored: false
 
   - id: 1.7.3
-    text: "Do not admit containers wishing to share the host IPC namespace (Not Scored)"
+    text: "Do not admit containers wishing to share the host IPC namespace (Scored)"
     type: "manual"
     remediation: |
       [Manual test]
@@ -1517,7 +1517,7 @@ groups:
     scored: false
 
   - id: 1.7.4
-    text: "Do not admit containers wishing to share the host network namespace (Not Scored)"
+    text: "Do not admit containers wishing to share the host network namespace (Scored)"
     type: "manual"
     remediation: |
       [Manual test]
@@ -1525,7 +1525,7 @@ groups:
     scored: false
 
   - id: 1.7.5
-    text: " Do not admit containers with allowPrivilegeEscalation (Not Scored)"
+    text: " Do not admit containers with allowPrivilegeEscalation (Scored)"
     type: "manual"
     remediation: |
       [Manual test]

--- a/package/cfg/rke-cis-1.4/master.yaml
+++ b/package/cfg/rke-cis-1.4/master.yaml
@@ -445,7 +445,7 @@ groups:
           --client-ca-file=<path/to/client-ca-file>
         scored: true
 
-      - id: 1.1.31
+      - id: 1.1.30
         text: "Ensure that the --etcd-cafile argument is set as appropriate (Scored)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:

--- a/package/cfg/rke-cis-1.4/master.yaml
+++ b/package/cfg/rke-cis-1.4/master.yaml
@@ -1124,3 +1124,61 @@ groups:
           Run the below command (based on the file location on your system) on the master node.
           For example, chmod -R 600 /etc/kubernetes/ssl/*key.pem
         scored: true
+  - id: 1.7
+    text: "PodSecurityPolicies"
+    checks:
+      - id: 1.7.2
+        text: "Do not admit containers wishing to share the host process ID namespace (Scored)"
+        audit: "kubectl get psp -o json | jq .items[] | jq -r 'select((.spec.hostPID == null) or (.spec.hostPID == false))' | jq .metadata.name | wc -l | xargs -I {} echo '--count={}'"
+        tests:
+          test_items:
+            - flag: "count"
+              compare:
+                op: gt
+                value: "0"
+              set: true
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that the .spec.hostPID field is omitted or set to false.
+        scored: true
+
+      - id: 1.7.3
+        text: "Do not admit containers wishing to share the host IPC namespace (Scored)"
+        audit: "kubectl get psp -o json | jq .items[] | jq -r 'select((.spec.hostIPC == null) or (.spec.hostIPC == false))' | jq .metadata.name | wc -l | xargs -I {} echo '--count={}'"
+        tests:
+          test_items:
+            - flag: "count"
+              compare:
+                op: gt
+                value: "0"
+              set: true
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that the .spec.hostIPC field is omitted or set to false.
+        scored: true
+
+      - id: 1.7.4
+        text: "Do not admit containers wishing to share the host network namespace (Scored)"
+        audit: "kubectl get psp -o json | jq .items[] | jq -r 'select((.spec.hostNetwork == null) or (.spec.hostNetwork == false))' | jq .metadata.name | wc -l | xargs -I {} echo '--count={}'"
+        tests:
+          test_items:
+            - flag: "count"
+              compare:
+                op: gt
+                value: "0"
+              set: true
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that the .spec.hostNetwork field is omitted or set to false.
+        scored: true
+
+      - id: 1.7.5
+        text: " Do not admit containers with allowPrivilegeEscalation (Scored)"
+        audit: "kubectl get psp -o json | jq .items[] | jq -r 'select((.spec.allowPrivilegeEscalation == null) or (.spec.allowPrivilegeEscalation == false))' | jq .metadata.name | wc -l | xargs -I {} echo '--count={}'"
+        tests:
+          test_items:
+            - flag: "count"
+              compare:
+                op: gt
+                value: "0"
+              set: true
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that the .spec.allowPrivilegeEscalation field is omitted or set to false.
+        scored: true


### PR DESCRIPTION
- The IDs for a couple of checks were swapped incorrectly, fixed.
- Some of the scored tests related to PSP were marked unscored incorrectly in upstream, fixed.

Related upstream PR: https://github.com/aquasecurity/kube-bench/pull/544