### PR TITLE
Fix to K3s checks on non-etcd cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,25 @@ Multi-purpose repo:
 The corresponding docker image (rancher/security-scan) is used in the system charts.
 
 ## Building
-
 `make`
+
+Tag the image to personal docker hub repo
+
+`docker tag rancher/security-scan:<MAKE TAG OUTPUT> <DOCKER_HUB_USER>/security-scan:dev`
+
+Push docker tag
+
+`docker push <DOCKER_HUB_USER>/security-scan:dev`
+
+On Rancher install CIS Benchmark app, changing the Values YAML to point to your image
+```
+image:
+...
+    securityScan:
+        repository: <DOCKER_HUB_USER>/security-scan
+        tag: dev
+```
+
 
 ## License
 Copyright (c) 2019 [Rancher Labs, Inc.](http://rancher.com)

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -40,6 +40,7 @@ COPY package/run.sh \
     package/helper_scripts/check_for_network_policies.sh \
     package/helper_scripts/check_for_default_sa.sh \
     package/helper_scripts/check_for_default_ns.sh \
+    package/helper_scripts/check_for_k3s_etcd.sh \
     package/helper_scripts/check_for_rke2_network_policies.sh \
     package/helper_scripts/check_for_rke2_cni_net_policy_support.sh \
     package/helper_scripts/check_cafile_permissions.sh \

--- a/package/cfg/k3s-cis-1.6-hardened/etcd.yaml
+++ b/package/cfg/k3s-cis-1.6-hardened/etcd.yaml
@@ -10,7 +10,7 @@ groups:
     checks:
       - id: 2.1
         text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Automated)"
-        audit: "grep file /var/lib/rancher/k3s/server/db/etcd/config | grep -v trusted"
+        audit: "check_for_k3s_etcd.sh 2.1"
         tests:
           bin_op: and
           test_items:
@@ -28,7 +28,7 @@ groups:
 
       - id: 2.2
         text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
-        audit: "grep 'client-cert-auth' /var/lib/rancher/k3s/server/db/etcd/config"
+        audit: "check_for_k3s_etcd.sh 2.2"
         tests:
           test_items:
             - flag: "--client-cert-auth"
@@ -43,7 +43,7 @@ groups:
 
       - id: 2.3
         text: "Ensure that the --auto-tls argument is not set to true (Automated)"
-        audit: "grep 'auto-tls' /var/lib/rancher/k3s/server/db/etcd/config"
+        audit: "check_for_k3s_etcd.sh 2.3"
         tests:
           bin_op: or
           test_items:
@@ -61,7 +61,7 @@ groups:
 
       - id: 2.4
         text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
-        audit: "grep peer /var/lib/rancher/k3s/server/db/etcd/config | grep -v trusted | grep -v security | grep -v advertise | grep -v listen"
+        audit: "check_for_k3s_etcd.sh 2.4"
         tests:
           bin_op: and
           test_items:
@@ -80,7 +80,7 @@ groups:
 
       - id: 2.5
         text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
-        audit: "grep 'client-cert-auth' /var/lib/rancher/k3s/server/db/etcd/config"
+        audit: "check_for_k3s_etcd.sh 2.5"
         tests:
           test_items:
             - flag: "client-cert-auth"
@@ -95,7 +95,7 @@ groups:
 
       - id: 2.6
         text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
-        audit: "grep 'peer-auto-tls' /var/lib/rancher/k3s/server/db/etcd/config"
+        audit: "check_for_k3s_etcd.sh 2.6"
         tests:
           bin_op: or
           test_items:
@@ -114,7 +114,7 @@ groups:
 
       - id: 2.7
         text: "Ensure that a unique Certificate Authority is used for etcd (Manual)"
-        audit: "grep 'trusted-ca-file' /var/lib/rancher/k3s/server/db/etcd/config"
+        audit: "check_for_k3s_etcd.sh 2.7"
         tests:
           test_items:
             - flag: "--trusted-ca-file"

--- a/package/cfg/k3s-cis-1.6-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.6-hardened/master.yaml
@@ -146,7 +146,7 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: "stat -c %a /var/lib/rancher/k3s/server/db/etcd"
+        audit: "check_for_k3s_etcd.sh 1.1.11"
         tests:
           test_items:
             - flag: "700"
