### PR TITLE
Fix  remediation message

### DIFF
--- a/package/cfg/rke2-cis-1.6-hardened/node.yaml
+++ b/package/cfg/rke2-cis-1.6-hardened/node.yaml
@@ -129,7 +129,7 @@ groups:
               set: true
         remediation: |
           Run the following command to modify the ownership of the --client-ca-file.
-          chown root:roset: trueot <filename>
+          chown root:root $kubeletcafile
         scored: true
 
       - id: 4.1.9


### PR DESCRIPTION
The kubeletcafile ownership remediation message for rke2 cis-1.6 doesn't look quite right.