### PR TITLE
Copy over the actual result info of the test after running the scan from the kube-bench results

### DIFF
--- a/pkg/kb-summarizer/report/report.go
+++ b/pkg/kb-summarizer/report/report.go
@@ -30,21 +30,21 @@ const (
 )
 
 type Check struct {
-	ID             string      `yaml:"id" json:"id"`
-	Text           string      `json:"description"`
-	Remediation    string      `json:"remediation"`
-	State          State       `json:"state"`
-	NodeType       []NodeType  `json:"node_type"`
-	Nodes          []string    `json:"nodes,omitempty"`
-	Audit          string      `json:"audit"`
-	AuditConfig    string      `json:"audit_config"`
-	TestInfo       []string    `json:"test_info"`
-	Commands       []*exec.Cmd `json:"commands"`
-	ConfigCommands []*exec.Cmd `json:"config_commands"`
-	ActualValue    string      `json:"actual_value"`
-	ExpectedResult string      `json:"expected_result"`
-	TestType       string      `json:"test_type"`
-	Scored         bool        `json:"scored"`
+	ID                 string            `yaml:"id" json:"id"`
+	Text               string            `json:"description"`
+	Remediation        string            `json:"remediation"`
+	State              State             `json:"state"`
+	NodeType           []NodeType        `json:"node_type"`
+	Nodes              []string          `json:"nodes,omitempty"`
+	Audit              string            `json:"audit"`
+	AuditConfig        string            `json:"audit_config"`
+	TestInfo           []string          `json:"test_info"`
+	Commands           []*exec.Cmd       `json:"commands"`
+	ConfigCommands     []*exec.Cmd       `json:"config_commands"`
+	ActualValueNodeMap map[string]string `json:"actual_value_per_node"`
+	ExpectedResult     string            `json:"expected_result"`
+	TestType           string            `json:"test_type"`
+	Scored             bool              `json:"scored"`
 }
 
 type Group struct {
@@ -105,21 +105,21 @@ func mapNodeType(nodeType []summarizer.NodeType) []NodeType {
 
 func mapCheck(intCheck *summarizer.CheckWrapper) *Check {
 	return &Check{
-		ID:             intCheck.ID,
-		Text:           intCheck.Text,
-		Remediation:    intCheck.Remediation,
-		State:          mapState(intCheck.State),
-		NodeType:       mapNodeType(intCheck.NodeType),
-		Nodes:          intCheck.Nodes,
-		Audit:          intCheck.Audit,
-		AuditConfig:    intCheck.AuditConfig,
-		TestInfo:       intCheck.TestInfo,
-		Commands:       intCheck.Commands,
-		ConfigCommands: intCheck.ConfigCommands,
-		ActualValue:    intCheck.ActualValue,
-		ExpectedResult: intCheck.ExpectedResult,
-		TestType:       intCheck.Type,
-		Scored:         intCheck.Scored,
+		ID:                 intCheck.ID,
+		Text:               intCheck.Text,
+		Remediation:        intCheck.Remediation,
+		State:              mapState(intCheck.State),
+		NodeType:           mapNodeType(intCheck.NodeType),
+		Nodes:              intCheck.Nodes,
+		Audit:              intCheck.Audit,
+		AuditConfig:        intCheck.AuditConfig,
+		TestInfo:           intCheck.TestInfo,
+		Commands:           intCheck.Commands,
+		ConfigCommands:     intCheck.ConfigCommands,
+		ActualValueNodeMap: intCheck.ActualValueNodeMap,
+		ExpectedResult:     intCheck.ExpectedResult,
+		TestType:           intCheck.Type,
+		Scored:             intCheck.Scored,
 	}
 }
 


### PR DESCRIPTION
The information from the kube-bench results was not getting copied while creating the scan report - instead the test config as found in the config yamls was left as is after being initialized in loadControls(). Hence the data of fields like these was missing :
- audit_config
- actual_value
- expected_result

And also the interpolated values of variables in the the audit field were not being rendered in the final ClusterScanReport.


https://github.com/rancher/security-scan/issues/28
https://github.com/rancher/security-scan/issues/29