### PR TITLE
Run tests for certs on etcd and master nodes

### DIFF
--- a/package/cfg/rke-cis-1.6-hardened/master.yaml
+++ b/package/cfg/rke-cis-1.6-hardened/master.yaml
@@ -215,6 +215,54 @@ groups:
           All configuration is passed in as arguments at container run time.
         scored: true
 
+      - id: 1.1.19
+        text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
+        audit: "check_files_owner_in_dir.sh /node/etc/kubernetes/ssl"
+        tests:
+          test_items:
+            - flag: "true"
+              compare:
+                op: eq
+                value: "true"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown -R root:root /etc/kubernetes/pki/
+        scored: true
+
+      - id: 1.1.20
+        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Automated) "
+        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/!(*key).pem"
+        tests:
+          test_items:
+            - flag: "true"
+              compare:
+                op: eq
+                value: "true"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod -R 644 /etc/kubernetes/pki/*.crt
+        scored: true
+
+      - id: 1.1.21
+        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Automated)"
+        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/*key.pem 600"
+        tests:
+          test_items:
+            - flag: "true"
+              compare:
+                op: eq
+                value: "true"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod -R 600 /etc/kubernetes/ssl/*key.pem
+        scored: true
+
   - id: 1.2
     text: "API Server"
     checks:

--- a/package/cfg/rke-cis-1.6-permissive/master.yaml
+++ b/package/cfg/rke-cis-1.6-permissive/master.yaml
@@ -215,6 +215,54 @@ groups:
           All configuration is passed in as arguments at container run time.
         scored: true
 
+      - id: 1.1.19
+        text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
+        audit: "check_files_owner_in_dir.sh /node/etc/kubernetes/ssl"
+        tests:
+          test_items:
+            - flag: "true"
+              compare:
+                op: eq
+                value: "true"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown -R root:root /etc/kubernetes/pki/
+        scored: true
+
+      - id: 1.1.20
+        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Automated) "
+        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/!(*key).pem"
+        tests:
+          test_items:
+            - flag: "true"
+              compare:
+                op: eq
+                value: "true"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod -R 644 /etc/kubernetes/pki/*.crt
+        scored: true
+
+      - id: 1.1.21
+        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Automated)"
+        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/*key.pem 600"
+        tests:
+          test_items:
+            - flag: "true"
+              compare:
+                op: eq
+                value: "true"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod -R 600 /etc/kubernetes/ssl/*key.pem
+        scored: true
+
   - id: 1.2
     text: "API Server"
     checks:


### PR DESCRIPTION
https://github.com/rancher/cis-operator/issues/62#issuecomment-743828261

Tests 1.1.19, 1.1.20 and 1.1.21 are for certs and should be run on both nodes, etcd and master. It was being run on both nodes for RKE 1.5 profiles. This commit adds these tests to master.yaml for both RKE 1.6 profiles too