### PR TITLE
Update sonobuoy to 0.53.2

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -11,7 +11,7 @@ RUN git clone -b v0.3.1 --depth 1 https://github.com/aquasecurity/kube-bench.git
 
 FROM ubuntu:18.04
 ARG kube_bench_tag=0.2.3-rancher-1
-ARG sonobuoy_version=0.52.0
+ARG sonobuoy_version=0.53.2
 
 RUN apt-get update \
     && apt-get install -y \


### PR DESCRIPTION
If this is ok to merge I'll need to backport to `v0.1.x` and `v0.2.x`, for the [rancher-cis-benchmark sytem chart](https://github.com/rancher/system-charts/blob/9d3c12a9704b5501baa87193a07fb9f953c465af/charts/rancher-cis-benchmark/0.2.0/values.yaml#:~:text=repository%3A%20rancher/security,tag%3A%20v0.1.14) and the [rancher-cis-benchmark feature chart](https://github.com/rancher/charts/blob/dev-v2.6/charts/rancher-cis-benchmark/rancher-cis-benchmark/2.0.0/values.yaml#:~:text=repository%3A%20rancher/security,tag%3A%20v0.2.3).