### PR TITLE
Add new kube-bench binary

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -10,7 +10,7 @@ RUN zypper --non-interactive update \
 RUN git clone -b v0.6.6 --depth 1 https://github.com/aquasecurity/kube-bench.git
 
 FROM registry.suse.com/suse/sle15:15.3
-ARG kube_bench_tag=0.2.3-rancher-1
+ARG kube_bench_tag=0.2.3-rancher-3
 ARG sonobuoy_version=0.53.2
 
 RUN zypper --non-interactive update \
@@ -26,7 +26,10 @@ RUN curl -sLf https://storage.googleapis.com/kubernetes-release/release/v1.13.5/
     && chmod +x /usr/local/bin/kubectl*
 RUN curl -sLf https://github.com/vmware-tanzu/sonobuoy/releases/download/v${sonobuoy_version}/sonobuoy_${sonobuoy_version}_linux_amd64.tar.gz | tar -xvzf - -C /usr/bin sonobuoy
 #RUN curl -sLf https://github.com/aquasecurity/kube-bench/releases/download/v${kube_bench_tag}/kube-bench_${kube_bench_tag}_linux_amd64.tar.gz | tar -xvzf - -C /usr/bin
-RUN curl -sLf https://github.com/leodotcloud/kube-bench/releases/download/v${kube_bench_tag}/kube-bench.tar.gz | tar -xvzf - -C /usr/bin
+#RUN curl -sLf https://github.com/rayandas/kube-bench/releases/download/v${kube_bench_tag}/kube-bench.tar.gz | tar -xvzf - -C /usr/bin
+RUN curl -L https://github.com/rayandas/kube-bench/releases/download/v0.2.3-rancher-3/kube-bench --output kube-bench
+RUN chmod +x kube-bench
+RUN cp kube-bench /usr/bin/kube-bench
 
 COPY --from=intermediate /kube-bench/cfg /etc/kube-bench/cfg/
 


### PR DESCRIPTION
Since the previously used [fork for kube-bench binary](https://github.com/leodotcloud/kube-bench) is deleted, the build for this repo is failing. We've tried using the upstream instead, but it introduces many scan issues for all the scan profiles. This is blocking the fix for the release-blocker issue [CIS scans fail on a hardened rke2 cluster with multiple roles](https://github.com/rancher/rancher/issues/37397). So as a temporary workaround we've recreated the missing fork here: https://github.com/rayandas/kube-bench/tree/v0.2.3-rancher-3
This PR makes use of the new fork. We've tested all the scan profiles with the new image & the results are as expected.
P.S.: We're working to use upstream kube-bench repo instead, in this issue: [https://github.com/rancher/cis-operator/issues/142](https://github.com/rancher/cis-operator/issues/142)