### PR TITLE
Add set flag for rke-cis-1.6-hardened profile

### DIFF
--- a/package/cfg/rke-cis-1.6-hardened/master.yaml
+++ b/package/cfg/rke-cis-1.6-hardened/master.yaml
@@ -953,6 +953,7 @@ groups:
               compare:
                 op: eq
                 value: "127.0.0.1"
+              set: true  
             - flag: "--bind-address"
               set: false
         remediation: |
@@ -989,6 +990,7 @@ groups:
               compare:
                 op: eq
                 value: "127.0.0.1"
+              set: true  
             - flag: "--bind-address"
               set: false
         remediation: |


### PR DESCRIPTION
This PR  adds `set` flag in `rke-cis-1.6-hardened` profile for 1.3.7 and 1.4.2 tests which was missing.