### PR TITLE
Fix for failing tests for rke2 scan profiles

### DIFF
--- a/package/cfg/rke2-cis-1.5-hardened/etcd.yaml
+++ b/package/cfg/rke2-cis-1.5-hardened/etcd.yaml
@@ -5,6 +5,73 @@ id: 2
 text: "Etcd Node Configuration"
 type: "etcd"
 groups:
+- id: 1.1
+  text: "Master Node Configuration Files "
+  checks:
+    - id: 1.1.7
+      text: "Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Scored)"
+      audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %a $etcdconf; fi'"
+      tests:
+        test_items:
+          - flag: "644"
+            compare:
+              op: eq
+              value: "644"
+            set: true
+      remediation: |
+        Run the below command (based on the file location on your system) on the master node.
+        For example,
+        chmod 644 $etcdconf
+      scored: true
+
+    - id: 1.1.8
+      text: "Ensure that the etcd pod specification file ownership is set to root:root (Scored)"
+      audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
+      tests:
+        test_items:
+          - flag: "root:root"
+            compare:
+              op: eq
+              value: "root:root"
+            set: true
+      remediation: |
+        Run the below command (based on the file location on your system) on the master node.
+        For example,
+        chown root:root $etcdconf
+      scored: true
+    
+    - id: 1.1.11
+      text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Scored)"
+      audit: stat -c %a /var/lib/rancher/rke2/server/db/etcd 
+      tests:
+        test_items:
+          - flag: "700"
+            compare:
+              op: eq
+              value: "700"
+            set: true
+      remediation: |
+        On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+        from the below command:
+        ps -ef | grep etcd Run the below command (based on the etcd data directory found above). For example,
+        chmod 700 /var/lib/etcd
+      scored: true
+
+    - id: 1.1.12
+      text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Scored)"
+      audit: stat -c %U:%G /var/lib/rancher/rke2/server/db/etcd
+      tests:
+        test_items:
+          - flag: "etcd:etcd"
+            set: true
+      remediation: |
+        On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+        from the below command:
+        ps -ef | grep etcd
+        Run the below command (based on the etcd data directory found above).
+        For example, chown etcd:etcd /var/lib/etcd
+      scored: true      
+
 - id: 2
   text: "Etcd Node Configuration Files"
   checks:

--- a/package/cfg/rke2-cis-1.5-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.5-hardened/master.yaml
@@ -238,20 +238,21 @@ groups:
       scored: true
 
     - id: 1.1.20
-      text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Scored) "
+      text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Manual) "
       audit: "check_files_permissions.sh /var/lib/rancher/rke2/server/tls/*.crt 644"
+      use_multiple_values: true
       tests:
         test_items:
-          - flag: "true"
+          - flag: "permissions"
             compare:
