### PR TITLE
Fix etcd checks for k3s clusters

### DIFF
--- a/package/cfg/k3s-cis-1.6-hardened/etcd.yaml
+++ b/package/cfg/k3s-cis-1.6-hardened/etcd.yaml
@@ -83,7 +83,7 @@ groups:
         audit: "check_for_k3s_etcd.sh 2.5"
         tests:
           test_items:
-            - flag: "client-cert-auth"
+            - flag: "--client-cert-auth"
               compare:
                 op: eq
                 value: true
@@ -117,7 +117,7 @@ groups:
         audit: "check_for_k3s_etcd.sh 2.7"
         tests:
           test_items:
-            - flag: "--trusted-ca-file"
+            - flag: "trusted-ca-file"
               set: true
         remediation: |
           [Manual test]

--- a/package/cfg/k3s-cis-1.6-permissive/etcd.yaml
+++ b/package/cfg/k3s-cis-1.6-permissive/etcd.yaml
@@ -83,7 +83,7 @@ groups:
         audit: "check_for_k3s_etcd.sh 2.5"
         tests:
           test_items:
-            - flag: "-client-cert-auth"
+            - flag: "--client-cert-auth"
               compare:
                 op: eq
                 value: true
@@ -117,7 +117,7 @@ groups:
         audit: "check_for_k3s_etcd.sh 2.7"
         tests:
           test_items:
-            - flag: "--trusted-ca-file"
+            - flag: "trusted-ca-file"
               set: true
         remediation: |
           [Manual test]

--- a/package/helper_scripts/check_for_k3s_etcd.sh
+++ b/package/helper_scripts/check_for_k3s_etcd.sh
@@ -18,15 +18,15 @@ if [[ "$(journalctl -D /var/log/journal -u k3s | grep 'Managed etcd' | grep -v g
         "1.2.29")
             echo $(journalctl -D /var/log/journal -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-');;
         "2.1")
-            echo $(grep file /var/lib/rancher/k3s/server/db/etcd/config | grep -v trusted);;
+            echo $(grep -A 5 'client-transport-security' /var/lib/rancher/k3s/server/db/etcd/config | grep -E 'cert-file|key-file');;
         "2.2")
-            echo "$(grep 'client-cert-auth' /var/lib/rancher/k3s/server/db/etcd/config)";;
+            echo "$(grep -A 5 'client-transport-security' /var/lib/rancher/k3s/server/db/etcd/config | grep 'client-cert-auth')";;
         "2.3")
             echo $(grep 'auto-tls' /var/lib/rancher/k3s/server/db/etcd/config);;
         "2.4")
-            echo $(grep peer /var/lib/rancher/k3s/server/db/etcd/config | grep -v trusted | grep -v security | grep -v advertise | grep -v listen);;
+            echo $(grep -A 5 'peer-transport-security' /var/lib/rancher/k3s/server/db/etcd/config | grep -E 'cert-file|key-file');;
         "2.5")
-            echo "$(grep 'client-cert-auth' /var/lib/rancher/k3s/server/db/etcd/config)";;
+            echo "$(grep -A 5 'peer-transport-security' /var/lib/rancher/k3s/server/db/etcd/config | grep 'client-cert-auth')";;
         "2.6")
             echo $(grep 'peer-auto-tls' /var/lib/rancher/k3s/server/db/etcd/config);;
         "2.7")


### PR DESCRIPTION
Resolves a couple of issues:

1. Using `rancher/security-scan:v0.2.5-rc1`, a hardened k3s cluster has two failures in hardened scans and one in permissive scans related to etcd.
**Permissive Scan:**
<img width="1229" alt="image" src="https://user-images.githubusercontent.com/55997940/142285349-eaa7ee4c-99ba-46ce-bc43-84f4c4ce5787.png">

**Hardened Scan:**
<img width="1224" alt="image" src="https://user-images.githubusercontent.com/55997940/142285408-fdca2249-4440-4b75-9532-fddf13f2b3c7.png">

2. Ensure the `grep` checks being performed are looking at more specific args to correctly validate the CIS control.