### PR TITLE
Add "warn" state, include unscored tests in report

### DIFF
--- a/pkg/kb-summarizer/report/report.go
+++ b/pkg/kb-summarizer/report/report.go
@@ -25,6 +25,7 @@ const (
 	Fail          State = "fail"
 	Skip          State = "skip"
 	Mixed         State = "mixed"
+	Warn          State = "warn"
 	NotApplicable State = "notApplicable"
 )
 
@@ -42,6 +43,8 @@ type Check struct {
 	ConfigCommands []*exec.Cmd `json:"config_commands"`
 	ActualValue    string      `json:"actual_value"`
 	ExpectedResult string      `json:"expected_result"`
+	TestType       string      `json:"test_type"`
+	Scored         bool        `json:"scored"`
 }
 
 type Group struct {
@@ -56,6 +59,7 @@ type Report struct {
 	Pass          int                   `json:"pass"`
 	Fail          int                   `json:"fail"`
 	Skip          int                   `json:"skip"`
+	Warn          int                   `json:"warn"`
 	NotApplicable int                   `json:"notApplicable"`
 	Nodes         map[NodeType][]string `json:"nodes"`
 	Results       []*Group              `json:"results"`
@@ -83,6 +87,8 @@ func mapState(state summarizer.State) State {
 		return Skip
 	case summarizer.Mixed:
 		return Mixed
+	case summarizer.Warn:
+		return Warn
 	case summarizer.NotApplicable:
 		return NotApplicable
 	}
@@ -112,6 +118,8 @@ func mapCheck(intCheck *summarizer.CheckWrapper) *Check {
 		ConfigCommands: intCheck.ConfigCommands,
 		ActualValue:    intCheck.ActualValue,
 		ExpectedResult: intCheck.ExpectedResult,
+		TestType:       intCheck.Type,
+		Scored:         intCheck.Scored,
 	}
 }
 
@@ -152,6 +160,7 @@ func mapReport(internalReport *summarizer.SummarizedReport) (*Report, error) {
 	externalReport.Pass = internalReport.Pass
 	externalReport.Fail = internalReport.Fail
 	externalReport.Skip = internalReport.Skip
+	externalReport.Warn = internalReport.Warn
 	externalReport.NotApplicable = internalReport.NotApplicable
 	externalReport.Nodes = mapNodes(internalReport.Nodes)
 

--- a/pkg/kb-summarizer/summarizer/summarizer.go
+++ b/pkg/kb-summarizer/summarizer/summarizer.go
@@ -59,6 +59,7 @@ const (
 	Skip          State = "S"
 	Mixed         State = "M"
 	NotApplicable State = "N"
+	Warn          State = "W"
 
 	SKIP kb.State = "SKIP"
 	NA   kb.State = "NA"
@@ -78,10 +79,10 @@ const (
 type CheckWrapper struct {
 	ID             string                       `yaml:"id" json:"id"`
 	Text           string                       `json:"d"`
-	Type           string                       `json:"-"`
+	Type           string                       `json:"tt"`
 	Remediation    string                       `json:"r"`
 	State          State                        `json:"s"`
-	Scored         bool                         `json:"-"`
+	Scored         bool                         `json:"sc"`
 	Result         map[kb.State]map[string]bool `json:"-"`
 	NodeType       []NodeType                   `json:"t"`
 	NodesMap       map[string]bool              `json:"-"`
@@ -106,6 +107,7 @@ type SummarizedReport struct {
 	Total         int                   `json:"t"`
 	Fail          int                   `json:"f"`
 	Pass          int                   `json:"p"`
+	Warn          int                   `json:"w"`
 	Skip          int                   `json:"s"`
 	NotApplicable int                   `json:"na"`
 	Nodes         map[NodeType][]string `json:"n"`
@@ -244,9 +246,6 @@ func (s *Summarizer) getBenchmarkFor(k8sVersion string) (string, error) {
 func (s *Summarizer) processOneResultFileForHost(results *kb.Controls, hostname string) {
 	for _, group := range results.Groups {
 		for _, check := range group.Checks {
-			if !check.Scored {
-				continue
-			}
 			logrus.Infof("host:%s id: %s %v", hostname, check.ID, check.State)
 			printCheck(check)
 			cw := s.checkWrappersMaps[check.ID]
@@ -444,9 +443,6 @@ func (s *Summarizer) loadControls() error {
 				s.groupWrappersMap[g.ID] = gw
 			}
 			for _, check := range g.Checks {
-				if !check.Scored {
-					continue
-				}
 				if check.Type == CheckTypeSkip {
 					check.State = NA
 				}
@@ -494,7 +490,7 @@ func getMappedState(state kb.State) State {
 	case kb.FAIL:
 		return Fail
 	case kb.WARN:
-		return Fail
+		return Warn
 	case kb.INFO:
 		return NotApplicable
 	case SKIP:
@@ -603,6 +599,17 @@ func (s *Summarizer) runFinalPassOnCheckWrapper(cw *CheckWrapper) {
 				cw.State = Mixed
 				s.fullReport.Fail++
 				cw.Nodes = s.getMissingNodesMapOfCheckWrapper(cw, cw.Result[SKIP])
+			}
+			return
+		}
+		if _, ok := cw.Result[kb.WARN]; ok {
+			if len(cw.Result[kb.WARN]) == nodeCount {
+				cw.State = Warn
+				s.fullReport.Warn++
+			} else {
+				cw.State = Mixed
+				s.fullReport.Warn++
+				cw.Nodes = s.getMissingNodesMapOfCheckWrapper(cw, cw.Result[kb.WARN])
 			}
 			return
 		}


### PR DESCRIPTION
This commit changes the report generation logic to include all tests, scored and unscored.
It also adds a new state "warn" corresponding to the "warn" output that kube-bench generates
for some of the manual tests.
It adds two new columns to the report, one to indicate if the test is scored/unscored and another
one to show if test is manual/automated

https://github.com/rancher/cis-operator/issues/45
https://github.com/rancher/cis-operator/issues/42