### PR TITLE
Changes to some tests audit config

### DIFF
--- a/package/cfg/rke-cis-1.5-hardened/node.yaml
+++ b/package/cfg/rke-cis-1.5-hardened/node.yaml
@@ -502,6 +502,7 @@ groups:
         # This is one of those properties that can only be set as a command line argument.
         # To check if the property is set as expected, we need to parse the kubelet command
         # instead reading the Kubelet Configuration file.
+        type: "skip"
         audit: "/bin/ps -fC $kubeletbin "
         tests:
           test_items:
@@ -514,6 +515,8 @@ groups:
           Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
+
+          Clusters provisioned by RKE set the --hostname-override to avoid any hostname configuration errors
         scored: false
 
       - id: 4.2.9

--- a/package/cfg/rke-cis-1.5-permissive/master.yaml
+++ b/package/cfg/rke-cis-1.5-permissive/master.yaml
@@ -690,6 +690,7 @@ groups:
 
       - id: 1.2.10
         text: "Ensure that the admission control plugin EventRateLimit is set (Not Scored)"
+        type: "skip"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:

--- a/package/cfg/rke-cis-1.5-permissive/node.yaml
+++ b/package/cfg/rke-cis-1.5-permissive/node.yaml
@@ -504,6 +504,7 @@ groups:
         # This is one of those properties that can only be set as a command line argument.
         # To check if the property is set as expected, we need to parse the kubelet command
         # instead reading the Kubelet Configuration file.
+        type: "skip"
         audit: "/bin/ps -fC $kubeletbin "
         tests:
           test_items:
@@ -516,6 +517,8 @@ groups:
           Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
+
+          Clusters provisioned by RKE set the --hostname-override to avoid any hostname configuration errors
         scored: false
 
       - id: 4.2.9

--- a/package/cfg/rke-cis-1.6-hardened/etcd.yaml
+++ b/package/cfg/rke-cis-1.6-hardened/etcd.yaml
@@ -5,6 +5,92 @@ id: 2
 text: "Etcd Node Configuration"
 type: "etcd"
 groups:
