### PR TITLE
Fix the script for test 5.6.4 to check default namespace

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -24,6 +24,7 @@ COPY package/run.sh \
      package/helper_scripts/check_encryption_provider_config.sh \
      package/helper_scripts/check_for_network_policies.sh \
      package/helper_scripts/check_for_default_sa.sh \
+     package/helper_scripts/check_for_default_ns.sh \
      /usr/bin/
 
 CMD ["run.sh"]

--- a/package/cfg/rke-cis-1.5/policies.yaml
+++ b/package/cfg/rke-cis-1.5/policies.yaml
@@ -103,13 +103,13 @@ groups:
     checks:
       - id: 5.6.4
         text: "The default namespace should not be used (Scored)"
-        audit: "kubectl get all -o json | jq .items[] | jq -r 'select((.metadata.name!=\"kubernetes\"))' | jq .metadata.name | wc -l | xargs -I {} echo '--count={}'"
+        audit: check_for_default_ns.sh
         tests:
           test_items:
-            - flag: "count"
+            - flag: "true"
               compare:
-                op: gt
-                value: "0"
+                op: eq
+                value: "true"
               set: true
         remediation: |
           Ensure that namespaces are created to allow for appropriate segregation of Kubernetes

--- a/package/helper_scripts/check_for_default_ns.sh
+++ b/package/helper_scripts/check_for_default_ns.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -eE
+
+handle_error() {
+    echo "false"
+}
+
+trap 'handle_error' ERR
+
+count=$(kubectl get all -n default -o json | jq .items[] | jq -r 'select((.metadata.name!="kubernetes"))' | jq .metadata.name | wc -l)
+if [[ ${count} -gt 0 ]]; then
+    echo "false"
+    exit
+fi
+
+echo "true"
+

--- a/package/helper_scripts/check_for_default_sa.sh
+++ b/package/helper_scripts/check_for_default_sa.sh
@@ -9,7 +9,7 @@ handle_error() {
 trap 'handle_error' ERR
 
 count_sa=$(kubectl get serviceaccounts --all-namespaces -o json | jq -r '.items[] | select(.metadata.name=="default") | select((.automountServiceAccountToken == null) or (.automountServiceAccountToken == true)) | select((.metadata.namespace!="default") and (.metadata.namespace!="kube-system"))' | jq .metadata.namespace | wc -l)
-if [[ ${count} -gt 0 ]]; then
+if [[ ${count_sa} -gt 0 ]]; then
     echo "false"
     exit
 fi


### PR DESCRIPTION
The kubectl command using double-quotes does not run correctly with kube-bench - so adding the command to a new helper script - check_for_default_ns.sh 

Also fixing an error in check_for_default_sa.sh