### PR TITLE
Set type to manual for all manual tests

### DIFF
--- a/package/cfg/rke-cis-1.6-hardened/master.yaml
+++ b/package/cfg/rke-cis-1.6-hardened/master.yaml
@@ -476,6 +476,7 @@ groups:
 
       - id: 1.2.12
         text: "Ensure that the admission control plugin AlwaysPullImages is set (Manual)"
+        type: "manual"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -493,6 +494,7 @@ groups:
 
       - id: 1.2.13
         text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)"
+        type: "manual"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           bin_op: or

--- a/package/cfg/rke-cis-1.6-permissive/master.yaml
+++ b/package/cfg/rke-cis-1.6-permissive/master.yaml
@@ -441,6 +441,7 @@ groups:
 
       - id: 1.2.10
         text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
+        type: "manual"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -477,6 +478,7 @@ groups:
 
       - id: 1.2.12
         text: "Ensure that the admission control plugin AlwaysPullImages is set (Manual)"
+        type: "manual"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -493,6 +495,7 @@ groups:
 
       - id: 1.2.13
         text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)"
+        type: "manual"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           bin_op: or
@@ -863,6 +866,7 @@ groups:
 
       - id: 1.2.35
         text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Manual)"
+        type: "manual"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:

--- a/package/cfg/rke-cis-1.6-permissive/policies.yaml
+++ b/package/cfg/rke-cis-1.6-permissive/policies.yaml
@@ -10,6 +10,7 @@ groups:
     checks:
       - id: 5.1.1
         text: "Ensure that the cluster-admin role is only used where required (Manual)"
+        type: "manual"
         remediation: |
           Identify all clusterrolebindings to the cluster-admin role. Check if they are used and
           if they need this role or if they could use a role with fewer privileges.


### PR DESCRIPTION
Most of the manual tests, that have the word (Manual) in the text field are marked
manual by setting type to "manual". Some of these tests don't have type field set to anything.
The new column in cis report stays empty for such tests. This commit ensures any test which has
the word "Manual" in its text field is marked type:manual, so that all tests with an empty
test_type column can be assumed to be automated.

https://github.com/rancher/cis-operator/issues/45#issuecomment-742046103