### PR TITLE
fixes to summarizer tool to support custom benchmark 

### DIFF
--- a/package/run.sh
+++ b/package/run.sh
@@ -21,6 +21,7 @@ DS_SKIP_LOCATION="/etc/kbs/defaultskip/config.json"
 SONOBUOY_OUTPUT_DIR=${SONOBUOY_OUTPUT_DIR:-/tmp/sonobuoy}
 
 KB_SUMMARIZER_ROOT=${KB_SUMMARIZER_ROOT:-/tmp/kb-summarizer}
+CONFIG_DIR="${CONFIG_DIR:-/etc/kube-bench/cfg}"
 
 handle_error() {
   if [[ "${DEBUG}" == "true" ]]; then
@@ -130,6 +131,7 @@ if [[ "${OVERRIDE_BENCHMARK_VERSION}" != "" ]]; then
   echo "using OVERRIDE_BENCHMARK_VERSION: ${OVERRIDE_BENCHMARK_VERSION}"
   if ! kb-summarizer \
         --benchmark-version "${OVERRIDE_BENCHMARK_VERSION}" \
+        --controls-dir "${CONFIG_DIR}" \
         --input-dir "${KBS_INPUT_DIR}" \
         --output-dir "${KBS_OUTPUT_DIR}" \
         --output-filename "${KBS_OUTPUT_FILENAME}" 2> "${ERROR_LOG_FILE}"

--- a/package/run_sonobuoy_plugin.sh
+++ b/package/run_sonobuoy_plugin.sh
@@ -166,7 +166,7 @@ fi
 #   master nodes only
 if [[ "${OVERRIDE_BENCHMARK_VERSION}" != "" ]]; then
   if [[ "$(pgrep -f ${KUBE_APISERVER_PROC} | wc -l)" -gt 0 ]]; then
-    for controlFile in $(find ${CONFIG_DIR}/${OVERRIDE_BENCHMARK_VERSION} -name '*.yaml' ! -name config.yaml ! -name master.yaml ! -name node.yaml ! -name etcd.yaml); do
+    for controlFile in $(find ${CONFIG_DIR}/${OVERRIDE_BENCHMARK_VERSION}/ -name '*.yaml' ! -name config.yaml ! -name master.yaml ! -name node.yaml ! -name etcd.yaml); do
         echo "controlFile: ${controlFile}"
         target=$(basename "${controlFile}" .yaml)
         kube-bench run \


### PR DESCRIPTION
- Pass config dir to summarizer tool
- The find command in run.sh did not work for symbolic link to volume backed by configmap data unless a trailing / is provided to the absolute path

https://github.com/rancher/cis-operator/issues/69