-              op: eq
-              value: "true"
+              op: bitmask
+              value: "644"
             set: true
       remediation: |
         Run the below command (based on the file location on your system) on the master node.
         For example,
         chmod -R 644 /var/lib/rancher/rke2/server/tls/*.crt
-      scored: true
+      scored: false    
 
     - id: 1.1.21
       text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Scored)"

--- a/package/cfg/rke2-cis-1.5-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.5-hardened/master.yaml
@@ -105,38 +105,6 @@ groups:
         chown root:root $schedulerconf
       scored: true
 
-    - id: 1.1.7
-      text: "Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Scored)"
-      audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %a $etcdconf; fi'"
-      tests:
-        test_items:
-          - flag: "644"
-            compare:
-              op: eq
-              value: "644"
-            set: true
-      remediation: |
-        Run the below command (based on the file location on your system) on the master node.
-        For example,
-        chmod 644 $etcdconf
-      scored: true
-
-    - id: 1.1.8
-      text: "Ensure that the etcd pod specification file ownership is set to root:root (Scored)"
-      audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
-      tests:
-        test_items:
-          - flag: "root:root"
-            compare:
-              op: eq
-              value: "root:root"
-            set: true
-      remediation: |
-        Run the below command (based on the file location on your system) on the master node.
-        For example,
-        chown root:root $etcdconf
-      scored: true
-
     - id: 1.1.9
       text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Not Scored)"
       audit: "stat -c %a <path/to/cni/files>"
@@ -156,38 +124,6 @@ groups:
         For example,
         chown root:root <path/to/cni/files>
       scored: false
-
-    - id: 1.1.11
-      text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Scored)"
-      audit: stat -c %a /var/lib/rancher/rke2/server/db/etcd 
-      tests:
-        test_items:
-          - flag: "700"
-            compare:
-              op: eq
-              value: "700"
-            set: true
-      remediation: |
-        On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-        from the below command:
-        ps -ef | grep etcd Run the below command (based on the etcd data directory found above). For example,
-        chmod 700 /var/lib/etcd
-      scored: true
-
-    - id: 1.1.12
-      text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Scored)"
-      audit: stat -c %U:%G /var/lib/rancher/rke2/server/db/etcd
-      tests:
-        test_items:
-          - flag: "etcd:etcd"
-            set: true
-      remediation: |
-        On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-        from the below command:
-        ps -ef | grep etcd
-        Run the below command (based on the etcd data directory found above).
-        For example, chown etcd:etcd /var/lib/etcd
-      scored: true
 
     - id: 1.1.13
       text: "Ensure that the admin.conf file permissions are set to 644 or more restrictive (Scored)"

--- a/package/cfg/rke2-cis-1.5-hardened/node.yaml
+++ b/package/cfg/rke2-cis-1.5-hardened/node.yaml
@@ -168,19 +168,19 @@ groups:
       scored: true
 
     - id: 4.1.7
-      text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Scored)"
+      text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Manual)"
       audit: "stat -c %a /var/lib/rancher/rke2/server/tls/server-ca.crt"
       tests:
         test_items:
           - flag: "644"
             compare:
-              op: eq
+              op: bitmask
               value: "644"
             set: true
       remediation: |
         Run the following command to modify the file permissions of the
-        --client-ca-file chmod 600 <filename>
-      scored: true
+        --client-ca-file chmod 644 <filename>
+      scored: false
 
     - id: 4.1.8
       text: "Ensure that the client certificate authorities file ownership is set to root:root (Scored)"

--- a/package/cfg/rke2-cis-1.5-permissive/etcd.yaml
+++ b/package/cfg/rke2-cis-1.5-permissive/etcd.yaml
@@ -5,6 +5,74 @@ id: 2
 text: "Etcd Node Configuration"
 type: "etcd"
 groups:
+- id: 1.1
+  text: "Master Node Configuration Files "
+  checks:
+    - id: 1.1.7
+      text: "Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Scored)"
+      audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %a $etcdconf; fi'"
+      tests:
+        test_items:
+          - flag: "644"
+            compare:
+              op: eq
+              value: "644"
+            set: true
+      remediation: |
+        Run the below command (based on the file location on your system) on the master node.
+        For example,
+        chmod 644 $etcdconf
+      scored: true
+
+    - id: 1.1.8
+      text: "Ensure that the etcd pod specification file ownership is set to root:root (Scored)"
+      audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
+      tests:
+        test_items:
+          - flag: "root:root"
+            compare:
+              op: eq
+              value: "root:root"
+            set: true
+      remediation: |
+        Run the below command (based on the file location on your system) on the master node.
+        For example,
+        chown root:root $etcdconf
+      scored: true
+      
+    - id: 1.1.11
+      text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Scored)"
+      audit: stat -c %a /var/lib/rancher/rke2/server/db/etcd 
+      tests:
+        test_items:
+          - flag: "700"
+            compare:
+              op: eq
+              value: "700"
+            set: true
+      remediation: |
+        On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+        from the below command:
+        ps -ef | grep etcd Run the below command (based on the etcd data directory found above). For example,
+        chmod 700 /var/lib/etcd
+      scored: true
+
+    - id: 1.1.12
+      text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Scored)"
+      type: "skip"
+      audit: stat -c %U:%G /var/lib/rancher/rke2/server/db/etcd
+      tests:
+        test_items:
+          - flag: "etcd:etcd"
+            set: true
+      remediation: |
+        On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+        from the below command:
+        ps -ef | grep etcd
+        Run the below command (based on the etcd data directory found above).
+        For example, chown etcd:etcd /var/lib/etcd
+      scored: true        
+
 - id: 2
   text: "Etcd Node Configuration Files"
   checks:

--- a/package/cfg/rke2-cis-1.5-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.5-permissive/master.yaml
@@ -238,20 +238,21 @@ groups:
       scored: true
 
     - id: 1.1.20
-      text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Scored) "
+      text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Manual) "
       audit: "check_files_permissions.sh /var/lib/rancher/rke2/server/tls/*.crt 644"
+      use_multiple_values: true
       tests:
         test_items:
-          - flag: "true"
+          - flag: "permissions"
             compare:
-              op: eq
-              value: "true"
+              op: bitmask
+              value: "644"
             set: true
       remediation: |
         Run the below command (based on the file location on your system) on the master node.
         For example,
         chmod -R 644 /var/lib/rancher/rke2/server/tls/*.crt
-      scored: true
+      scored: false
 
     - id: 1.1.21
       text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Scored)"

--- a/package/cfg/rke2-cis-1.5-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.5-permissive/master.yaml
@@ -103,39 +103,7 @@ groups:
         Run the below command (based on the file location on your system) on the master node.
         For example,
         chown root:root $schedulerconf
-      scored: true
-
-    - id: 1.1.7
-      text: "Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Scored)"
-      audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %a $etcdconf; fi'"
-      tests:
-        test_items:
-          - flag: "644"
-            compare:
-              op: eq
-              value: "644"
-            set: true
-      remediation: |
-        Run the below command (based on the file location on your system) on the master node.
-        For example,
-        chmod 644 $etcdconf
-      scored: true
-
-    - id: 1.1.8
-      text: "Ensure that the etcd pod specification file ownership is set to root:root (Scored)"
-      audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
-      tests:
-        test_items:
-          - flag: "root:root"
-            compare:
-              op: eq
-              value: "root:root"
-            set: true
-      remediation: |
-        Run the below command (based on the file location on your system) on the master node.
-        For example,
-        chown root:root $etcdconf
-      scored: true
+      scored: true  
 
     - id: 1.1.9
       text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Not Scored)"
@@ -156,39 +124,6 @@ groups:
         For example,
         chown root:root <path/to/cni/files>
       scored: false
-
-    - id: 1.1.11
-      text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Scored)"
-      audit: stat -c %a /var/lib/rancher/rke2/server/db/etcd 
-      tests:
-        test_items:
-          - flag: "700"
-            compare:
-              op: eq
-              value: "700"
-            set: true
-      remediation: |
-        On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-        from the below command:
-        ps -ef | grep etcd Run the below command (based on the etcd data directory found above). For example,
-        chmod 700 /var/lib/etcd
-      scored: true
-
-    - id: 1.1.12
-      text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Scored)"
-      type: "skip"
-      audit: stat -c %U:%G /var/lib/rancher/rke2/server/db/etcd
-      tests:
-        test_items:
-          - flag: "etcd:etcd"
-            set: true
-      remediation: |
-        On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-        from the below command:
-        ps -ef | grep etcd
-        Run the below command (based on the etcd data directory found above).
-        For example, chown etcd:etcd /var/lib/etcd
-      scored: true
 
     - id: 1.1.13
       text: "Ensure that the admin.conf file permissions are set to 644 or more restrictive (Scored)"

--- a/package/cfg/rke2-cis-1.5-permissive/node.yaml
+++ b/package/cfg/rke2-cis-1.5-permissive/node.yaml
@@ -168,19 +168,19 @@ groups:
       scored: true
 
     - id: 4.1.7
-      text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Scored)"
+      text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Manual)"
       audit: "stat -c %a /var/lib/rancher/rke2/server/tls/server-ca.crt"
       tests:
         test_items:
           - flag: "644"
             compare:
-              op: eq
+              op: bitmask
               value: "644"
             set: true
       remediation: |
         Run the following command to modify the file permissions of the
-        --client-ca-file chmod 600 <filename>
-      scored: true
+        --client-ca-file chmod 644 <filename>
+      scored: false
 
     - id: 4.1.8
       text: "Ensure that the client certificate authorities file ownership is set to root:root (Scored)"

--- a/package/cfg/rke2-cis-1.5-permissive/policies.yaml
+++ b/package/cfg/rke2-cis-1.5-permissive/policies.yaml
@@ -198,19 +198,12 @@ groups:
   checks:
     - id: 5.3.1
       text: "Ensure that the CNI in use supports Network Policies (Not Scored)"
-      audit: "kubectl get pods -n kube-system -l k8s-app=canal -o json | jq .items[] | jq .metadata.name | wc -l | xargs -I {} echo '--count={}'"
-      tests:
-        test_items:
-          - flag: "count"
-            compare:
-              op: gt
-              value: "0"
-            set: true
+      type: "manual"      
       remediation: |
         If the CNI plugin in use does not support network policies, consideration should be given to
         making use of a different plugin, or finding an alternate mechanism for restricting traffic
         in the Kubernetes cluster.
-      scored: true
+      scored: false
 
     - id: 5.3.2
       text: "Ensure that all Namespaces have Network Policies defined (Scored)"

--- a/package/cfg/rke2-cis-1.6-hardened/etcd.yaml
+++ b/package/cfg/rke2-cis-1.6-hardened/etcd.yaml
@@ -5,6 +5,73 @@ id: 2
 text: "Etcd Node Configuration"
 type: "etcd"
 groups:
+  - id: 1.1
+    text: "Master Node Configuration Files"
+    checks:
+      - id: 1.1.7
+        text: "Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %a $etcdconf; fi'"
+        tests:
+          test_items:
+            - flag: "644"
+              compare:
+                op: eq
+                value: "644"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod 644 $etcdconf
+        scored: true
+
+      - id: 1.1.8
+        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+              compare:
+                op: eq
+                value: "root:root"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown root:root $etcdconf
+        scored: true
+
+      - id: 1.1.11
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
+        audit: stat -c %a /var/lib/rancher/rke2/server/db/etcd
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "700"
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the below command:
+          ps -ef | grep etcd
+          Run the below command (based on the etcd data directory found above). For example,
+          chmod 700 /var/lib/etcd
+        scored: true
+
+      - id: 1.1.12
+        text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
+        audit: stat -c %U:%G /var/lib/rancher/rke2/server/db/etcd
+        tests:
+          test_items:
+            - flag: "etcd:etcd"
+              set: true
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the below command:
+          ps -ef | grep etcd
+          Run the below command (based on the etcd data directory found above).
+          For example, chown etcd:etcd /var/lib/etcd
+        scored: true
+
   - id: 2
     text: "Etcd Node Configuration Files"
     checks:

--- a/package/cfg/rke2-cis-1.6-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.6-hardened/master.yaml
@@ -99,38 +99,6 @@ groups:
           chown root:root $schedulerconf
         scored: true
 
-      - id: 1.1.7
-        text: "Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %a $etcdconf; fi'"
-        tests:
-          test_items:
-            - flag: "644"
-              compare:
-                op: eq
-                value: "644"
-              set: true
-        remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chmod 644 $etcdconf
-        scored: true
-
-      - id: 1.1.8
-        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
-        tests:
-          test_items:
-            - flag: "root:root"
-              compare:
-                op: eq
-                value: "root:root"
-              set: true
-        remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chown root:root $etcdconf
-        scored: true
-
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Manual)"
         audit: "stat -c %a <path/to/cni/files>"
@@ -150,38 +118,6 @@ groups:
           For example,
           chown root:root <path/to/cni/files>
         scored: false
-
-      - id: 1.1.11
-        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: stat -c %a /var/lib/rancher/rke2/server/db/etcd
-        tests:
-          test_items:
-            - flag: "permissions"
-              compare:
-                op: bitmask
-                value: "700"
-        remediation: |
-          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-          from the below command:
-          ps -ef | grep etcd
-          Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
-        scored: true
-
-      - id: 1.1.12
-        text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
-        audit: stat -c %U:%G /var/lib/rancher/rke2/server/db/etcd
-        tests:
-          test_items:
-            - flag: "etcd:etcd"
-              set: true
-        remediation: |
-          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-          from the below command:
-          ps -ef | grep etcd
-          Run the below command (based on the etcd data directory found above).
-          For example, chown etcd:etcd /var/lib/etcd
-        scored: true
 
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 644 or more restrictive (Automated)"

--- a/package/cfg/rke2-cis-1.6-permissive/etcd.yaml
+++ b/package/cfg/rke2-cis-1.6-permissive/etcd.yaml
@@ -5,6 +5,59 @@ id: 2
 text: "Etcd Node Configuration"
 type: "etcd"
 groups:
+  - id: 1.1
+    text: "Master Node Configuration Files"
+    checks:
+      - id: 1.1.7
+        text: "Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c permissions=%a $etcdconf; fi'"
+        tests:
+          test_items:
+            - flag: "644"
+              compare:
+                op: eq
+                value: "644"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod 644 $etcdconf
+        scored: true
+
+      - id: 1.1.8
+        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+              compare:
+                op: eq
+                value: "root:root"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown root:root $etcdconf
+        scored: true
+
+      - id: 1.1.11
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
+        audit: stat -c %a /var/lib/rancher/rke2/server/db/etcd
+        tests:
+          test_items:
+            - flag: "700"
+              compare:
+                op: eq
+                value: "700"
+              set: true
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the below command:
+          ps -ef | grep etcd
+          Run the below command (based on the etcd data directory found above). For example,
+          chmod 700 /var/lib/etcd
+        scored: true
+        
   - id: 2
     text: "Etcd Node Configuration Files"
     checks:

--- a/package/cfg/rke2-cis-1.6-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.6-permissive/master.yaml
@@ -100,38 +100,6 @@ groups:
           chown root:root $schedulerconf
         scored: true
 
-      - id: 1.1.7
-        text: "Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c permissions=%a $etcdconf; fi'"
-        tests:
-          test_items:
-            - flag: "644"
-              compare:
-                op: eq
-                value: "644"
-              set: true
-        remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chmod 644 $etcdconf
-        scored: true
-
-      - id: 1.1.8
-        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
-        tests:
-          test_items:
-            - flag: "root:root"
-              compare:
-                op: eq
-                value: "root:root"
-              set: true
-        remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chown root:root $etcdconf
-        scored: true
-
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Manual)"
         audit: "stat -c permissions=%a <path/to/cni/files>"
@@ -151,24 +119,6 @@ groups:
           For example,
           chown root:root <path/to/cni/files>
         scored: false
-
-      - id: 1.1.11
-        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: stat -c %a /var/lib/rancher/rke2/server/db/etcd
-        tests:
-          test_items:
-            - flag: "700"
-              compare:
-                op: eq
-                value: "700"
-              set: true
-        remediation: |
-          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-          from the below command:
-          ps -ef | grep etcd
-          Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
-        scored: true
 
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"

--- a/package/run_sonobuoy_plugin.sh
+++ b/package/run_sonobuoy_plugin.sh
@@ -57,9 +57,14 @@ if [[ "$(journalctl -D $JOURNAL_LOG --lines=0 2>&1 | grep -s 'No such file or di
 fi
 mkdir -p "${RESULTS_DIR}"
 
+ETCD_PROC="etcd"
+if [ ! ${IS_RKE2} ]; then
+  ETCD_PROC="/etcd"
+fi
+
 # etcd
 if [[ "${OVERRIDE_BENCHMARK_VERSION}" != "" ]]; then
-  if [[ "$(pgrep -f /etcd | wc -l)" -gt 0 ]]  || [[ "$(journalctl -D $JOURNAL_LOG -u k3s -u k3s-agent | grep -wv 'No entries' | grep -wv 'Logs begin' | wc -l)" -gt 0 ]]; then
+  if [[ "$(pgrep -f $ETCD_PROC | wc -l)" -gt 1  ]]  || [[ "$(journalctl -D $JOURNAL_LOG -u k3s -u k3s-agent | grep -wv 'No entries' | grep -wv 'Logs begin' | wc -l)" -gt 0 ]]; then
     echo "etcd: Using OVERRIDE_BENCHMARK_VERSION=${OVERRIDE_BENCHMARK_VERSION}"
     kube-bench run \
       --targets etcd \
@@ -74,7 +79,7 @@ if [[ "${OVERRIDE_BENCHMARK_VERSION}" != "" ]]; then
       --outputfile "${RESULTS_DIR}/etcd.json" 2> "${ERROR_LOG_FILE}"
   fi
 else
-  if [[ "$(pgrep -f /etcd | wc -l)" -gt 0 ]]; then
+  if [[ "$(pgrep -f $ETCD_PROC | wc -l)" -gt 1 ]]; then
     echo "etcd: Using RANCHER_K8S_VERSION=${RANCHER_K8S_VERSION}"
     kube-bench run \
       --targets etcd \


### PR DESCRIPTION
This PR fixes failing CIS Scan tests for `rke2-cis-1.5-profile-permissive` , `rke2-cis-1.5-profile-hardened` , `rke2-cis-1.6-profile-permissive` , `rke2-cis-1.6-profile-hardened` .

- etcd related tests moved from master to etcd config
- fixed 4.1.7, 1.1.20 and 5.3.1
- fixed `run_sonobuoy_plugin.sh` to ensure etcd related tests are run on only etcd nodes and not on master and worker nodes incase of multi node RKE2 cluster. - addressing https://github.com/rancher/cis-operator/issues/107#issuecomment-953493091

Linked Issue:
https://github.com/rancher/rancher/issues/37397