+  - id: 1.1
+    text: "Etcd Node Configuration Files"
+    checks:
+      - id: 1.1.11
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Scored)"
+        audit: stat -c %a /node/var/lib/etcd
+        tests:
+          test_items:
+            - flag: "700"
+              compare:
+                op: eq
+                value: "700"
+              set: true
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the below command:
+          ps -ef | grep etcd Run the below command (based on the etcd data directory found above). For example,
+          chmod 700 /var/lib/etcd
+        scored: true
+
+      - id: 1.1.12
+        text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Scored)"
+        audit: stat -c %U:%G /node/var/lib/etcd
+        tests:
+          test_items:
+            - flag: "etcd:etcd"
+              set: true
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the below command:
+          ps -ef | grep etcd
+          Run the below command (based on the etcd data directory found above).
+          For example, chown etcd:etcd /var/lib/etcd
+
+          A system service account is required for etcd data directory ownership.
+          Refer to Rancher's hardening guide for more details on how to configure this ownership.
+        scored: true
+
+      - id: 1.1.19
+        text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Scored)"
+        audit: "check_files_owner_in_dir.sh /node/etc/kubernetes/ssl"
+        tests:
+          test_items:
+            - flag: "true"
+              compare:
+                op: eq
+                value: "true"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown -R root:root /etc/kubernetes/pki/
+        scored: true
+
+      - id: 1.1.20
+        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Scored) "
+        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/!(*key).pem"
+        tests:
+          test_items:
+            - flag: "true"
+              compare:
+                op: eq
+                value: "true"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod -R 644 /etc/kubernetes/pki/*.crt
+        scored: true
+
+      - id: 1.1.21
+        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Scored)"
+        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/*key.pem 600"
+        tests:
+          test_items:
+            - flag: "true"
+              compare:
+                op: eq
+                value: "true"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod -R 600 /etc/kubernetes/ssl/*key.pem
+        scored: true
+
   - id: 2
     text: "Etcd Node Configuration Files"
     checks:

--- a/package/cfg/rke-cis-1.6-hardened/master.yaml
+++ b/package/cfg/rke-cis-1.6-hardened/master.yaml
@@ -136,37 +136,6 @@ groups:
           chown root:root <path/to/cni/files>
         scored: false
 
-      - id: 1.1.11
-        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c permissions=%a
-        tests:
-          test_items:
-            - flag: "permissions"
-              compare:
-                op: bitmask
-                value: "700"
-        remediation: |
-          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-          from the below command:
-          ps -ef | grep etcd
-          Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
-        scored: true
-
-      - id: 1.1.12
-        text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
-        audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G
-        tests:
-          test_items:
-            - flag: "etcd:etcd"
-        remediation: |
-          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-          from the below command:
-          ps -ef | grep etcd
-          Run the below command (based on the etcd data directory found above).
-          For example, chown etcd:etcd /var/lib/etcd
-        scored: true
-
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 644 or more restrictive (Automated)"
         type: "skip"
@@ -244,51 +213,6 @@ groups:
         remediation: |
           Cluster provisioned by RKE doesn't require or maintain a configuration file for controller-manager.
           All configuration is passed in as arguments at container run time.
-        scored: true
-
-      - id: 1.1.19
-        text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
-        audit: "check_files_owner_in_dir.sh /node/etc/kubernetes/ssl"
-        use_multiple_values: true
-        tests:
-          test_items:
-            - flag: "root:root"
-        remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chown -R root:root /etc/kubernetes/pki/
-        scored: true
-
-      - id: 1.1.20
-        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Automated)"
-        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/!(*key).pem"
-        tests:
-          test_items:
-            - flag: "true"
-              compare:
-                op: eq
-                value: "true"
-              set: true
-        remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chmod -R 644 /etc/kubernetes/pki/*.crt
-        scored: true
-
-      - id: 1.1.21
-        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Automated)"
-        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/*key.pem 600"
-        tests:
-          test_items:
-            - flag: "true"
-              compare:
-                op: eq
-                value: "true"
-              set: true
-        remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chmod -R 600 /etc/kubernetes/pki/*.key
         scored: true
 
   - id: 1.2

--- a/package/cfg/rke-cis-1.6-hardened/node.yaml
+++ b/package/cfg/rke-cis-1.6-hardened/node.yaml
@@ -376,6 +376,8 @@ groups:
           Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
+
+          Clusters provisioned by RKE set the --hostname-override to avoid any hostname configuration errors
         scored: false
 
       - id: 4.2.9

--- a/package/cfg/rke-cis-1.6-permissive/etcd.yaml
+++ b/package/cfg/rke-cis-1.6-permissive/etcd.yaml
@@ -5,6 +5,93 @@ id: 2
 text: "Etcd Node Configuration"
 type: "etcd"
 groups:
+  - id: 1.1
+    text: "Master Node Configuration Files "
+    checks:
+      - id: 1.1.11
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Scored)"
+        audit: stat -c %a /node/var/lib/etcd
+        tests:
+          test_items:
+            - flag: "700"
+              compare:
+                op: eq
+                value: "700"
+              set: true
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the below command:
+          ps -ef | grep etcd Run the below command (based on the etcd data directory found above). For example,
+          chmod 700 /var/lib/etcd
+        scored: true
+
+      - id: 1.1.12
+        text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Scored)"
+        type: "skip"
+        audit: stat -c %U:%G /node/var/lib/etcd
+        tests:
+          test_items:
+            - flag: "etcd:etcd"
+              set: true
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the below command:
+          ps -ef | grep etcd
+          Run the below command (based on the etcd data directory found above).
+          For example, chown etcd:etcd /var/lib/etcd
+
+          A system service account is required for etcd data directory ownership.
+          Refer to Rancher's hardening guide for more details on how to configure this ownership.
+        scored: true
+
+      - id: 1.1.19
+        text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Scored)"
+        audit: "check_files_owner_in_dir.sh /node/etc/kubernetes/ssl"
+        tests:
+          test_items:
+            - flag: "true"
+              compare:
+                op: eq
+                value: "true"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown -R root:root /etc/kubernetes/pki/
+        scored: true
+
+      - id: 1.1.20
+        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Scored) "
+        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/!(*key).pem"
+        tests:
+          test_items:
+            - flag: "true"
+              compare:
+                op: eq
+                value: "true"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod -R 644 /etc/kubernetes/pki/*.crt
+        scored: true
+
+      - id: 1.1.21
+        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Scored)"
+        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/*key.pem 600"
+        tests:
+          test_items:
+            - flag: "true"
+              compare:
+                op: eq
+                value: "true"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod -R 600 /etc/kubernetes/ssl/*key.pem
+        scored: true
+
   - id: 2
     text: "Etcd Node Configuration Files"
     checks:

--- a/package/cfg/rke-cis-1.6-permissive/master.yaml
+++ b/package/cfg/rke-cis-1.6-permissive/master.yaml
@@ -441,7 +441,7 @@ groups:
 
       - id: 1.2.10
         text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
-        type: "manual"
+        type: "skip"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:

--- a/package/cfg/rke-cis-1.6-permissive/master.yaml
+++ b/package/cfg/rke-cis-1.6-permissive/master.yaml
@@ -136,37 +136,6 @@ groups:
           chown root:root <path/to/cni/files>
         scored: false
 
-      - id: 1.1.11
-        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c permissions=%a
-        tests:
-          test_items:
-            - flag: "permissions"
-              compare:
-                op: bitmask
-                value: "700"
-        remediation: |
-          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-          from the below command:
-          ps -ef | grep etcd
-          Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
-        scored: true
-
-      - id: 1.1.12
-        text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
-        audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G
-        tests:
-          test_items:
-            - flag: "etcd:etcd"
-        remediation: |
-          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-          from the below command:
-          ps -ef | grep etcd
-          Run the below command (based on the etcd data directory found above).
-          For example, chown etcd:etcd /var/lib/etcd
-        scored: true
-
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 644 or more restrictive (Automated)"
         type: "skip"
@@ -244,51 +213,6 @@ groups:
         remediation: |
           Cluster provisioned by RKE doesn't require or maintain a configuration file for controller-manager.
           All configuration is passed in as arguments at container run time.
-        scored: true
-
-      - id: 1.1.19
-        text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
-        audit: "find /etc/kubernetes/pki/ | xargs stat -c %U:%G"
-        use_multiple_values: true
-        tests:
-          test_items:
-            - flag: "root:root"
-        remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chown -R root:root /etc/kubernetes/pki/
-        scored: true
-
-      - id: 1.1.20
-        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Automated)"
-        audit: "find /etc/kubernetes/pki -name '*.crt' | xargs stat -c permissions=%a"
-        use_multiple_values: true
-        tests:
-          test_items:
-            - flag: "permissions"
-              compare:
-                op: bitmask
-                value: "644"
-        remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chmod -R 644 /etc/kubernetes/pki/*.crt
-        scored: true
-
-      - id: 1.1.21
-        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Automated)"
-        audit: "find /etc/kubernetes/pki -name '*.key' | xargs stat -c permissions=%a"
-        use_multiple_values: true
-        tests:
-          test_items:
-            - flag: "permissions"
-              compare:
-                op: bitmask
-                value: "600"
-        remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chmod -R 600 /etc/kubernetes/pki/*.key
         scored: true
 
   - id: 1.2

--- a/package/cfg/rke-cis-1.6-permissive/node.yaml
+++ b/package/cfg/rke-cis-1.6-permissive/node.yaml
@@ -339,6 +339,8 @@ groups:
           Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
+
+          Clusters provisioned by RKE set the --hostname-override to avoid any hostname configuration errors
         scored: false
 
       - id: 4.2.9

--- a/package/cfg/rke-cis-1.6-permissive/policies.yaml
+++ b/package/cfg/rke-cis-1.6-permissive/policies.yaml
@@ -81,7 +81,7 @@ groups:
 
       - id: 5.2.2
         text: "Minimize the admission of containers wishing to share the host process ID namespace (Manual)"
-        type: "manual"
+        type: "skip"
         remediation: |
           Create a PSP as described in the Kubernetes documentation, ensuring that the
           .spec.hostPID field is omitted or set to false.
@@ -89,7 +89,7 @@ groups:
 
       - id: 5.2.3
         text: "Minimize the admission of containers wishing to share the host IPC namespace (Manual)"
-        type: "manual"
+        type: "skip"
         remediation: |
           Create a PSP as described in the Kubernetes documentation, ensuring that the
           .spec.hostIPC field is omitted or set to false.
@@ -97,7 +97,7 @@ groups:
 
       - id: 5.2.4
         text: "Minimize the admission of containers wishing to share the host network namespace (Manual)"
-        type: "manual"
+        type: "skip"
         remediation: |
           Create a PSP as described in the Kubernetes documentation, ensuring that the
           .spec.hostNetwork field is omitted or set to false.
@@ -105,7 +105,7 @@ groups:
 
       - id: 5.2.5
         text: "Minimize the admission of containers with allowPrivilegeEscalation (Manual)"
-        type: "manual"
+        type: "skip"
         remediation: |
           Create a PSP as described in the Kubernetes documentation, ensuring that the
           .spec.allowPrivilegeEscalation field is omitted or set to false.
@@ -159,7 +159,7 @@ groups:
 
       - id: 5.3.2
         text: "Ensure that all Namespaces have Network Policies defined (Manual)"
-        type: "manual"
+        type: "skip"
         remediation: |
           Follow the documentation and create NetworkPolicy objects as you need them.
         scored: false
@@ -241,7 +241,7 @@ groups:
 
       - id: 5.7.4
         text: "The default namespace should not be used (Manual)"
-        type: "manual"
+        type: "skip"
         remediation: |
           Ensure that namespaces are created to allow for appropriate segregation of Kubernetes
           resources and that all new resources are created in a specific namespace.


### PR DESCRIPTION
This PR adds following changes:
* The tests 1.2.10, 5.2.2, 5.2.3, 5.2.4, 5.2.5, 5.3.2 and 5.7.4 have been automated in hardened profiles
and pass on hardened clusters. But they don't pass on non-hardened clusters and generate "Warn" output.
This commit skips them on the permissive profile so they don't generate "Warn" output. They were skipped for the 1.5 profile, doing the same for 1.6 profile too

https://github.com/rancher/rancher/issues/29649#issuecomment-733985659

* For test 1.1.12 the RKE hardening guide provides steps on configuring etcd data directory ownership. So this test should be skipped on a non-hardened cluster since the ownership won't be configured on it. Also this test along with tests 1.1.11, 1.1.19, 1.1.20 and 1.1.21 was originally in master.yaml in the upstream profiles. But for RKE 1.5 profiles these 5 tests were moved from master.yaml to etcd.yaml to be run on the etcd nodes. This PR does the same for the RKE 1.6 profile moving these tests from master.yaml to etcd.yaml
https://github.com/rancher/cis-operator/issues/62

* Test 4.2.8 is to be skipped on all profiles, because RKE sets --hostname-override. This PR also adds the reason in remediation