### PR TITLE
Fixes to the audit script 5.1.5

### DIFF
--- a/package/helper_scripts/check_for_default_sa.sh
+++ b/package/helper_scripts/check_for_default_sa.sh
@@ -8,23 +8,24 @@ handle_error() {
 
 trap 'handle_error' ERR
 
-count_sa=$(kubectl get serviceaccounts --all-namespaces -o json | jq -r '.items[] | select(.metadata.name=="default") | select((.automountServiceAccountToken == null) or (.automountServiceAccountToken == true)) | select((.metadata.namespace!="default") and (.metadata.namespace!="kube-system"))' | jq .metadata.namespace | wc -l)
+count_sa=$(kubectl get serviceaccounts --all-namespaces -o json | jq -r '.items[] | select(.metadata.name=="default") | select((.automountServiceAccountToken == null) or (.automountServiceAccountToken == true))' | jq .metadata.namespace | wc -l)
 if [[ ${count_sa} -gt 0 ]]; then
     echo "false"
     exit
 fi
 
-count_rb=$(kubectl get rolebinding --all-namespaces -o json | jq -r '.items[].subjects[] | select(.kind=="ServiceAccount") | select(.name=="default")' | jq .metadata.namespace | wc -l)
-if [[ ${count_rb} -gt 0 ]]; then
-    echo "false"
-    exit
-fi
+for ns in $(kubectl get ns --no-headers -o custom-columns=":metadata.name")
+do
+    for result in $(kubectl get clusterrolebinding,rolebinding -n $ns -o json | jq -r '.items[] | select((.subjects[].kind=="ServiceAccount" and .subjects[].name=="default") or (.subjects[].kind=="Group" and .subjects[].name=="system:serviceaccounts"))' | jq -r '"\(.roleRef.kind),\(.roleRef.name)"')
+    do
+        read kind name <<<$(IFS=","; echo $result)
+        resource_count=$(kubectl get $kind $name -n $ns -o json | jq -r '.rules[] | select(.resources[] != "podsecuritypolicies")' | wc -l)
+        if [[ ${resource_count} -gt 0 ]]; then
+            echo "false"
+            exit
+        fi
+    done
+done
 
-count_crb=$(kubectl get clusterrolebinding --all-namespaces -o json | jq -r '.items[].subjects[] | select(.kind=="ServiceAccount") | select(.name=="default")' | jq .metadata.namespace | wc -l)
-if [[ ${count_crb} -gt 0 ]]; then
-    echo "false"
-    exit
-fi
 
 echo "true"
-


### PR DESCRIPTION
Changes to the audit script done for the CIS benchmark test 5.1.5:
1)  While checking for the "automountServiceAccountToken" of the default service accounts, we should not skip "default" and "kube-system" namespaces. 
Rancher controller to add this flag to the default SA skips these 2 NS so that the cluster bootup should not be affected; but CIS scan audit should still check it for all namespaces. It will a manual step needed by admins to make sure this flag is set for the default service accounts in "default" and "kube-system" namespaces 

2) Added check to make sure there are no rolebindings or clusterrolebindings for the default serviceaccounts or for the entire "system:serviceaccounts" against roles that are created for resources other than podsecuritypolicies.

There will be bindings present for "podsecuritypolicies" since we ask users to enable "restricted" psp. Only these psp bindings will be allowed.


So the test has 2 parts-
 a) default service accounts should have automount flag false
 b) no bindings against default svc accounts

Now (a) will fail on an rke cluster out of the box since in rancher we do not set this flag for the default service accounts in the "default" and "kube-system" namespace. But we will document that Admin should set these flags manually and then this will pass. Rancher wont set them for these 2 namespaces as it can interfere with the k8s cluster bootup.

(b): For a hardened rke cluster, we ask admins to enable "restricted" psp which will cause (b) to fail - but we are going to allow this psp bindings to be present in the audit