### PR TITLE
Allow RKE2 benchmarks to work with older `procps` versions

### DIFF
--- a/package/cfg/rke2-cis-1.5-hardened/config.yaml
+++ b/package/cfg/rke2-cis-1.5-hardened/config.yaml
@@ -12,7 +12,7 @@ master:
   apiserver:
     bins:
       - kube-apiserver
-    confs: 
+    confs:
       - /var/lib/rancher/rke2/agent/pod-manifests/kube-apiserver.yaml
     defaultconf: /var/lib/rancher/rke2/agent/pod-manifests/kube-apiserver.yaml
 
@@ -24,12 +24,10 @@ master:
     defaultconf: /var/lib/rancher/rke2/agent/pod-manifests/kube-scheduler.yaml
 
   controllermanager:
-    bins:
-      - kube-controller-manager
     confs:
       - /var/lib/rancher/rke2/agent/pod-manifests/kube-controller-manager.yaml
     defaultconf: /var/lib/rancher/rke2/agent/pod-manifests/kube-controller-manager.yaml
-  
+
   etcd:
     bins:
       - etcd
@@ -45,7 +43,7 @@ master:
     kubelet:
       defaultkubeconfig: /var/lib/rancher/rke2/agent/kubelet.kubeconfig
       defaultcafile: /var/lib/rancher/rke2/agent/client-ca.crt
-  
+
     proxy:
       defaultkubeconfig: /var/lib/rancher/rke2/agent/kubeproxy.kubeconfig
 

--- a/package/cfg/rke2-cis-1.5-permissive/config.yaml
+++ b/package/cfg/rke2-cis-1.5-permissive/config.yaml
@@ -12,7 +12,7 @@ master:
   apiserver:
     bins:
       - kube-apiserver
-    confs: 
+    confs:
       - /var/lib/rancher/rke2/agent/pod-manifests/kube-apiserver.yaml
     defaultconf: /var/lib/rancher/rke2/agent/pod-manifests/kube-apiserver.yaml
 
@@ -24,12 +24,10 @@ master:
     defaultconf: /var/lib/rancher/rke2/agent/pod-manifests/kube-scheduler.yaml
 
   controllermanager:
-    bins:
-      - kube-controller-manager
     confs:
       - /var/lib/rancher/rke2/agent/pod-manifests/kube-controller-manager.yaml
     defaultconf: /var/lib/rancher/rke2/agent/pod-manifests/kube-controller-manager.yaml
-  
+
   etcd:
     bins:
       - etcd
@@ -45,7 +43,7 @@ master:
     kubelet:
       defaultkubeconfig: /var/lib/rancher/rke2/agent/kubelet.kubeconfig
       defaultcafile: /var/lib/rancher/rke2/agent/client-ca.crt
-  
+
     proxy:
       defaultkubeconfig: /var/lib/rancher/rke2/agent/kubeproxy.kubeconfig
 

--- a/package/cfg/rke2-cis-1.6-hardened/config.yaml
+++ b/package/cfg/rke2-cis-1.6-hardened/config.yaml
@@ -12,7 +12,7 @@ master:
   apiserver:
     bins:
       - kube-apiserver
-    confs: 
+    confs:
       - /var/lib/rancher/rke2/agent/pod-manifests/kube-apiserver.yaml
     defaultconf: /var/lib/rancher/rke2/agent/pod-manifests/kube-apiserver.yaml
 
@@ -24,12 +24,10 @@ master:
     defaultconf: /var/lib/rancher/rke2/agent/pod-manifests/kube-scheduler.yaml
 
   controllermanager:
-    bins:
-      - kube-controller-manager
     confs:
       - /var/lib/rancher/rke2/agent/pod-manifests/kube-controller-manager.yaml
     defaultconf: /var/lib/rancher/rke2/agent/pod-manifests/kube-controller-manager.yaml
-  
+
   etcd:
     bins:
       - etcd
@@ -45,7 +43,7 @@ master:
     kubelet:
       defaultkubeconfig: /var/lib/rancher/rke2/agent/kubelet.kubeconfig
       defaultcafile: /var/lib/rancher/rke2/agent/client-ca.crt
-  
+
     proxy:
       defaultkubeconfig: /var/lib/rancher/rke2/agent/kubeproxy.kubeconfig
 

--- a/package/cfg/rke2-cis-1.6-permissive/config.yaml
+++ b/package/cfg/rke2-cis-1.6-permissive/config.yaml
@@ -24,8 +24,6 @@ master:
     defaultconf: /var/lib/rancher/rke2/agent/pod-manifests/kube-scheduler.yaml
 
   controllermanager:
