### PR TITLE
Add -D flag back to journalctl for etcd check

### DIFF
--- a/package/run_sonobuoy_plugin.sh
+++ b/package/run_sonobuoy_plugin.sh
@@ -59,7 +59,7 @@ mkdir -p "${RESULTS_DIR}"
 
 # etcd
 if [[ "${OVERRIDE_BENCHMARK_VERSION}" != "" ]]; then
-  if [[ "$(pgrep -f /etcd | wc -l)" -gt 0 ]]  || [[ "$(journalctl -u k3s | grep -wv 'No entries' | grep -wv 'Logs begin' | wc -l)" -gt 0 ]]; then
+  if [[ "$(pgrep -f /etcd | wc -l)" -gt 0 ]]  || [[ "$(journalctl -D $JOURNAL_LOG -u k3s | grep -wv 'No entries' | grep -wv 'Logs begin' | wc -l)" -gt 0 ]]; then
     echo "etcd: Using OVERRIDE_BENCHMARK_VERSION=${OVERRIDE_BENCHMARK_VERSION}"
     kube-bench run \
       --targets etcd \


### PR DESCRIPTION
When the etcd check was fixed for non k3s cluster, https://github.com/rancher/security-scan/commit/401227ea56a487f7cd85ae0dfc0ce08b2e762d7f, this had an unintended effect of damaging the original fix for k3s checks https://github.com/rancher/security-scan/commit/d7071178a48d01e3ec8ad03403847a63b9e5b8b0. This PR add back the missing flag and ensures k3s passes with all database types.  

Linking to the original issue as it remains unfixed without this PR: https://github.com/rancher/cis-operator/issues/100
Signed-off-by: dereknola <derek.nola@suse.com>