@@ -769,7 +769,7 @@ groups:
 
       - id: 1.2.29
         text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-'"
+        audit: "check_for_k3s_etcd.sh 1.2.29"
         tests:
           bin_op: and
           test_items:

--- a/package/cfg/k3s-cis-1.6-permissive/etcd.yaml
+++ b/package/cfg/k3s-cis-1.6-permissive/etcd.yaml
@@ -10,7 +10,7 @@ groups:
     checks:
       - id: 2.1
         text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Automated)"
-        audit: "grep file /var/lib/rancher/k3s/server/db/etcd/config | grep -v trusted"
+        audit: "check_for_k3s_etcd.sh 2.1"
         tests:
           bin_op: and
           test_items:
@@ -28,7 +28,7 @@ groups:
 
       - id: 2.2
         text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
-        audit: "grep 'client-cert-auth' /var/lib/rancher/k3s/server/db/etcd/config"
+        audit: "check_for_k3s_etcd.sh 2.2"
         tests:
           test_items:
             - flag: "--client-cert-auth"
@@ -43,7 +43,7 @@ groups:
 
       - id: 2.3
         text: "Ensure that the --auto-tls argument is not set to true (Automated)"
-        audit: "grep 'auto-tls' /var/lib/rancher/k3s/server/db/etcd/config"
+        audit: "check_for_k3s_etcd.sh 2.3"
         tests:
           bin_op: or
           test_items:
@@ -61,7 +61,7 @@ groups:
 
       - id: 2.4
         text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
-        audit: "grep peer /var/lib/rancher/k3s/server/db/etcd/config | grep -v trusted | grep -v security | grep -v advertise | grep -v listen"
+        audit: "check_for_k3s_etcd.sh 2.4"
         tests:
           bin_op: and
           test_items:
@@ -80,10 +80,10 @@ groups:
 
       - id: 2.5
         text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
-        audit: "grep 'client-cert-auth' /var/lib/rancher/k3s/server/db/etcd/config"
+        audit: "check_for_k3s_etcd.sh 2.5"
         tests:
           test_items:
-            - flag: "client-cert-auth"
+            - flag: "-client-cert-auth"
               compare:
                 op: eq
                 value: true
@@ -95,7 +95,7 @@ groups:
 
       - id: 2.6
         text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
-        audit: "grep 'peer-auto-tls' /var/lib/rancher/k3s/server/db/etcd/config"
+        audit: "check_for_k3s_etcd.sh 2.6"
         tests:
           bin_op: or
           test_items:
@@ -114,7 +114,7 @@ groups:
 
       - id: 2.7
         text: "Ensure that a unique Certificate Authority is used for etcd (Manual)"
-        audit: "grep 'trusted-ca-file' /var/lib/rancher/k3s/server/db/etcd/config"
+        audit: "check_for_k3s_etcd.sh 2.7"
         tests:
           test_items:
             - flag: "--trusted-ca-file"

--- a/package/cfg/k3s-cis-1.6-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.6-permissive/master.yaml
@@ -146,7 +146,7 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: "stat -c %a /var/lib/rancher/k3s/server/db/etcd"
+        audit: "check_for_k3s_etcd.sh 1.1.11"
         tests:
           test_items:
             - flag: "700"
@@ -769,7 +769,7 @@ groups:
 
       - id: 1.2.29
         text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-'"
+        audit: "check_for_k3s_etcd.sh 1.2.29"
         tests:
           bin_op: and
           test_items:

