### PR TITLE
Update the audit tests for CIS test (5.3.2)

### DIFF
--- a/package/cfg/rke-cis-1.5/policies.yaml
+++ b/package/cfg/rke-cis-1.5/policies.yaml
@@ -93,7 +93,14 @@ groups:
     checks:
       - id: 5.3.2
         text: "Ensure that all Namespaces have Network Policies defined (Scored)"
-        type: "manual"
+        audit: check_for_network_policies.sh
+        tests:
+          test_items:
+            - flag: "true"
+              compare:
+                op: eq
+                value: "true"
+              set: true
         remediation: |
           Follow the documentation and create NetworkPolicy objects as you need them.
         scored: true


### PR DESCRIPTION
This PR updates the audit check for CIS test 5.3.2

The audit is to ensure each namespace in the cluster has a network policy defined.

