### PR TITLE
[2.6.4] Add AKS as an option to run CIS Scan

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -7,7 +7,7 @@ RUN zypper --non-interactive update \
     && zypper --non-interactive install \
     git
 
-RUN git clone -b v0.3.1 --depth 1 https://github.com/aquasecurity/kube-bench.git
+RUN git clone -b v0.6.6 --depth 1 https://github.com/aquasecurity/kube-bench.git
 
 FROM registry.suse.com/suse/sle15:15.3
 ARG kube_bench_tag=0.2.3-rancher-1

--- a/package/cfg/config.yaml
+++ b/package/cfg/config.yaml
@@ -212,6 +212,7 @@ version_mapping:
   "v1.18.10+rke2r1": "rke2-cis-1.5-permissive"
   "eks-1.0": "eks-1.0"
   "gke-1.0": "gke-1.0"
+  "aks-1.0": "aks-1.0"	
   "v1.20.5+rke2r1": "rke2-cis-1.6-hardened"
   "v1.20.5+rke2r1": "rke2-cis-1.6-permissive"
   "v1.20.5+k3s1": "k3s-cis-1.6-hardened"
@@ -280,6 +281,8 @@ target_mapping:
     - "node"
     - "managedservices"
     - "policies"
+  "aks-1.0":	
+    - "node"
   "rke2-cis-1.6-hardened":
     - "master"
     - "node"


### PR DESCRIPTION
Linked Issue: 
https://github.com/rancher/rancher/issues/35844

**What has changed?**

This PR includes 2 changes:

1. _[New Feature]_ Incorporate option to run the CIS Scan for the Microsoft Azure AKS cluster. The upstream kube-bench aks-1.0 benchmark version has been added to the `rancher/security-scan` repo to be able to run the CIS Scan on the AKS cluster.
2. _[Bug fix]_ Logic change in the summarizer to read the required controls of a benchmark from `config.yaml`. While testing the result of AKS CIS Scan, we figured that the summarizer logic needs to be changed as it was ignoring the controls defined in the `target_mapping` for a particular benchmark in `config.yaml` which was causing a gap between kube-bench output result and summarizer result. This change fixes this issue.

**How to test:**

1. Create an AKS cluster
```
AKS Cluster config:
Kubernetes Version: v1.21.2
VM Size: Standard_DS2_v2
VM Operating System: Ubuntu 18.04.6 LTS

Rancher Version: v2.6.2
```
2. Deploy the the CIS operator chart with updated `rancher/security-scan` image
3. Go to CIS Benchmark -> Create Scan -> Select the Scan profile `aks-1.0`
4. Run the scan

**Expected Output:**
```
summary:
    total: 15
    pass: 15
    fail: 0
    warn: 0
    skip: 0
    notApplicable: 0
```



