### PR TITLE
Update the tests to check default ServiceAccount (5.1.5) and default namespace (5.6.4)

### DIFF
--- a/package/cfg/rke-cis-1.5/policies.yaml
+++ b/package/cfg/rke-cis-1.5/policies.yaml
@@ -103,7 +103,14 @@ groups:
     checks:
       - id: 5.6.4
         text: "The default namespace should not be used (Scored)"
-        type: "manual"
+        audit: "kubectl get all -o json | jq .items[] | jq -r 'select((.metadata.name!=\"kubernetes\"))' | jq .metadata.name | wc -l | xargs -I {} echo '--count={}'"
+        tests:
+          test_items:
+            - flag: "count"
+              compare:
+                op: gt
+                value: "0"
+              set: true
         remediation: |
           Ensure that namespaces are created to allow for appropriate segregation of Kubernetes
           resources and that all new resources are created in a specific namespace.

--- a/package/helper_scripts/check_for_default_sa.sh
+++ b/package/helper_scripts/check_for_default_sa.sh
@@ -8,10 +8,23 @@ handle_error() {
 
 trap 'handle_error' ERR
 
-count=$(kubectl get serviceaccounts --all-namespaces -o json | jq -r '.items[] | select(.metadata.name=="default") | select((.automountServiceAccountToken == null) or (.automountServiceAccountToken == true))' | jq .metadata.namespace | wc -l)
+count_sa=$(kubectl get serviceaccounts --all-namespaces -o json | jq -r '.items[] | select(.metadata.name=="default") | select((.automountServiceAccountToken == null) or (.automountServiceAccountToken == true)) | select((.metadata.namespace!="default") and (.metadata.namespace!="kube-system"))' | jq .metadata.namespace | wc -l)
 if [[ ${count} -gt 0 ]]; then
     echo "false"
     exit
 fi
+
+count_rb=$(kubectl get rolebinding --all-namespaces -o json | jq -r '.items[].subjects[] | select(.kind=="ServiceAccount") | select(.name=="default")' | jq .metadata.namespace | wc -l)
+if [[ ${count_rb} -gt 0 ]]; then
+    echo "false"
+    exit
+fi
+
+count_crb=$(kubectl get clusterrolebinding --all-namespaces -o json | jq -r '.items[].subjects[] | select(.kind=="ServiceAccount") | select(.name=="default")' | jq .metadata.namespace | wc -l)
+if [[ ${count_crb} -gt 0 ]]; then
+    echo "false"
+    exit
+fi
+
 echo "true"
 


### PR DESCRIPTION
This PR updates the script to check default ServiceAccounts only for namespaces
 other than default and kube-system (as suggested in design review). Also now we check for rolebindings and clusterrolebindings using default serviceaccounts, as mentioned in the CIS document for the test 5.1.5.

For test 5.6.4 added the command to ensure no resource is found in default namespace other than the kubernetes service as mentioned in the CIS doc.