### PR TITLE
Skip non-applicable check for rke2 permissive scans

### DIFF
--- a/package/cfg/rke2-cis-1.6-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.6-permissive/master.yaml
@@ -1002,6 +1002,7 @@ groups:
           on the master node and set the --feature-gates parameter to include RotateKubeletServerCertificate=true.
           --feature-gates=RotateKubeletServerCertificate=true
         scored: true
+        type: skip
 
       - id: 1.3.7
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"


### PR DESCRIPTION
This check should be skipped based on https://docs.rke2.io/security/cis_self_assessment16/#136

It is already skipped in the hardened scans (marked Not Applicable in the rancher UI).