-    bins:
-      - kube-controller-manager
     confs:
       - /var/lib/rancher/rke2/agent/pod-manifests/kube-controller-manager.yaml
     defaultconf: /var/lib/rancher/rke2/agent/pod-manifests/kube-controller-manager.yaml


### PR DESCRIPTION
`controllermanager.bins[]` has `kube-controller` in `cfg/config.yaml`, so the override in the profile `config.yaml` isn't needed.

When run:

```
I1015 17:19:12.665026  148762 util.go:70] ps - proc: "kube-controller-manager"
I1015 17:19:12.792614  148762 util.go:74] [/bin/ps -C kube-controller-manager -o cmd --no-headers]: exit status 1
I1015 17:19:12.792677  148762 util.go:77] ps - returning: ""
I1015 17:19:12.792740  148762 util.go:219] reFirstWord.Match()
I1015 17:19:12.792762  148762 util.go:249] executable 'kube-controller-manager' not running
I1015 17:19:12.792782  148762 util.go:70] ps - proc: "kube-controller"
I1015 17:19:12.929012  148762 util.go:77] ps - returning: "kube-controller-manager --flex-volume-plugin-dir=/var/lib/kubelet/volumeplugins --terminated-pod-gc-threshold=1000 --permit-port-sharing=true --cloud-provider=aws --cloud-config= --address=127.0.0.1 --allocate-node-cidrs=true --bind-address=127.0.0.1 --cluster-cidr=10.42.0.0/16 --cluster-signing-kube-apiserver-client-cert-file=/var/lib/rancher/rke2/server/tls/client-ca.crt --cluster-signing-kube-apiserver-client-key-file=/var/lib/rancher/rke2/server/tls/client-ca.key --cluster-signing-kubelet-client-cert-file=/var/lib/rancher/rke2/server/tls/client-ca.crt --cluster-signing-kubelet-client-key-file=/var/lib/rancher/rke2/server/tls/client-ca.key --cluster-signing-kubelet-serving-cert-file=/var/lib/rancher/rke2/server/tls/server-ca.crt --cluster-signing-kubelet-serving-key-file=/var/lib/rancher/rke2/server/tls/server-ca.key --cluster-signing-legacy-unknown-cert-file=/var/lib/rancher/rke2/server/tls/client-ca.crt --cluster-signing-legacy-unknown-key-file=/var/lib/rancher/rke2/server/tls/client-ca.key --kubeconfig=/var/lib/rancher/rke2/server/cred/controller.kubeconfig --port=10252 --profiling=false --root-ca-file=/var/lib/rancher/rke2/server/tls/server-ca.crt --secure-port=0 --service-account-private-key-file=/var/lib/rancher/rke2/server/tls/service.key --use-service-account-credentials=true\n"
I1015 17:19:12.929184  148762 util.go:219] reFirstWord.Match(kube-controller-manager --flex-volume-plugin-dir=/var/lib/kubelet/volumeplugins --terminated-pod-gc-threshold=1000 --permit-port-sharing=true --cloud-provider=aws --cloud-config= --address=127.0.0.1 --allocate-node-cidrs=true --bind-address=127.0.0.1 --cluster-cidr=10.42.0.0/16 --cluster-signing-kube-apiserver-client-cert-file=/var/lib/rancher/rke2/server/tls/client-ca.crt --cluster-signing-kube-apiserver-client-key-file=/var/lib/rancher/rke2/server/tls/client-ca.key --cluster-signing-kubelet-client-cert-file=/var/lib/rancher/rke2/server/tls/client-ca.crt --cluster-signing-kubelet-client-key-file=/var/lib/rancher/rke2/server/tls/client-ca.key --cluster-signing-kubelet-serving-cert-file=/var/lib/rancher/rke2/server/tls/server-ca.crt --cluster-signing-kubelet-serving-key-file=/var/lib/rancher/rke2/server/tls/server-ca.key --cluster-signing-legacy-unknown-cert-file=/var/lib/rancher/rke2/server/tls/client-ca.crt --cluster-signing-legacy-unknown-key-file=/var/lib/rancher/rke2/server/tls/client-ca.key --kubeconfig=/var/lib/rancher/rke2/server/cred/controller.kubeconfig --port=10252 --profiling=false --root-ca-file=/var/lib/rancher/rke2/server/tls/server-ca.crt --secure-port=0 --service-account-private-key-file=/var/lib/rancher/rke2/server/tls/service.key --use-service-account-credentials=true)
I1015 17:19:12.929264  148762 util.go:106] Component controllermanager uses running binary kube-controller
```

```
I1015 17:19:13.601852  148762 util.go:382] Substituting $controllermanagerbin with 'kube-controller'
```

Closes #59 