--- a/package/helper_scripts/check_for_k3s_etcd.sh
+++ b/package/helper_scripts/check_for_k3s_etcd.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# This script is used to ensure that k3s is actually running etcd (and not other databases like sqlite3)
+# before it checks the requirement
+set -eE
+
+handle_error() {
+    echo "false"
+}
+
+trap 'handle_error' ERR
+
+
+if [[ "$(journalctl -D /var/log/journal -u k3s | grep 'Managed etcd' | grep -v grep | wc -l)" -gt 0 ]]; then
+    case $1 in 
+        "1.1.11")
+            echo $(stat -c %a /var/lib/rancher/k3s/server/db/etcd);;
+        "1.2.29")
+            echo $(journalctl -D /var/log/journal -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-');;
+        "2.1")
+            echo $(grep file /var/lib/rancher/k3s/server/db/etcd/config | grep -v trusted);;
+        "2.2")
+            echo "$(grep 'client-cert-auth' /var/lib/rancher/k3s/server/db/etcd/config)";;
+        "2.3")
+            echo $(grep 'auto-tls' /var/lib/rancher/k3s/server/db/etcd/config);;
+        "2.4")
+            echo $(grep peer /var/lib/rancher/k3s/server/db/etcd/config | grep -v trusted | grep -v security | grep -v advertise | grep -v listen);;
+        "2.5")
+            echo "$(grep 'client-cert-auth' /var/lib/rancher/k3s/server/db/etcd/config)";;
+        "2.6")
+            echo $(grep 'peer-auto-tls' /var/lib/rancher/k3s/server/db/etcd/config);;
+        "2.7")
+            echo $(grep 'trusted-ca-file' /var/lib/rancher/k3s/server/db/etcd/config);;
+    esac
+else
+# If another database is running, return whatever is required to pass the scan
+    case $1 in
+        "1.1.11")
+            echo "700";;
+        "1.2.29")
+            echo "--etcd-certfile AND --etcd-keyfile";;
+        "2.1")
+            echo "cert-file AND key-file";;
+        "2.2")
+            echo "true";;
+        "2.3")
+            echo "false";;
+        "2.4")
+            echo "peer-cert-file AND peer-key-file";;
+        "2.5")
+            echo "true";;
+        "2.6")
+            echo "--peer-auto-tls=false";;
+        "2.7")
+            echo "--trusted-ca-file";;
+    esac
+fi

--- a/package/run_sonobuoy_plugin.sh
+++ b/package/run_sonobuoy_plugin.sh
@@ -59,7 +59,7 @@ mkdir -p "${RESULTS_DIR}"
 
 # etcd
 if [[ "${OVERRIDE_BENCHMARK_VERSION}" != "" ]]; then
-  if [[ "$(pgrep -f /etcd | wc -l)" -gt 0 ]]  || [[ "$(journalctl -D $JOURNAL_LOG -u k3s | grep 'Managed etcd' | grep -v grep | wc -l)" -gt 0 ]]; then
+  if [[ "$(pgrep -f /etcd | wc -l)" -gt 0 ]]  || [[ "$(journalctl -D $JOURNAL_LOG -u k3s | wc -l)" -gt 0 ]]; then
     echo "etcd: Using OVERRIDE_BENCHMARK_VERSION=${OVERRIDE_BENCHMARK_VERSION}"
     kube-bench run \
       --targets etcd \


### PR DESCRIPTION
Associated Issue: https://github.com/rancher/cis-operator/issues/100

This PR removes the if check around the etcd.yaml benchmarks, this was causing MIXED results on the scan. Now, all etcd related checks are run thru a helper script, which if etcd is running, performs the proper check. If etcd is not running, like on a single node using sqlite3, then the benchmarks are still run, but the helper script returns the correct answer for the check to pass. 

Both k3s permissive and hardened cis-1.6 scans now pass, on both etcd and non-etcd clusters.
![Screenshot from 2021-07-28 13-33-53](https://user-images.githubusercontent.com/11727736/127394170-e8e8e389-89bf-4bdf-8bfa-0aa0cb244908.png)
![Screenshot from 2021-07-27 11-32-20](https://user-images.githubusercontent.com/11727736/127394162-322fa96a-9429-46d5-a459-4b741a8b6aaa.png)
![Screenshot from 2021-07-27 11-32-31](https://user-images.githubusercontent.com/11727736/127394165-88d923b7-665e-4042-950e-b4cf6f47b159.png)
![Screenshot from 2021-07-28 12-25-46](https://user-images.githubusercontent.com/11727736/127394167-9773eaeb-18cd-4abe-99f6-e6b8c106341c.png)

