### PR TITLE
Add cis-1.20 profiles for rke1

### DIFF
--- a/package/cfg/cis-1.20/config.yaml
+++ b/package/cfg/cis-1.20/config.yaml
@@ -1,0 +1,2 @@
+---
+## Version-specific settings that override the values in cfg/config.yaml

--- a/package/cfg/cis-1.20/controlplane.yaml
+++ b/package/cfg/cis-1.20/controlplane.yaml
@@ -1,0 +1,39 @@
+---
+controls:
+version: "1.20"
+id: 3
+text: "Control Plane Configuration"
+type: "controlplane"
+groups:
+  - id: 3.1
+    text: "Authentication and Authorization"
+    checks:
+      - id: 3.1.1
+        text: "Client certificate authentication should not be used for users (Manual)"
+        type: "manual"
+        remediation: |
+          Alternative mechanisms provided by Kubernetes such as the use of OIDC should be
+          implemented in place of client certificates.
+        scored: false
+
+  - id: 3.2
+    text: "Logging"
+    checks:
+      - id: 3.2.1
+        text: "Ensure that a minimal audit policy is created (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-policy-file"
+              set: true
+        remediation: |
+          Create an audit policy file for your cluster.
+        scored: false
+
+      - id: 3.2.2
+        text: "Ensure that the audit policy covers key security concerns (Manual)"
+        type: "manual"
+        remediation: |
+          Consider modification of the audit policy in use on the cluster to include these items, at a
+          minimum.
+        scored: false

--- a/package/cfg/cis-1.20/etcd.yaml
+++ b/package/cfg/cis-1.20/etcd.yaml
@@ -1,0 +1,135 @@
+---
+controls:
+version: "1.20"
+id: 2
+text: "Etcd Node Configuration"
+type: "etcd"
+groups:
+  - id: 2
+    text: "Etcd Node Configuration Files"
+    checks:
+      - id: 2.1
+        text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--cert-file"
+              env: "ETCD_CERT_FILE"
+            - flag: "--key-file"
+              env: "ETCD_KEY_FILE"
+        remediation: |
+          Follow the etcd service documentation and configure TLS encryption.
+          Then, edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml
+          on the master node and set the below parameters.
+          --cert-file=</path/to/ca-file>
+          --key-file=</path/to/key-file>
+        scored: true
+
+      - id: 2.2
+        text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          test_items:
+            - flag: "--client-cert-auth"
+              env: "ETCD_CLIENT_CERT_AUTH"
+              compare:
+                op: eq
+                value: true
+        remediation: |
+          Edit the etcd pod specification file $etcdconf on the master
+          node and set the below parameter.
+          --client-cert-auth="true"
+        scored: true
+
+      - id: 2.3
+        text: "Ensure that the --auto-tls argument is not set to true (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--auto-tls"
+              env: "ETCD_AUTO_TLS"
+              set: false
+            - flag: "--auto-tls"
+              env: "ETCD_AUTO_TLS"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the etcd pod specification file $etcdconf on the master
+          node and either remove the --auto-tls parameter or set it to false.
+            --auto-tls=false
+        scored: true
+
+      - id: 2.4
+        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are
+        set as appropriate (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--peer-cert-file"
+              env: "ETCD_PEER_CERT_FILE"
+            - flag: "--peer-key-file"
+              env: "ETCD_PEER_KEY_FILE"
+        remediation: |
+          Follow the etcd service documentation and configure peer TLS encryption as appropriate
+          for your etcd cluster.
+          Then, edit the etcd pod specification file $etcdconf on the
+          master node and set the below parameters.
+          --peer-client-file=</path/to/peer-cert-file>
+          --peer-key-file=</path/to/peer-key-file>
+        scored: true
+
+      - id: 2.5
+        text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          test_items:
+            - flag: "--peer-client-cert-auth"
+              env: "ETCD_PEER_CLIENT_CERT_AUTH"
+              compare:
+                op: eq
+                value: true
+        remediation: |
+          Edit the etcd pod specification file $etcdconf on the master
+          node and set the below parameter.
+          --peer-client-cert-auth=true
+        scored: true
+
+      - id: 2.6
+        text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--peer-auto-tls"
+              env: "ETCD_PEER_AUTO_TLS"
+              set: false
+            - flag: "--peer-auto-tls"
+              env: "ETCD_PEER_AUTO_TLS"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the etcd pod specification file $etcdconf on the master
+          node and either remove the --peer-auto-tls parameter or set it to false.
+          --peer-auto-tls=false
+        scored: true
+
+      - id: 2.7
+        text: "Ensure that a unique Certificate Authority is used for etcd (Manual)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          test_items:
+            - flag: "--trusted-ca-file"
+              env: "ETCD_TRUSTED_CA_FILE"
+        remediation: |
+          [Manual test]
+          Follow the etcd documentation and create a dedicated certificate authority setup for the
+          etcd service.
+          Then, edit the etcd pod specification file $etcdconf on the
+          master node and set the below parameter.
+          --trusted-ca-file=</path/to/ca-file>
+        scored: false

--- a/package/cfg/cis-1.20/master.yaml
+++ b/package/cfg/cis-1.20/master.yaml
@@ -813,7 +813,8 @@ groups:
         scored: false
 
       - id: 1.2.33
-        text: "Ensure that encryption providers are appropriately configured (Manual)"
+        text: "Ensure that encryption providers are appropriately configured (Manual)"        
+        type: "manual"
         audit: |
           ENCRYPTION_PROVIDER_CONFIG=$(ps -ef | grep $apiserverbin | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
           if test -e $ENCRYPTION_PROVIDER_CONFIG; then grep -A1 'providers:' $ENCRYPTION_PROVIDER_CONFIG | tail -n1 | grep -o "[A-Za-z]*" | sed 's/^/provider=/'; fi

--- a/package/cfg/cis-1.20/master.yaml
+++ b/package/cfg/cis-1.20/master.yaml
@@ -1,0 +1,989 @@
+---
+controls:
+version: "1.20"
+id: 1
+text: "Master Node Security Configuration"
+type: "master"
+groups:
+  - id: 1.1
+    text: "Master Node Configuration Files"
+    checks:
+      - id: 1.1.1
+        text: "Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $apiserverconf; then stat -c permissions=%a $apiserverconf; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the
+          master node.
+          For example, chmod 644 $apiserverconf
+        scored: true
+
+      - id: 1.1.2
+        text: "Ensure that the API server pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $apiserverconf; then stat -c %U:%G $apiserverconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown root:root $apiserverconf
+        scored: true
+
+      - id: 1.1.3
+        text: "Ensure that the controller manager pod specification file permissions are set to 644 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $controllermanagerconf; then stat -c permissions=%a $controllermanagerconf; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod 644 $controllermanagerconf
+        scored: true
+
+      - id: 1.1.4
+        text: "Ensure that the controller manager pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $controllermanagerconf; then stat -c %U:%G $controllermanagerconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown root:root $controllermanagerconf
+        scored: true
+
+      - id: 1.1.5
+        text: "Ensure that the scheduler pod specification file permissions are set to 644 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c permissions=%a $schedulerconf; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod 644 $schedulerconf
+        scored: true
+
+      - id: 1.1.6
+        text: "Ensure that the scheduler pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c %U:%G $schedulerconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown root:root $schedulerconf
+        scored: true
+
+      - id: 1.1.7
+        text: "Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod 644 $etcdconf
+        scored: true
+
+      - id: 1.1.8
+        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c %U:%G; fi'"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown root:root $etcdconf
+        scored: true
+
+      - id: 1.1.9
+        text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Manual)"
+        audit: |
+          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
+          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod 644 <path/to/cni/files>
+        scored: false
+
+      - id: 1.1.10
+        text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
+        audit: |
+          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
+          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown root:root <path/to/cni/files>
+        scored: false
+
+      - id: 1.1.11
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
+        audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c permissions=%a
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "700"
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the below command:
+          ps -ef | grep etcd
+          Run the below command (based on the etcd data directory found above). For example,
+          chmod 700 /var/lib/etcd
+        scored: true
+
+      - id: 1.1.12
+        text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
+        audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G
+        tests:
+          test_items:
+            - flag: "etcd:etcd"
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the below command:
+          ps -ef | grep etcd
+          Run the below command (based on the etcd data directory found above).
+          For example, chown etcd:etcd /var/lib/etcd
+        scored: true
+
+      - id: 1.1.13
+        text: "Ensure that the admin.conf file permissions are set to 644 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c permissions=%a /etc/kubernetes/admin.conf; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod 644 /etc/kubernetes/admin.conf
+        scored: true
+
+      - id: 1.1.14
+        text: "Ensure that the admin.conf file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c %U:%G /etc/kubernetes/admin.conf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown root:root /etc/kubernetes/admin.conf
+        scored: true
+
+      - id: 1.1.15
+        text: "Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c permissions=%a $schedulerkubeconfig; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod 644 $schedulerkubeconfig
+        scored: true
+
+      - id: 1.1.16
+        text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c %U:%G $schedulerkubeconfig; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown root:root $schedulerkubeconfig
+        scored: true
+
+      - id: 1.1.17
+        text: "Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c permissions=%a $controllermanagerkubeconfig; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod 644 $controllermanagerkubeconfig
+        scored: true
+
+      - id: 1.1.18
+        text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c %U:%G $controllermanagerkubeconfig; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown root:root $controllermanagerkubeconfig
+        scored: true
+
+      - id: 1.1.19
+        text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
+        audit: "find /etc/kubernetes/pki/ | xargs stat -c %U:%G"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown -R root:root /etc/kubernetes/pki/
+        scored: true
+
+      - id: 1.1.20
+        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Manual)"
+        audit: "find /etc/kubernetes/pki/ -name '*.crt' | xargs stat -c permissions=%a"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod -R 644 /etc/kubernetes/pki/*.crt
+        scored: false
+
+      - id: 1.1.21
+        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
+        audit: "find /etc/kubernetes/pki/ -name '*.key' | xargs stat -c permissions=%a"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod -R 600 /etc/kubernetes/pki/*.key
+        scored: false
+
+  - id: 1.2
+    text: "API Server"
+    checks:
+      - id: 1.2.1
+        text: "Ensure that the --anonymous-auth argument is set to false (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--anonymous-auth"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the below parameter.
+          --anonymous-auth=false
+        scored: false
+
+      - id: 1.2.2
+        text: "Ensure that the --token-auth-file parameter is not set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--token-auth-file"
+              set: false
+        remediation: |
+          Follow the documentation and configure alternate mechanisms for authentication. Then,
+          edit the API server pod specification file $apiserverconf
+          on the master node and remove the --token-auth-file=<filename> parameter.
+        scored: true
+
+      - id: 1.2.3
+        text: "Ensure that the --kubelet-https argument is set to true (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--kubelet-https"
+              compare:
+                op: eq
+                value: true
+            - flag: "--kubelet-https"
+              set: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and remove the --kubelet-https parameter.
+        scored: true
+
+      - id: 1.2.4
+        text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--kubelet-client-certificate"
+            - flag: "--kubelet-client-key"
+        remediation: |
+          Follow the Kubernetes documentation and set up the TLS connection between the
+          apiserver and kubelets. Then, edit API server pod specification file
+          $apiserverconf on the master node and set the
+          kubelet client certificate and key parameters as below.
+          --kubelet-client-certificate=<path/to/client-certificate-file>
+          --kubelet-client-key=<path/to/client-key-file>
+        scored: true
+
+      - id: 1.2.5
+        text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--kubelet-certificate-authority"
+        remediation: |
+          Follow the Kubernetes documentation and setup the TLS connection between
+          the apiserver and kubelets. Then, edit the API server pod specification file
+          $apiserverconf on the master node and set the
+          --kubelet-certificate-authority parameter to the path to the cert file for the certificate authority.
+          --kubelet-certificate-authority=<ca-string>
+        scored: true
+
+      - id: 1.2.6
+        text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--authorization-mode"
+              compare:
+                op: nothave
+                value: "AlwaysAllow"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --authorization-mode parameter to values other than AlwaysAllow.
+          One such example could be as below.
+          --authorization-mode=RBAC
+        scored: true
+
+      - id: 1.2.7
+        text: "Ensure that the --authorization-mode argument includes Node (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--authorization-mode"
+              compare:
+                op: has
+                value: "Node"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --authorization-mode parameter to a value that includes Node.
+          --authorization-mode=Node,RBAC
+        scored: true
+
+      - id: 1.2.8
+        text: "Ensure that the --authorization-mode argument includes RBAC (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--authorization-mode"
+              compare:
+                op: has
+                value: "RBAC"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --authorization-mode parameter to a value that includes RBAC,
+          for example:
+          --authorization-mode=Node,RBAC
+        scored: true
+
+      - id: 1.2.9
+        text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "EventRateLimit"
+        remediation: |
+          Follow the Kubernetes documentation and set the desired limits in a configuration file.
+          Then, edit the API server pod specification file $apiserverconf
+          and set the below parameters.
+          --enable-admission-plugins=...,EventRateLimit,...
+          --admission-control-config-file=<path/to/configuration/file>
+        scored: false
+
+      - id: 1.2.10
+        text: "Ensure that the admission control plugin AlwaysAdmit is not set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: nothave
+                value: AlwaysAdmit
+            - flag: "--enable-admission-plugins"
+              set: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and either remove the --enable-admission-plugins parameter, or set it to a
+          value that does not include AlwaysAdmit.
+        scored: true
+
+      - id: 1.2.11
+        text: "Ensure that the admission control plugin AlwaysPullImages is set (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "AlwaysPullImages"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --enable-admission-plugins parameter to include
+          AlwaysPullImages.
+          --enable-admission-plugins=...,AlwaysPullImages,...
+        scored: false
+
+      - id: 1.2.12
+        text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "SecurityContextDeny"
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "PodSecurityPolicy"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --enable-admission-plugins parameter to include
+          SecurityContextDeny, unless PodSecurityPolicy is already in place.
+          --enable-admission-plugins=...,SecurityContextDeny,...
+        scored: false
+
+      - id: 1.2.13
+        text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--disable-admission-plugins"
+              compare:
+                op: nothave
+                value: "ServiceAccount"
+            - flag: "--disable-admission-plugins"
+              set: false
+        remediation: |
+          Follow the documentation and create ServiceAccount objects as per your environment.
+          Then, edit the API server pod specification file $apiserverconf
+          on the master node and ensure that the --disable-admission-plugins parameter is set to a
+          value that does not include ServiceAccount.
+        scored: true
+
+      - id: 1.2.14
+        text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--disable-admission-plugins"
+              compare:
+                op: nothave
+                value: "NamespaceLifecycle"
+            - flag: "--disable-admission-plugins"
+              set: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --disable-admission-plugins parameter to
+          ensure it does not include NamespaceLifecycle.
+        scored: true
+
+      - id: 1.2.15
+        text: "Ensure that the admission control plugin PodSecurityPolicy is set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "PodSecurityPolicy"
+        remediation: |
+          Follow the documentation and create Pod Security Policy objects as per your environment.
+          Then, edit the API server pod specification file $apiserverconf
+          on the master node and set the --enable-admission-plugins parameter to a
+          value that includes PodSecurityPolicy:
+          --enable-admission-plugins=...,PodSecurityPolicy,...
+          Then restart the API Server.
+        scored: true
+
+      - id: 1.2.16
+        text: "Ensure that the admission control plugin NodeRestriction is set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "NodeRestriction"
+        remediation: |
+          Follow the Kubernetes documentation and configure NodeRestriction plug-in on kubelets.
+          Then, edit the API server pod specification file $apiserverconf
+          on the master node and set the --enable-admission-plugins parameter to a
+          value that includes NodeRestriction.
+          --enable-admission-plugins=...,NodeRestriction,...
+        scored: true
+
+      - id: 1.2.17
+        text: "Ensure that the --insecure-bind-address argument is not set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--insecure-bind-address"
+              set: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and remove the --insecure-bind-address parameter.
+        scored: true
+
+      - id: 1.2.18
+        text: "Ensure that the --insecure-port argument is set to 0 (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--insecure-port"
+              compare:
+                op: eq
+                value: 0
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the below parameter.
+          --insecure-port=0
+        scored: true
+
+      - id: 1.2.19
+        text: "Ensure that the --secure-port argument is not set to 0 (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--secure-port"
+              compare:
+                op: gt
+                value: 0
+            - flag: "--secure-port"
+              set: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and either remove the --secure-port parameter or
+          set it to a different (non-zero) desired port.
+        scored: true
+
+      - id: 1.2.20
+        text: "Ensure that the --profiling argument is set to false (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--profiling"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the below parameter.
+          --profiling=false
+        scored: true
+
+      - id: 1.2.21
+        text: "Ensure that the --audit-log-path argument is set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-log-path"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --audit-log-path parameter to a suitable path and
+          file where you would like audit logs to be written, for example:
+          --audit-log-path=/var/log/apiserver/audit.log
+        scored: true
+
+      - id: 1.2.22
+        text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-log-maxage"
+              compare:
+                op: gte
+                value: 30
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --audit-log-maxage parameter to 30 or as an appropriate number of days:
+          --audit-log-maxage=30
+        scored: true
+
+      - id: 1.2.23
+        text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-log-maxbackup"
+              compare:
+                op: gte
+                value: 10
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --audit-log-maxbackup parameter to 10 or to an appropriate
+          value.
+          --audit-log-maxbackup=10
+        scored: true
+
+      - id: 1.2.24
+        text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-log-maxsize"
+              compare:
+                op: gte
+                value: 100
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --audit-log-maxsize parameter to an appropriate size in MB.
+          For example, to set it as 100 MB:
+          --audit-log-maxsize=100
+        scored: true
+
+      - id: 1.2.25
+        text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        type: manual
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          and set the below parameter as appropriate and if needed.
+          For example,
+          --request-timeout=300s
+        scored: false
+
+      - id: 1.2.26
+        text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--service-account-lookup"
+              set: false
+            - flag: "--service-account-lookup"
+              compare:
+                op: eq
+                value: true
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the below parameter.
+          --service-account-lookup=true
+          Alternatively, you can delete the --service-account-lookup parameter from this file so
+          that the default takes effect.
+        scored: true
+
+      - id: 1.2.27
+        text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--service-account-key-file"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --service-account-key-file parameter
+          to the public key file for service accounts:
+          --service-account-key-file=<filename>
+        scored: true
+
+      - id: 1.2.28
+        text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--etcd-certfile"
+            - flag: "--etcd-keyfile"
+        remediation: |
+          Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
+          Then, edit the API server pod specification file $apiserverconf
+          on the master node and set the etcd certificate and key file parameters.
+          --etcd-certfile=<path/to/client-certificate-file>
+          --etcd-keyfile=<path/to/client-key-file>
+        scored: true
+
+      - id: 1.2.29
+        text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--tls-cert-file"
+            - flag: "--tls-private-key-file"
+        remediation: |
+          Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
+          Then, edit the API server pod specification file $apiserverconf
+          on the master node and set the TLS certificate and private key file parameters.
+          --tls-cert-file=<path/to/tls-certificate-file>
+          --tls-private-key-file=<path/to/tls-key-file>
+        scored: true
+
+      - id: 1.2.30
+        text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--client-ca-file"
+        remediation: |
+          Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
+          Then, edit the API server pod specification file $apiserverconf
+          on the master node and set the client certificate authority file.
+          --client-ca-file=<path/to/client-ca-file>
+        scored: true
+
+      - id: 1.2.31
+        text: "Ensure that the --etcd-cafile argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--etcd-cafile"
+        remediation: |
+          Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
+          Then, edit the API server pod specification file $apiserverconf
+          on the master node and set the etcd certificate authority file parameter.
+          --etcd-cafile=<path/to/ca-file>
+        scored: true
+
+      - id: 1.2.32
+        text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--encryption-provider-config"
+        remediation: |
+          Follow the Kubernetes documentation and configure a EncryptionConfig file.
+          Then, edit the API server pod specification file $apiserverconf
+          on the master node and set the --encryption-provider-config parameter to the path of that file: --encryption-provider-config=</path/to/EncryptionConfig/File>
+        scored: false
+
+      - id: 1.2.33
+        text: "Ensure that encryption providers are appropriately configured (Manual)"
+        audit: |
+          ENCRYPTION_PROVIDER_CONFIG=$(ps -ef | grep $apiserverbin | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
+          if test -e $ENCRYPTION_PROVIDER_CONFIG; then grep -A1 'providers:' $ENCRYPTION_PROVIDER_CONFIG | tail -n1 | grep -o "[A-Za-z]*" | sed 's/^/provider=/'; fi
+        tests:
+          test_items:
+            - flag: "provider"
+              compare:
+                op: valid_elements
+                value: "aescbc,kms,secretbox"
+        remediation: |
+          Follow the Kubernetes documentation and configure a EncryptionConfig file.
+          In this file, choose aescbc, kms or secretbox as the encryption provider.
+        scored: false
+
+      - id: 1.2.34
+        text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--tls-cipher-suites"
+              compare:
+                op: valid_elements
+                value: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256"
+        remediation: |
+          Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
+          on the master node and set the below parameter.
+          --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM
+          _SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM
+          _SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM
+          _SHA384
+        scored: false
+
+  - id: 1.3
+    text: "Controller Manager"
+    checks:
+      - id: 1.3.1
+        text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Manual)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--terminated-pod-gc-threshold"
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the master node and set the --terminated-pod-gc-threshold to an appropriate threshold,
+          for example:
+          --terminated-pod-gc-threshold=10
+        scored: false
+
+      - id: 1.3.2
+        text: "Ensure that the --profiling argument is set to false (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--profiling"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the master node and set the below parameter.
+          --profiling=false
+        scored: true
+
+      - id: 1.3.3
+        text: "Ensure that the --use-service-account-credentials argument is set to true (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--use-service-account-credentials"
+              compare:
+                op: noteq
+                value: false
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the master node to set the below parameter.
+          --use-service-account-credentials=true
+        scored: true
+
+      - id: 1.3.4
+        text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--service-account-private-key-file"
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the master node and set the --service-account-private-key-file parameter
+          to the private key file for service accounts.
+          --service-account-private-key-file=<filename>
+        scored: true
+
+      - id: 1.3.5
+        text: "Ensure that the --root-ca-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--root-ca-file"
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the master node and set the --root-ca-file parameter to the certificate bundle file`.
+          --root-ca-file=<path/to/file>
+        scored: true
+
+      - id: 1.3.6
+        text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--feature-gates"
+              compare:
+                op: nothave
+                value: "RotateKubeletServerCertificate=false"
+              set: true
+            - flag: "--feature-gates"
+              set: false
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the master node and set the --feature-gates parameter to include RotateKubeletServerCertificate=true.
+          --feature-gates=RotateKubeletServerCertificate=true
+        scored: true
+
+      - id: 1.3.7
+        text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--bind-address"
+              compare:
+                op: eq
+                value: "127.0.0.1"
+            - flag: "--bind-address"
+              set: false
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the master node and ensure the correct value for the --bind-address parameter
+        scored: true
+
+  - id: 1.4
+    text: "Scheduler"
+    checks:
+      - id: 1.4.1
+        text: "Ensure that the --profiling argument is set to false (Automated)"
+        audit: "/bin/ps -ef | grep $schedulerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--profiling"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the Scheduler pod specification file $schedulerconf file
+          on the master node and set the below parameter.
+          --profiling=false
+        scored: true
+
+      - id: 1.4.2
+        text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
+        audit: "/bin/ps -ef | grep $schedulerbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--bind-address"
+              compare:
+                op: eq
+                value: "127.0.0.1"
+            - flag: "--bind-address"
+              set: false
+        remediation: |
+          Edit the Scheduler pod specification file $schedulerconf
+          on the master node and ensure the correct value for the --bind-address parameter
+        scored: true

--- a/package/cfg/cis-1.20/node.yaml
+++ b/package/cfg/cis-1.20/node.yaml
@@ -1,0 +1,463 @@
+---
+controls:
+version: "1.20"
+id: 4
+text: "Worker Node Security Configuration"
+type: "node"
+groups:
+  - id: 4.1
+    text: "Worker Node Configuration Files"
+    checks:
+      - id: 4.1.1
+        text: "Ensure that the kubelet service file permissions are set to 644 or more restrictive (Automated)"
+        audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c permissions=%a $kubeletsvc; fi'' '
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chmod 644 $kubeletsvc
+        scored: true
+
+      - id: 4.1.2
+        text: "Ensure that the kubelet service file ownership is set to root:root (Automated)"
+        audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc; fi'' '
+        tests:
+          test_items:
+            - flag: root:root
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chown root:root $kubeletsvc
+        scored: true
+
+      - id: 4.1.3
+        text: "If proxy kubeconfig file exists ensure permissions are set to 644 or more restrictive (Manual)"
+        audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c permissions=%a $proxykubeconfig; fi'' '
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "permissions"
+              set: true
+              compare:
+                op: bitmask
+                value: "644"
+            - flag: "$proxykubeconfig"
+              set: false
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chmod 644 $proxykubeconfig
+        scored: false
+
+      - id: 4.1.4
+        text: "If proxy kubeconfig file exists ensure ownership is set to root:root (Manual)"
+        audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c %U:%G $proxykubeconfig; fi'' '
+        tests:
+          bin_op: or
+          test_items:
+            - flag: root:root
+            - flag: "$proxykubeconfig"
+              set: false
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example, chown root:root $proxykubeconfig
+        scored: false
+
+      - id: 4.1.5
+        text: "Ensure that the --kubeconfig kubelet.conf file permissions are set to 644 or more restrictive (Automated)"
+        audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c permissions=%a $kubeletkubeconfig; fi'' '
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chmod 644 $kubeletkubeconfig
+        scored: true
+
+      - id: 4.1.6
+        text: "Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root (Automated)"
+        audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c %U:%G $kubeletkubeconfig; fi'' '
+        tests:
+          test_items:
+            - flag: root:root
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chown root:root $kubeletkubeconfig
+        scored: true
+
+      - id: 4.1.7
+        text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Manual)"
+        audit: |
+          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
+          if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
+          if test -e $CAFILE; then stat -c permissions=%a $CAFILE; fi
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the following command to modify the file permissions of the
+          --client-ca-file chmod 644 <filename>
+        scored: false
+
+      - id: 4.1.8
+        text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
+        audit: |
+          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
+          if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
+          if test -e $CAFILE; then stat -c %U:%G $CAFILE; fi
+        tests:
+          test_items:
+            - flag: root:root
+              compare:
+                op: eq
+                value: root:root
+        remediation: |
+          Run the following command to modify the ownership of the --client-ca-file.
+          chown root:root <filename>
+        scored: false
+
+      - id: 4.1.9
+        text: "Ensure that the kubelet --config configuration file has permissions set to 644 or more restrictive (Automated)"
+        audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c permissions=%a $kubeletconf; fi'' '
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the following command (using the config file location identified in the Audit step)
+          chmod 644 $kubeletconf
+        scored: true
+
+      - id: 4.1.10
+        text: "Ensure that the kubelet --config configuration file ownership is set to root:root (Automated)"
+        audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c %U:%G $kubeletconf; fi'' '
+        tests:
+          test_items:
+            - flag: root:root
+        remediation: |
+          Run the following command (using the config file location identified in the Audit step)
+          chown root:root $kubeletconf
+        scored: true
+
+  - id: 4.2
+    text: "Kubelet"
+    checks:
+      - id: 4.2.1
+        text: "Ensure that the anonymous-auth argument is set to false (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: "--anonymous-auth"
+              path: '{.authentication.anonymous.enabled}'
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          If using a Kubelet config file, edit the file to set authentication: anonymous: enabled to
+          false.
+          If using executable arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          --anonymous-auth=false
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.2
+        text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --authorization-mode
+              path: '{.authorization.mode}'
+              compare:
+                op: nothave
+                value: AlwaysAllow
+        remediation: |
+          If using a Kubelet config file, edit the file to set authorization: mode to Webhook. If
+          using executable arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_AUTHZ_ARGS variable.
+          --authorization-mode=Webhook
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.3
+        text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --client-ca-file
+              path: '{.authentication.x509.clientCAFile}'
+        remediation: |
+          If using a Kubelet config file, edit the file to set authentication: x509: clientCAFile to
+          the location of the client CA file.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_AUTHZ_ARGS variable.
+          --client-ca-file=<path/to/client-ca-file>
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.4
+        text: "Ensure that the --read-only-port argument is set to 0 (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--read-only-port"
+              path: '{.readOnlyPort}'
+              compare:
+                op: eq
+                value: 0
+            - flag: "--read-only-port"
+              path: '{.readOnlyPort}'
+              set: false
+        remediation: |
+          If using a Kubelet config file, edit the file to set readOnlyPort to 0.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          --read-only-port=0
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.5
+        text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --streaming-connection-idle-timeout
+              path: '{.streamingConnectionIdleTimeout}'
+              compare:
+                op: noteq
+                value: 0
+            - flag: --streaming-connection-idle-timeout
+              path: '{.streamingConnectionIdleTimeout}'
+              set: false
+          bin_op: or
+        remediation: |
+          If using a Kubelet config file, edit the file to set streamingConnectionIdleTimeout to a
+          value other than 0.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          --streaming-connection-idle-timeout=5m
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.6
+        text: "Ensure that the --protect-kernel-defaults argument is set to true (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --protect-kernel-defaults
+              path: '{.protectKernelDefaults}'
+              compare:
+                op: eq
+                value: true
+        remediation: |
+          If using a Kubelet config file, edit the file to set protectKernelDefaults: true.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          --protect-kernel-defaults=true
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.7
+        text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --make-iptables-util-chains
+              path: '{.makeIPTablesUtilChains}'
+              compare:
+                op: eq
+                value: true
+            - flag: --make-iptables-util-chains
+              path: '{.makeIPTablesUtilChains}'
+              set: false
+          bin_op: or
+        remediation: |
+          If using a Kubelet config file, edit the file to set makeIPTablesUtilChains: true.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          remove the --make-iptables-util-chains argument from the
+          KUBELET_SYSTEM_PODS_ARGS variable.
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.8
+        text: "Ensure that the --hostname-override argument is not set (Manual)"
+        # This is one of those properties that can only be set as a command line argument.
+        # To check if the property is set as expected, we need to parse the kubelet command
+        # instead reading the Kubelet Configuration file.
+        audit: "/bin/ps -fC $kubeletbin "
+        tests:
+          test_items:
+            - flag: --hostname-override
+              set: false
+        remediation: |
+          Edit the kubelet service file $kubeletsvc
+          on each worker node and remove the --hostname-override argument from the
+          KUBELET_SYSTEM_PODS_ARGS variable.
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.9
+        text: "Ensure that the --event-qps argument is set to 0 or a level which ensures appropriate event capture (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --event-qps
+              path: '{.eventRecordQPS}'
+              compare:
+                op: eq
+                value: 0
+        remediation: |
+          If using a Kubelet config file, edit the file to set eventRecordQPS: to an appropriate level.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.10
+        text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --tls-cert-file
+              path: '{.tlsCertFile}'
+            - flag: --tls-private-key-file
+              path: '{.tlsPrivateKeyFile}'
+        remediation: |
+          If using a Kubelet config file, edit the file to set tlsCertFile to the location
+          of the certificate file to use to identify this Kubelet, and tlsPrivateKeyFile
+          to the location of the corresponding private key file.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameters in KUBELET_CERTIFICATE_ARGS variable.
+          --tls-cert-file=<path/to/tls-certificate-file>
+          --tls-private-key-file=<path/to/tls-key-file>
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.11
+        text: "Ensure that the --rotate-certificates argument is not set to false (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --rotate-certificates
+              path: '{.rotateCertificates}'
+              compare:
+                op: eq
+                value: true
+            - flag: --rotate-certificates
+              path: '{.rotateCertificates}'
+              set: false
+          bin_op: or
+        remediation: |
+          If using a Kubelet config file, edit the file to add the line rotateCertificates: true or
+          remove it altogether to use the default value.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          remove --rotate-certificates=false argument from the KUBELET_CERTIFICATE_ARGS
+          variable.
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.12
+        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: RotateKubeletServerCertificate
+              path: '{.featureGates.RotateKubeletServerCertificate}'
+              compare:
+                op: nothave
+                value: false
+            - flag: RotateKubeletServerCertificate
+              path: '{.featureGates.RotateKubeletServerCertificate}'
+              set: false
+        remediation: |
+          Edit the kubelet service file $kubeletsvc
+          on each worker node and set the below parameter in KUBELET_CERTIFICATE_ARGS variable.
+          --feature-gates=RotateKubeletServerCertificate=true
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.13
+        text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --tls-cipher-suites
+              path: '{range .tlsCipherSuites[:]}{}{'',''}{end}'
+              compare:
+                op: valid_elements
+                value: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+        remediation: |
+          If using a Kubelet config file, edit the file to set TLSCipherSuites: to
+          TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+          or to a subset of these values.
+          If using executable arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the --tls-cipher-suites parameter as follows, or to a subset of these values.
+          --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false

--- a/package/cfg/cis-1.20/node.yaml
+++ b/package/cfg/cis-1.20/node.yaml
@@ -97,10 +97,7 @@ groups:
 
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Manual)"
-        audit: |
-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
-          if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
-          if test -e $CAFILE; then stat -c permissions=%a $CAFILE; fi
+        audit: "check_cafile_permissions.sh"
         tests:
           test_items:
             - flag: "permissions"
@@ -114,10 +111,7 @@ groups:
 
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
-        audit: |
-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
-          if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
-          if test -e $CAFILE; then stat -c %U:%G $CAFILE; fi
+        audit: "check_cafile_ownership.sh"
         tests:
           test_items:
             - flag: root:root

--- a/package/cfg/cis-1.20/policies.yaml
+++ b/package/cfg/cis-1.20/policies.yaml
@@ -1,0 +1,238 @@
+---
+controls:
+version: "1.20"
+id: 5
+text: "Kubernetes Policies"
+type: "policies"
+groups:
+  - id: 5.1
+    text: "RBAC and Service Accounts"
+    checks:
+      - id: 5.1.1
+        text: "Ensure that the cluster-admin role is only used where required (Manual)"
+        type: "manual"
+        remediation: |
+          Identify all clusterrolebindings to the cluster-admin role. Check if they are used and
+          if they need this role or if they could use a role with fewer privileges.
+          Where possible, first bind users to a lower privileged role and then remove the
+          clusterrolebinding to the cluster-admin role :
+          kubectl delete clusterrolebinding [name]
+        scored: false
+
+      - id: 5.1.2
+        text: "Minimize access to secrets (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove get, list and watch access to secret objects in the cluster.
+        scored: false
+
+      - id: 5.1.3
+        text: "Minimize wildcard use in Roles and ClusterRoles (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible replace any use of wildcards in clusterroles and roles with specific
+          objects or actions.
+        scored: false
+
+      - id: 5.1.4
+        text: "Minimize access to create pods (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove create access to pod objects in the cluster.
+        scored: false
+
+      - id: 5.1.5
+        text: "Ensure that default service accounts are not actively used. (Manual)"
+        type: "manual"
+        remediation: |
+          Create explicit service accounts wherever a Kubernetes workload requires specific access
+          to the Kubernetes API server.
+          Modify the configuration of each default service account to include this value
+          automountServiceAccountToken: false
+        scored: false
+
+      - id: 5.1.6
+        text: "Ensure that Service Account Tokens are only mounted where necessary (Manual)"
+        type: "manual"
+        remediation: |
+          Modify the definition of pods and service accounts which do not need to mount service
+          account tokens to disable it.
+        scored: false
+
+      - id: 5.1.7
+        text: "Avoid use of system:masters group (Manual)"
+        type: "manual"
+        remediation: |
+          Remove the system:masters group from all users in the cluster.
+        scored: false
+
+      - id: 5.1.8
+        text: "Limit use of the Bind, Impersonate and Escalate permissions in the Kubernetes cluster (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove the impersonate, bind and escalate rights from subjects.
+        scored: false
+
+  - id: 5.2
+    text: "Pod Security Policies"
+    checks:
+      - id: 5.2.1
+        text: "Minimize the admission of privileged containers (Automated)"
+        type: "manual"
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that
+          the .spec.privileged field is omitted or set to false.
+        scored: false
+
+      - id: 5.2.2
+        text: "Minimize the admission of containers wishing to share the host process ID namespace (Automated)"
+        type: "manual"
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that the
+          .spec.hostPID field is omitted or set to false.
+        scored: false
+
+      - id: 5.2.3
+        text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
+        type: "manual"
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that the
+          .spec.hostIPC field is omitted or set to false.
+        scored: false
+
+      - id: 5.2.4
+        text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
+        type: "manual"
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that the
+          .spec.hostNetwork field is omitted or set to false.
+        scored: false
+
+      - id: 5.2.5
+        text: "Minimize the admission of containers with allowPrivilegeEscalation (Automated)"
+        type: "manual"
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that the
+          .spec.allowPrivilegeEscalation field is omitted or set to false.
+        scored: false
+
+      - id: 5.2.6
+        text: "Minimize the admission of root containers (Automated)"
+        type: "manual"
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that the
+          .spec.runAsUser.rule is set to either MustRunAsNonRoot or MustRunAs with the range of
+          UIDs not including 0.
+        scored: false
+
+      - id: 5.2.7
+        text: "Minimize the admission of containers with the NET_RAW capability (Automated)"
+        type: "manual"
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that the
+          .spec.requiredDropCapabilities is set to include either NET_RAW or ALL.
+        scored: false
+
+      - id: 5.2.8
+        text: "Minimize the admission of containers with added capabilities (Automated)"
+        type: "manual"
+        remediation: |
+          Ensure that allowedCapabilities is not present in PSPs for the cluster unless
+          it is set to an empty array.
+        scored: false
+
+      - id: 5.2.9
+        text: "Minimize the admission of containers with capabilities assigned (Manual)"
+        type: "manual"
+        remediation: |
+          Review the use of capabilites in applications running on your cluster. Where a namespace
+          contains applicaions which do not require any Linux capabities to operate consider adding
+          a PSP which forbids the admission of containers which do not drop all capabilities.
+        scored: false
+
+  - id: 5.3
+    text: "Network Policies and CNI"
+    checks:
+      - id: 5.3.1
+        text: "Ensure that the CNI in use supports Network Policies (Manual)"
+        type: "manual"
+        remediation: |
+          If the CNI plugin in use does not support network policies, consideration should be given to
+          making use of a different plugin, or finding an alternate mechanism for restricting traffic
+          in the Kubernetes cluster.
+        scored: false
+
+      - id: 5.3.2
+        text: "Ensure that all Namespaces have Network Policies defined (Manual)"
+        type: "manual"
+        remediation: |
+          Follow the documentation and create NetworkPolicy objects as you need them.
+        scored: false
+
+  - id: 5.4
+    text: "Secrets Management"
+    checks:
+      - id: 5.4.1
+        text: "Prefer using secrets as files over secrets as environment variables (Manual)"
+        type: "manual"
+        remediation: |
+          if possible, rewrite application code to read secrets from mounted secret files, rather than
+          from environment variables.
+        scored: false
+
+      - id: 5.4.2
+        text: "Consider external secret storage (Manual)"
+        type: "manual"
+        remediation: |
+          Refer to the secrets management options offered by your cloud provider or a third-party
+          secrets management solution.
+        scored: false
+
+  - id: 5.5
+    text: "Extensible Admission Control"
+    checks:
+      - id: 5.5.1
+        text: "Configure Image Provenance using ImagePolicyWebhook admission controller (Manual)"
+        type: "manual"
+        remediation: |
+          Follow the Kubernetes documentation and setup image provenance.
+        scored: false
+
+  - id: 5.7
+    text: "General Policies"
+    checks:
+      - id: 5.7.1
+        text: "Create administrative boundaries between resources using namespaces (Manual)"
+        type: "manual"
+        remediation: |
+          Follow the documentation and create namespaces for objects in your deployment as you need
+          them.
+        scored: false
+
+      - id: 5.7.2
+        text: "Ensure that the seccomp profile is set to docker/default in your pod definitions (Manual)"
+        type: "manual"
+        remediation: |
+          Use security context to enable the docker/default seccomp profile in your pod definitions.
+          An example is as below:
+            securityContext:
+              seccompProfile:
+                type: RuntimeDefault
+        scored: false
+
+      - id: 5.7.3
+        text: "Apply Security Context to Your Pods and Containers (Manual)"
+        type: "manual"
+        remediation: |
+          Follow the Kubernetes documentation and apply security contexts to your pods. For a
+          suggested list of security contexts, you may refer to the CIS Security Benchmark for Docker
+          Containers.
+        scored: false
+
+      - id: 5.7.4
+        text: "The default namespace should not be used (Manual)"
+        type: "manual"
+        remediation: |
+          Ensure that namespaces are created to allow for appropriate segregation of Kubernetes
+          resources and that all new resources are created in a specific namespace.
+        scored: false

--- a/package/cfg/config.yaml
+++ b/package/cfg/config.yaml
@@ -207,6 +207,8 @@ version_mapping:
   "rke-1.16": "rke-cis-1.6-permissive"
   "rke-1.17": "rke-cis-1.6-permissive"
   "rke-1.18": "rke-cis-1.6-permissive"
+  "rke-1.19": "rke-cis-1.20-permissive"
+  "rke-1.20": "rke-cis-1.20-permissive"
   "v1.18.10+rke2r1": "rke2-cis-1.5-hardened"
   "v1.18.10+rke2r1": "rke2-cis-1.5-permissive"
   "eks-1.0": "eks-1.0"
@@ -280,6 +282,12 @@ target_mapping:
     - "controlplane"
     - "etcd"
     - "policies"
+  "rke-cis-1.20-permissive":
+    - "master"
+    - "node"
+    - "controlplane"
+    - "etcd"
+    - "policies"  
   "eks-1.0":
     - "node"
   "gke-1.0":

--- a/package/cfg/config.yaml
+++ b/package/cfg/config.yaml
@@ -264,6 +264,12 @@ target_mapping:
     - "controlplane"
     - "etcd"
     - "policies"
+  "rke-cis-1.20-hardened":
+    - "master"
+    - "node"
+    - "controlplane"
+    - "etcd"
+    - "policies"
   "rke-cis-1.5-permissive":
     - "master"
     - "node"

--- a/package/cfg/config.yaml
+++ b/package/cfg/config.yaml
@@ -207,7 +207,6 @@ version_mapping:
   "rke-1.16": "rke-cis-1.6-permissive"
   "rke-1.17": "rke-cis-1.6-permissive"
   "rke-1.18": "rke-cis-1.6-permissive"
-  "rke-1.19": "rke-cis-1.6-permissive"
   "v1.18.10+rke2r1": "rke2-cis-1.5-hardened"
   "v1.18.10+rke2r1": "rke2-cis-1.5-permissive"
   "eks-1.0": "eks-1.0"
@@ -235,6 +234,12 @@ target_mapping:
     - "controlplane"
     - "etcd"
     - "policies"
+  "cis-1.20":
+    - "master"
+    - "node"
+    - "controlplane"
+    - "etcd"
+    - "policies"  
   "rke-cis-1.4":
     - "master"
     - "node"

--- a/package/cfg/rke-cis-1.20-hardened/config.yaml
+++ b/package/cfg/rke-cis-1.20-hardened/config.yaml
@@ -1,0 +1,2 @@
+---
+## Version-specific settings that override the values in cfg/config.yaml

--- a/package/cfg/rke-cis-1.20-hardened/config.yaml
+++ b/package/cfg/rke-cis-1.20-hardened/config.yaml
@@ -1,2 +1,10 @@
 ---
 ## Version-specific settings that override the values in cfg/config.yaml
+
+node:
+  kubelet:
+    defaultkubeconfig: "/etc/kubernetes/ssl/kubecfg-kube-node.yaml"
+    defaultcafile: "/etc/kubernetes/ssl/kube-ca.pem"
+
+  proxy:
+    defaultkubeconfig: "/etc/kubernetes/ssl/kubecfg-kube-proxy.yaml"

--- a/package/cfg/rke-cis-1.20-hardened/controlplane.yaml
+++ b/package/cfg/rke-cis-1.20-hardened/controlplane.yaml
@@ -1,0 +1,39 @@
+---
+controls:
+version: "1.20"
+id: 3
+text: "Control Plane Configuration"
+type: "controlplane"
+groups:
+  - id: 3.1
+    text: "Authentication and Authorization"
+    checks:
+      - id: 3.1.1
+        text: "Client certificate authentication should not be used for users (Manual)"
+        type: "manual"
+        remediation: |
+          Alternative mechanisms provided by Kubernetes such as the use of OIDC should be
+          implemented in place of client certificates.
+        scored: false
+
+  - id: 3.2
+    text: "Logging"
+    checks:
+      - id: 3.2.1
+        text: "Ensure that a minimal audit policy is created (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-policy-file"
+              set: true
+        remediation: |
+          Create an audit policy file for your cluster.
+        scored: false
+
+      - id: 3.2.2
+        text: "Ensure that the audit policy covers key security concerns (Manual)"
+        type: "manual"
+        remediation: |
+          Consider modification of the audit policy in use on the cluster to include these items, at a
+          minimum.
+        scored: false

--- a/package/cfg/rke-cis-1.20-hardened/controlplane.yaml
+++ b/package/cfg/rke-cis-1.20-hardened/controlplane.yaml
@@ -1,6 +1,6 @@
 ---
 controls:
-version: "1.20"
+version: 1.20
 id: 3
 text: "Control Plane Configuration"
 type: "controlplane"
@@ -20,7 +20,7 @@ groups:
     text: "Logging"
     checks:
       - id: 3.2.1
-        text: "Ensure that a minimal audit policy is created (Manual)"
+        text: "Ensure that a minimal audit policy is created (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -28,7 +28,7 @@ groups:
               set: true
         remediation: |
           Create an audit policy file for your cluster.
-        scored: false
+        scored: true
 
       - id: 3.2.2
         text: "Ensure that the audit policy covers key security concerns (Manual)"

--- a/package/cfg/rke-cis-1.20-hardened/etcd.yaml
+++ b/package/cfg/rke-cis-1.20-hardened/etcd.yaml
@@ -1,0 +1,135 @@
+---
+controls:
+version: "1.20"
+id: 2
+text: "Etcd Node Configuration"
+type: "etcd"
+groups:
+  - id: 2
+    text: "Etcd Node Configuration Files"
+    checks:
+      - id: 2.1
+        text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--cert-file"
+              env: "ETCD_CERT_FILE"
+            - flag: "--key-file"
+              env: "ETCD_KEY_FILE"
+        remediation: |
+          Follow the etcd service documentation and configure TLS encryption.
+          Then, edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml
+          on the master node and set the below parameters.
+          --cert-file=</path/to/ca-file>
+          --key-file=</path/to/key-file>
+        scored: true
+
+      - id: 2.2
+        text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          test_items:
+            - flag: "--client-cert-auth"
+              env: "ETCD_CLIENT_CERT_AUTH"
+              compare:
+                op: eq
+                value: true
+        remediation: |
+          Edit the etcd pod specification file $etcdconf on the master
+          node and set the below parameter.
+          --client-cert-auth="true"
+        scored: true
+
+      - id: 2.3
+        text: "Ensure that the --auto-tls argument is not set to true (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--auto-tls"
+              env: "ETCD_AUTO_TLS"
+              set: false
+            - flag: "--auto-tls"
+              env: "ETCD_AUTO_TLS"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the etcd pod specification file $etcdconf on the master
+          node and either remove the --auto-tls parameter or set it to false.
+            --auto-tls=false
+        scored: true
+
+      - id: 2.4
+        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are
+        set as appropriate (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--peer-cert-file"
+              env: "ETCD_PEER_CERT_FILE"
+            - flag: "--peer-key-file"
+              env: "ETCD_PEER_KEY_FILE"
+        remediation: |
+          Follow the etcd service documentation and configure peer TLS encryption as appropriate
+          for your etcd cluster.
+          Then, edit the etcd pod specification file $etcdconf on the
+          master node and set the below parameters.
+          --peer-client-file=</path/to/peer-cert-file>
+          --peer-key-file=</path/to/peer-key-file>
+        scored: true
+
+      - id: 2.5
+        text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          test_items:
+            - flag: "--peer-client-cert-auth"
+              env: "ETCD_PEER_CLIENT_CERT_AUTH"
+              compare:
+                op: eq
+                value: true
+        remediation: |
+          Edit the etcd pod specification file $etcdconf on the master
+          node and set the below parameter.
+          --peer-client-cert-auth=true
+        scored: true
+
+      - id: 2.6
+        text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--peer-auto-tls"
+              env: "ETCD_PEER_AUTO_TLS"
+              set: false
+            - flag: "--peer-auto-tls"
+              env: "ETCD_PEER_AUTO_TLS"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the etcd pod specification file $etcdconf on the master
+          node and either remove the --peer-auto-tls parameter or set it to false.
+          --peer-auto-tls=false
+        scored: true
+
+      - id: 2.7
+        text: "Ensure that a unique Certificate Authority is used for etcd (Manual)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          test_items:
+            - flag: "--trusted-ca-file"
+              env: "ETCD_TRUSTED_CA_FILE"
+        remediation: |
+          [Manual test]
+          Follow the etcd documentation and create a dedicated certificate authority setup for the
+          etcd service.
+          Then, edit the etcd pod specification file $etcdconf on the
+          master node and set the below parameter.
+          --trusted-ca-file=</path/to/ca-file>
+        scored: false

--- a/package/cfg/rke-cis-1.20-hardened/etcd.yaml
+++ b/package/cfg/rke-cis-1.20-hardened/etcd.yaml
@@ -1,10 +1,87 @@
 ---
 controls:
-version: "1.20"
+version: 1.20
 id: 2
 text: "Etcd Node Configuration"
 type: "etcd"
 groups:
+  - id: 1.1
+    text: "Master Node Configuration Files"
+    checks:
+    - id: 1.1.11
+      text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
+      audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c permissions=%a
+      tests:
+        test_items:
+          - flag: "permissions"
+            compare:
+              op: bitmask
+              value: "700"
+      remediation: |
+        On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+        from the below command:
+        ps -ef | grep etcd
+        Run the below command (based on the etcd data directory found above). For example,
+        chmod 700 /var/lib/etcd
+      scored: true
+    - id: 1.1.12
+      text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
+      audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G
+      tests:
+        test_items:
+          - flag: "etcd:etcd"
+      remediation: |
+        On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+        from the below command:
+        ps -ef | grep etcd
+        Run the below command (based on the etcd data directory found above).
+        For example, chown etcd:etcd /var/lib/etcd
+      scored: true
+    - id: 1.1.19
+      text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
+      audit: "check_files_owner_in_dir.sh /node/etc/kubernetes/ssl"
+      tests:
+        test_items:
+          - flag: "true"
+            compare:
+              op: eq
+              value: "true"
+            set: true
+      remediation: |
+        Run the below command (based on the file location on your system) on the master node.
+        For example,
+        chown -R root:root /etc/kubernetes/pki/
+      scored: true
+    - id: 1.1.20
+      text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Automated) "
+      audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/!(*key).pem"
+      tests:
+        test_items:
+          - flag: "true"
+            compare:
+              op: eq
+              value: "true"
+            set: true
+      remediation: |
+        Run the below command (based on the file location on your system) on the master node.
+        For example,
+        chmod -R 644 /etc/kubernetes/pki/*.crt
+      scored: true
+    - id: 1.1.21
+      text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Automated)"
+      audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/*key.pem 600"
+      tests:
+        test_items:
+          - flag: "true"
+            compare:
+              op: eq
+              value: "true"
+            set: true
+      remediation: |
+        Run the below command (based on the file location on your system) on the master node.
+        For example,
+        chmod -R 600 /etc/kubernetes/ssl/*key.pem
+      scored: true  
   - id: 2
     text: "Etcd Node Configuration Files"
     checks:
@@ -16,8 +93,10 @@ groups:
           test_items:
             - flag: "--cert-file"
               env: "ETCD_CERT_FILE"
+              set: true
             - flag: "--key-file"
               env: "ETCD_KEY_FILE"
+              set: true
         remediation: |
           Follow the etcd service documentation and configure TLS encryption.
           Then, edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml
@@ -36,6 +115,7 @@ groups:
               compare:
                 op: eq
                 value: true
+              set: true
         remediation: |
           Edit the etcd pod specification file $etcdconf on the master
           node and set the below parameter.
@@ -71,8 +151,10 @@ groups:
           test_items:
             - flag: "--peer-cert-file"
               env: "ETCD_PEER_CERT_FILE"
+              set: true              
             - flag: "--peer-key-file"
               env: "ETCD_PEER_KEY_FILE"
+              set: true
         remediation: |
           Follow the etcd service documentation and configure peer TLS encryption as appropriate
           for your etcd cluster.
@@ -86,12 +168,15 @@ groups:
         text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
         audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
         tests:
+          bin_op: or
           test_items:
             - flag: "--peer-client-cert-auth"
+              set: true
               env: "ETCD_PEER_CLIENT_CERT_AUTH"
               compare:
                 op: eq
                 value: true
+              set: true
         remediation: |
           Edit the etcd pod specification file $etcdconf on the master
           node and set the below parameter.
@@ -112,6 +197,7 @@ groups:
               compare:
                 op: eq
                 value: false
+              set: true
         remediation: |
           Edit the etcd pod specification file $etcdconf on the master
           node and either remove the --peer-auto-tls parameter or set it to false.
@@ -119,12 +205,13 @@ groups:
         scored: true
 
       - id: 2.7
-        text: "Ensure that a unique Certificate Authority is used for etcd (Manual)"
+        text: "Ensure that a unique Certificate Authority is used for etcd (Automated)"
         audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
         tests:
           test_items:
             - flag: "--trusted-ca-file"
               env: "ETCD_TRUSTED_CA_FILE"
+              set: true
         remediation: |
           [Manual test]
           Follow the etcd documentation and create a dedicated certificate authority setup for the
@@ -132,4 +219,4 @@ groups:
           Then, edit the etcd pod specification file $etcdconf on the
           master node and set the below parameter.
           --trusted-ca-file=</path/to/ca-file>
-        scored: false
+        scored: true

--- a/package/cfg/rke-cis-1.20-hardened/master.yaml
+++ b/package/cfg/rke-cis-1.20-hardened/master.yaml
@@ -1,6 +1,6 @@
 ---
 controls:
-version: "1.20"
+version: 1.20
 id: 1
 text: "Master Node Security Configuration"
 type: "master"
@@ -10,6 +10,7 @@ groups:
     checks:
       - id: 1.1.1
         text: "Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $apiserverconf; then stat -c permissions=%a $apiserverconf; fi'"
         tests:
           test_items:
@@ -18,25 +19,25 @@ groups:
                 op: bitmask
                 value: "644"
         remediation: |
-          Run the below command (based on the file location on your system) on the
-          master node.
-          For example, chmod 644 $apiserverconf
+          Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.2
         text: "Ensure that the API server pod specification file ownership is set to root:root (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $apiserverconf; then stat -c %U:%G $apiserverconf; fi'"
         tests:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chown root:root $apiserverconf
+          Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.3
         text: "Ensure that the controller manager pod specification file permissions are set to 644 or more restrictive (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $controllermanagerconf; then stat -c permissions=%a $controllermanagerconf; fi'"
         tests:
           test_items:
@@ -45,25 +46,25 @@ groups:
                 op: bitmask
                 value: "644"
         remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chmod 644 $controllermanagerconf
+          Cluster provisioned by RKE doesn't require or maintain a configuration file for controller-manager.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.4
         text: "Ensure that the controller manager pod specification file ownership is set to root:root (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $controllermanagerconf; then stat -c %U:%G $controllermanagerconf; fi'"
         tests:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chown root:root $controllermanagerconf
+          Cluster provisioned by RKE doesn't require or maintain a configuration file for controller-manager.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.5
         text: "Ensure that the scheduler pod specification file permissions are set to 644 or more restrictive (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c permissions=%a $schedulerconf; fi'"
         tests:
           test_items:
@@ -72,25 +73,25 @@ groups:
                 op: bitmask
                 value: "644"
         remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chmod 644 $schedulerconf
+          Cluster provisioned by RKE doesn't require or maintain a configuration file for scheduler.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.6
         text: "Ensure that the scheduler pod specification file ownership is set to root:root (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c %U:%G $schedulerconf; fi'"
         tests:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chown root:root $schedulerconf
+          Cluster provisioned by RKE doesn't require or maintain a configuration file for scheduler.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.7
         text: "Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
         use_multiple_values: true
         tests:
@@ -100,26 +101,26 @@ groups:
                 op: bitmask
                 value: "644"
         remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chmod 644 $etcdconf
+          Cluster provisioned by RKE doesn't require or maintain a configuration file for etcd.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.8
         text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c %U:%G; fi'"
         use_multiple_values: true
         tests:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chown root:root $etcdconf
+          Cluster provisioned by RKE doesn't require or maintain a configuration file for etcd.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Manual)"
+        type: "manual"
         audit: |
           ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
           find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
@@ -138,6 +139,7 @@ groups:
 
       - id: 1.1.10
         text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
+        type: "manual"
         audit: |
           ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
           find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
@@ -151,39 +153,11 @@ groups:
           chown root:root <path/to/cni/files>
         scored: false
 
-      - id: 1.1.11
-        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c permissions=%a
-        tests:
-          test_items:
-            - flag: "permissions"
-              compare:
-                op: bitmask
-                value: "700"
-        remediation: |
-          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-          from the below command:
-          ps -ef | grep etcd
-          Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
-        scored: true
-
-      - id: 1.1.12
-        text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
-        audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G
-        tests:
-          test_items:
-            - flag: "etcd:etcd"
-        remediation: |
-          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-          from the below command:
-          ps -ef | grep etcd
-          Run the below command (based on the etcd data directory found above).
-          For example, chown etcd:etcd /var/lib/etcd
-        scored: true
+     
 
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 644 or more restrictive (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c permissions=%a /etc/kubernetes/admin.conf; fi'"
         tests:
           test_items:
@@ -192,25 +166,23 @@ groups:
                 op: bitmask
                 value: "644"
         remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chmod 644 /etc/kubernetes/admin.conf
+          Cluster provisioned by RKE does not store the kubernetes default kubeconfig credentials file on the nodes.
         scored: true
 
       - id: 1.1.14
         text: "Ensure that the admin.conf file ownership is set to root:root (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c %U:%G /etc/kubernetes/admin.conf; fi'"
         tests:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chown root:root /etc/kubernetes/admin.conf
+          Cluster provisioned by RKE does not store the kubernetes default kubeconfig credentials file on the nodes.
         scored: true
 
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c permissions=%a $schedulerkubeconfig; fi'"
         tests:
           test_items:
@@ -219,25 +191,25 @@ groups:
                 op: bitmask
                 value: "644"
         remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chmod 644 $schedulerkubeconfig
+          Cluster provisioned by RKE doesn't require or maintain a configuration file for scheduler.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c %U:%G $schedulerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chown root:root $schedulerkubeconfig
+          Cluster provisioned by RKE doesn't require or maintain a configuration file for scheduler.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c permissions=%a $controllermanagerkubeconfig; fi'"
         tests:
           test_items:
@@ -246,30 +218,32 @@ groups:
                 op: bitmask
                 value: "644"
         remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chmod 644 $controllermanagerkubeconfig
+          Cluster provisioned by RKE doesn't require or maintain a configuration file for controller-manager.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.18
         text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c %U:%G $controllermanagerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chown root:root $controllermanagerkubeconfig
+          Cluster provisioned by RKE doesn't require or maintain a configuration file for controller-manager.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.19
         text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
-        audit: "find /etc/kubernetes/pki/ | xargs stat -c %U:%G"
-        use_multiple_values: true
+        audit: "check_files_owner_in_dir.sh /node/etc/kubernetes/ssl"
         tests:
           test_items:
-            - flag: "root:root"
+            - flag: "true"
+              compare:
+                op: eq
+                value: "true"
+              set: true
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
@@ -277,42 +251,42 @@ groups:
         scored: true
 
       - id: 1.1.20
-        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Manual)"
-        audit: "find /etc/kubernetes/pki/ -name '*.crt' | xargs stat -c permissions=%a"
-        use_multiple_values: true
+        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Automated) "
+        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/!(*key).pem"
         tests:
           test_items:
-            - flag: "permissions"
+            - flag: "true"
               compare:
-                op: bitmask
-                value: "644"
+                op: eq
+                value: "true"
+              set: true
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
           chmod -R 644 /etc/kubernetes/pki/*.crt
-        scored: false
+        scored: true
 
       - id: 1.1.21
-        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "find /etc/kubernetes/pki/ -name '*.key' | xargs stat -c permissions=%a"
-        use_multiple_values: true
+        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Automated)"
+        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/*key.pem 600"
         tests:
           test_items:
-            - flag: "permissions"
+            - flag: "true"
               compare:
-                op: bitmask
-                value: "600"
+                op: eq
+                value: "true"
+              set: true
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 600 /etc/kubernetes/pki/*.key
-        scored: false
+          chmod -R 600 /etc/kubernetes/ssl/*key.pem
+        scored: true
 
   - id: 1.2
     text: "API Server"
     checks:
       - id: 1.2.1
-        text: "Ensure that the --anonymous-auth argument is set to false (Manual)"
+        text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -320,11 +294,11 @@ groups:
               compare:
                 op: eq
                 value: false
+              set: true
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the below parameter.
-          --anonymous-auth=false
-        scored: false
+        scored: true
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
@@ -363,7 +337,9 @@ groups:
           bin_op: and
           test_items:
             - flag: "--kubelet-client-certificate"
+              set: true
             - flag: "--kubelet-client-key"
+              set: true
         remediation: |
           Follow the Kubernetes documentation and set up the TLS connection between the
           apiserver and kubelets. Then, edit API server pod specification file
@@ -379,6 +355,7 @@ groups:
         tests:
           test_items:
             - flag: "--kubelet-certificate-authority"
+              set: true
         remediation: |
           Follow the Kubernetes documentation and setup the TLS connection between
           the apiserver and kubelets. Then, edit the API server pod specification file
@@ -396,6 +373,7 @@ groups:
               compare:
                 op: nothave
                 value: "AlwaysAllow"
+              set: true
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the --authorization-mode parameter to values other than AlwaysAllow.
@@ -412,6 +390,7 @@ groups:
               compare:
                 op: has
                 value: "Node"
+              set: true
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the --authorization-mode parameter to a value that includes Node.
@@ -427,6 +406,7 @@ groups:
               compare:
                 op: has
                 value: "RBAC"
+              set: true
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the --authorization-mode parameter to a value that includes RBAC,
@@ -435,7 +415,7 @@ groups:
         scored: true
 
       - id: 1.2.9
-        text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
+        text: "Ensure that the admission control plugin EventRateLimit is set (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -443,13 +423,14 @@ groups:
               compare:
                 op: has
                 value: "EventRateLimit"
+              set: true
         remediation: |
           Follow the Kubernetes documentation and set the desired limits in a configuration file.
           Then, edit the API server pod specification file $apiserverconf
           and set the below parameters.
           --enable-admission-plugins=...,EventRateLimit,...
           --admission-control-config-file=<path/to/configuration/file>
-        scored: false
+        scored: true
 
       - id: 1.2.10
         text: "Ensure that the admission control plugin AlwaysAdmit is not set (Automated)"
@@ -461,6 +442,7 @@ groups:
               compare:
                 op: nothave
                 value: AlwaysAdmit
+              set: true
             - flag: "--enable-admission-plugins"
               set: false
         remediation: |
@@ -471,6 +453,7 @@ groups:
 
       - id: 1.2.11
         text: "Ensure that the admission control plugin AlwaysPullImages is set (Manual)"
+        type: "manual"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -478,6 +461,7 @@ groups:
               compare:
                 op: has
                 value: "AlwaysPullImages"
+              set: true
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the --enable-admission-plugins parameter to include
@@ -487,6 +471,7 @@ groups:
 
       - id: 1.2.12
         text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)"
+        type: "manual"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           bin_op: or
@@ -552,6 +537,7 @@ groups:
               compare:
                 op: has
                 value: "PodSecurityPolicy"
+              set: true
         remediation: |
           Follow the documentation and create Pod Security Policy objects as per your environment.
           Then, edit the API server pod specification file $apiserverconf
@@ -570,6 +556,7 @@ groups:
               compare:
                 op: has
                 value: "NodeRestriction"
+              set: true
         remediation: |
           Follow the Kubernetes documentation and configure NodeRestriction plug-in on kubelets.
           Then, edit the API server pod specification file $apiserverconf
@@ -599,6 +586,7 @@ groups:
               compare:
                 op: eq
                 value: 0
+              set: true
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the below parameter.
@@ -615,6 +603,7 @@ groups:
               compare:
                 op: gt
                 value: 0
+              set: true
             - flag: "--secure-port"
               set: false
         remediation: |
@@ -632,6 +621,7 @@ groups:
               compare:
                 op: eq
                 value: false
+              set: true
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the below parameter.
@@ -644,6 +634,7 @@ groups:
         tests:
           test_items:
             - flag: "--audit-log-path"
+              set: true
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the --audit-log-path parameter to a suitable path and
@@ -660,6 +651,7 @@ groups:
               compare:
                 op: gte
                 value: 30
+              set: true
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the --audit-log-maxage parameter to 30 or as an appropriate number of days:
@@ -675,6 +667,7 @@ groups:
               compare:
                 op: gte
                 value: 10
+              set: true
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the --audit-log-maxbackup parameter to 10 or to an appropriate
@@ -691,6 +684,7 @@ groups:
               compare:
                 op: gte
                 value: 100
+              set: true
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the --audit-log-maxsize parameter to an appropriate size in MB.
@@ -699,15 +693,20 @@ groups:
         scored: true
 
       - id: 1.2.25
-        text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"
+        text: "Ensure that the --request-timeout argument is set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
-        type: manual
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--request-timeout"
+              set: false
+            - flag: "--request-timeout"
         remediation: |
           Edit the API server pod specification file $apiserverconf
           and set the below parameter as appropriate and if needed.
           For example,
           --request-timeout=300s
-        scored: false
+        scored: true
 
       - id: 1.2.26
         text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
@@ -721,6 +720,7 @@ groups:
               compare:
                 op: eq
                 value: true
+              set: true
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the below parameter.
@@ -735,6 +735,7 @@ groups:
         tests:
           test_items:
             - flag: "--service-account-key-file"
+              set: true
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the --service-account-key-file parameter
@@ -749,7 +750,9 @@ groups:
           bin_op: and
           test_items:
             - flag: "--etcd-certfile"
+              set: true
             - flag: "--etcd-keyfile"
+              set: true
         remediation: |
           Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
           Then, edit the API server pod specification file $apiserverconf
@@ -765,7 +768,9 @@ groups:
           bin_op: and
           test_items:
             - flag: "--tls-cert-file"
+              set: true
             - flag: "--tls-private-key-file"
+              set: true
         remediation: |
           Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
           Then, edit the API server pod specification file $apiserverconf
@@ -780,6 +785,7 @@ groups:
         tests:
           test_items:
             - flag: "--client-ca-file"
+              set: true
         remediation: |
           Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
           Then, edit the API server pod specification file $apiserverconf
@@ -793,6 +799,7 @@ groups:
         tests:
           test_items:
             - flag: "--etcd-cafile"
+              set: true
         remediation: |
           Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
           Then, edit the API server pod specification file $apiserverconf
@@ -801,35 +808,35 @@ groups:
         scored: true
 
       - id: 1.2.32
-        text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
+        text: "Ensure that the --encryption-provider-config argument is set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
             - flag: "--encryption-provider-config"
+              set: true
         remediation: |
           Follow the Kubernetes documentation and configure a EncryptionConfig file.
           Then, edit the API server pod specification file $apiserverconf
           on the master node and set the --encryption-provider-config parameter to the path of that file: --encryption-provider-config=</path/to/EncryptionConfig/File>
-        scored: false
+        scored: true
 
       - id: 1.2.33
-        text: "Ensure that encryption providers are appropriately configured (Manual)"
-        audit: |
-          ENCRYPTION_PROVIDER_CONFIG=$(ps -ef | grep $apiserverbin | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
-          if test -e $ENCRYPTION_PROVIDER_CONFIG; then grep -A1 'providers:' $ENCRYPTION_PROVIDER_CONFIG | tail -n1 | grep -o "[A-Za-z]*" | sed 's/^/provider=/'; fi
+        text: "Ensure that encryption providers are appropriately configured (Automated)"
+        audit: "check_encryption_provider_config.sh aescbc kms secretbox"
         tests:
           test_items:
-            - flag: "provider"
+            - flag: "true"
               compare:
-                op: valid_elements
-                value: "aescbc,kms,secretbox"
+                op: eq
+                value: "true"
+              set: true
         remediation: |
           Follow the Kubernetes documentation and configure a EncryptionConfig file.
           In this file, choose aescbc, kms or secretbox as the encryption provider.
-        scored: false
+        scored: true
 
       - id: 1.2.34
-        text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Manual)"
+        text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -850,11 +857,12 @@ groups:
     text: "Controller Manager"
     checks:
       - id: 1.3.1
-        text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Manual)"
+        text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
         tests:
           test_items:
             - flag: "--terminated-pod-gc-threshold"
+              set: true
         remediation: |
           Edit the Controller Manager pod specification file $controllermanagerconf
           on the master node and set the --terminated-pod-gc-threshold to an appropriate threshold,
@@ -871,6 +879,7 @@ groups:
               compare:
                 op: eq
                 value: false
+              set: true
         remediation: |
           Edit the Controller Manager pod specification file $controllermanagerconf
           on the master node and set the below parameter.
@@ -886,6 +895,7 @@ groups:
               compare:
                 op: noteq
                 value: false
+              set: true
         remediation: |
           Edit the Controller Manager pod specification file $controllermanagerconf
           on the master node to set the below parameter.
@@ -898,6 +908,7 @@ groups:
         tests:
           test_items:
             - flag: "--service-account-private-key-file"
+              set: true
         remediation: |
           Edit the Controller Manager pod specification file $controllermanagerconf
           on the master node and set the --service-account-private-key-file parameter
@@ -911,6 +922,7 @@ groups:
         tests:
           test_items:
             - flag: "--root-ca-file"
+              set: true
         remediation: |
           Edit the Controller Manager pod specification file $controllermanagerconf
           on the master node and set the --root-ca-file parameter to the certificate bundle file`.
@@ -919,14 +931,15 @@ groups:
 
       - id: 1.3.6
         text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
+        type: "skip"
         audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
         tests:
           bin_op: or
           test_items:
             - flag: "--feature-gates"
               compare:
-                op: nothave
-                value: "RotateKubeletServerCertificate=false"
+                op: eq
+                value: "RotateKubeletServerCertificate=true"
               set: true
             - flag: "--feature-gates"
               set: false
@@ -934,6 +947,8 @@ groups:
           Edit the Controller Manager pod specification file $controllermanagerconf
           on the master node and set the --feature-gates parameter to include RotateKubeletServerCertificate=true.
           --feature-gates=RotateKubeletServerCertificate=true
+
+          Cluster provisioned by RKE handles certificate rotation directly through RKE.
         scored: true
 
       - id: 1.3.7
@@ -946,6 +961,7 @@ groups:
               compare:
                 op: eq
                 value: "127.0.0.1"
+              set: true  
             - flag: "--bind-address"
               set: false
         remediation: |
@@ -965,6 +981,7 @@ groups:
               compare:
                 op: eq
                 value: false
+              set: true
         remediation: |
           Edit the Scheduler pod specification file $schedulerconf file
           on the master node and set the below parameter.
@@ -981,6 +998,7 @@ groups:
               compare:
                 op: eq
                 value: "127.0.0.1"
+              set: true  
             - flag: "--bind-address"
               set: false
         remediation: |

--- a/package/cfg/rke-cis-1.20-hardened/master.yaml
+++ b/package/cfg/rke-cis-1.20-hardened/master.yaml
@@ -1,0 +1,989 @@
+---
+controls:
+version: "1.20"
+id: 1
+text: "Master Node Security Configuration"
+type: "master"
+groups:
+  - id: 1.1
+    text: "Master Node Configuration Files"
+    checks:
+      - id: 1.1.1
+        text: "Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $apiserverconf; then stat -c permissions=%a $apiserverconf; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the
+          master node.
+          For example, chmod 644 $apiserverconf
+        scored: true
+
+      - id: 1.1.2
+        text: "Ensure that the API server pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $apiserverconf; then stat -c %U:%G $apiserverconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown root:root $apiserverconf
+        scored: true
+
+      - id: 1.1.3
+        text: "Ensure that the controller manager pod specification file permissions are set to 644 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $controllermanagerconf; then stat -c permissions=%a $controllermanagerconf; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod 644 $controllermanagerconf
+        scored: true
+
+      - id: 1.1.4
+        text: "Ensure that the controller manager pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $controllermanagerconf; then stat -c %U:%G $controllermanagerconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown root:root $controllermanagerconf
+        scored: true
+
+      - id: 1.1.5
+        text: "Ensure that the scheduler pod specification file permissions are set to 644 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c permissions=%a $schedulerconf; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod 644 $schedulerconf
+        scored: true
+
+      - id: 1.1.6
+        text: "Ensure that the scheduler pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c %U:%G $schedulerconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown root:root $schedulerconf
+        scored: true
+
+      - id: 1.1.7
+        text: "Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod 644 $etcdconf
+        scored: true
+
+      - id: 1.1.8
+        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c %U:%G; fi'"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown root:root $etcdconf
+        scored: true
+
+      - id: 1.1.9
+        text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Manual)"
+        audit: |
+          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
+          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod 644 <path/to/cni/files>
+        scored: false
+
+      - id: 1.1.10
+        text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
+        audit: |
+          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
+          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown root:root <path/to/cni/files>
+        scored: false
+
+      - id: 1.1.11
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
+        audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c permissions=%a
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "700"
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the below command:
+          ps -ef | grep etcd
+          Run the below command (based on the etcd data directory found above). For example,
+          chmod 700 /var/lib/etcd
+        scored: true
+
+      - id: 1.1.12
+        text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
+        audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G
+        tests:
+          test_items:
+            - flag: "etcd:etcd"
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the below command:
+          ps -ef | grep etcd
+          Run the below command (based on the etcd data directory found above).
+          For example, chown etcd:etcd /var/lib/etcd
+        scored: true
+
+      - id: 1.1.13
+        text: "Ensure that the admin.conf file permissions are set to 644 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c permissions=%a /etc/kubernetes/admin.conf; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod 644 /etc/kubernetes/admin.conf
+        scored: true
+
+      - id: 1.1.14
+        text: "Ensure that the admin.conf file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c %U:%G /etc/kubernetes/admin.conf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown root:root /etc/kubernetes/admin.conf
+        scored: true
+
+      - id: 1.1.15
+        text: "Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c permissions=%a $schedulerkubeconfig; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod 644 $schedulerkubeconfig
+        scored: true
+
+      - id: 1.1.16
+        text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c %U:%G $schedulerkubeconfig; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown root:root $schedulerkubeconfig
+        scored: true
+
+      - id: 1.1.17
+        text: "Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c permissions=%a $controllermanagerkubeconfig; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod 644 $controllermanagerkubeconfig
+        scored: true
+
+      - id: 1.1.18
+        text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c %U:%G $controllermanagerkubeconfig; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown root:root $controllermanagerkubeconfig
+        scored: true
+
+      - id: 1.1.19
+        text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
+        audit: "find /etc/kubernetes/pki/ | xargs stat -c %U:%G"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown -R root:root /etc/kubernetes/pki/
+        scored: true
+
+      - id: 1.1.20
+        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Manual)"
+        audit: "find /etc/kubernetes/pki/ -name '*.crt' | xargs stat -c permissions=%a"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod -R 644 /etc/kubernetes/pki/*.crt
+        scored: false
+
+      - id: 1.1.21
+        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
+        audit: "find /etc/kubernetes/pki/ -name '*.key' | xargs stat -c permissions=%a"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod -R 600 /etc/kubernetes/pki/*.key
+        scored: false
+
+  - id: 1.2
+    text: "API Server"
+    checks:
+      - id: 1.2.1
+        text: "Ensure that the --anonymous-auth argument is set to false (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--anonymous-auth"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the below parameter.
+          --anonymous-auth=false
+        scored: false
+
+      - id: 1.2.2
+        text: "Ensure that the --token-auth-file parameter is not set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--token-auth-file"
+              set: false
+        remediation: |
+          Follow the documentation and configure alternate mechanisms for authentication. Then,
+          edit the API server pod specification file $apiserverconf
+          on the master node and remove the --token-auth-file=<filename> parameter.
+        scored: true
+
+      - id: 1.2.3
+        text: "Ensure that the --kubelet-https argument is set to true (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--kubelet-https"
+              compare:
+                op: eq
+                value: true
+            - flag: "--kubelet-https"
+              set: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and remove the --kubelet-https parameter.
+        scored: true
+
+      - id: 1.2.4
+        text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--kubelet-client-certificate"
+            - flag: "--kubelet-client-key"
+        remediation: |
+          Follow the Kubernetes documentation and set up the TLS connection between the
+          apiserver and kubelets. Then, edit API server pod specification file
+          $apiserverconf on the master node and set the
+          kubelet client certificate and key parameters as below.
+          --kubelet-client-certificate=<path/to/client-certificate-file>
+          --kubelet-client-key=<path/to/client-key-file>
+        scored: true
+
+      - id: 1.2.5
+        text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--kubelet-certificate-authority"
+        remediation: |
+          Follow the Kubernetes documentation and setup the TLS connection between
+          the apiserver and kubelets. Then, edit the API server pod specification file
+          $apiserverconf on the master node and set the
+          --kubelet-certificate-authority parameter to the path to the cert file for the certificate authority.
+          --kubelet-certificate-authority=<ca-string>
+        scored: true
+
+      - id: 1.2.6
+        text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--authorization-mode"
+              compare:
+                op: nothave
+                value: "AlwaysAllow"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --authorization-mode parameter to values other than AlwaysAllow.
+          One such example could be as below.
+          --authorization-mode=RBAC
+        scored: true
+
+      - id: 1.2.7
+        text: "Ensure that the --authorization-mode argument includes Node (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--authorization-mode"
+              compare:
+                op: has
+                value: "Node"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --authorization-mode parameter to a value that includes Node.
+          --authorization-mode=Node,RBAC
+        scored: true
+
+      - id: 1.2.8
+        text: "Ensure that the --authorization-mode argument includes RBAC (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--authorization-mode"
+              compare:
+                op: has
+                value: "RBAC"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --authorization-mode parameter to a value that includes RBAC,
+          for example:
+          --authorization-mode=Node,RBAC
+        scored: true
+
+      - id: 1.2.9
+        text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "EventRateLimit"
+        remediation: |
+          Follow the Kubernetes documentation and set the desired limits in a configuration file.
+          Then, edit the API server pod specification file $apiserverconf
+          and set the below parameters.
+          --enable-admission-plugins=...,EventRateLimit,...
+          --admission-control-config-file=<path/to/configuration/file>
+        scored: false
+
+      - id: 1.2.10
+        text: "Ensure that the admission control plugin AlwaysAdmit is not set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: nothave
+                value: AlwaysAdmit
+            - flag: "--enable-admission-plugins"
+              set: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and either remove the --enable-admission-plugins parameter, or set it to a
+          value that does not include AlwaysAdmit.
+        scored: true
+
+      - id: 1.2.11
+        text: "Ensure that the admission control plugin AlwaysPullImages is set (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "AlwaysPullImages"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --enable-admission-plugins parameter to include
+          AlwaysPullImages.
+          --enable-admission-plugins=...,AlwaysPullImages,...
+        scored: false
+
+      - id: 1.2.12
+        text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "SecurityContextDeny"
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "PodSecurityPolicy"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --enable-admission-plugins parameter to include
+          SecurityContextDeny, unless PodSecurityPolicy is already in place.
+          --enable-admission-plugins=...,SecurityContextDeny,...
+        scored: false
+
+      - id: 1.2.13
+        text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--disable-admission-plugins"
+              compare:
+                op: nothave
+                value: "ServiceAccount"
+            - flag: "--disable-admission-plugins"
+              set: false
+        remediation: |
+          Follow the documentation and create ServiceAccount objects as per your environment.
+          Then, edit the API server pod specification file $apiserverconf
+          on the master node and ensure that the --disable-admission-plugins parameter is set to a
+          value that does not include ServiceAccount.
+        scored: true
+
+      - id: 1.2.14
+        text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--disable-admission-plugins"
+              compare:
+                op: nothave
+                value: "NamespaceLifecycle"
+            - flag: "--disable-admission-plugins"
+              set: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --disable-admission-plugins parameter to
+          ensure it does not include NamespaceLifecycle.
+        scored: true
+
+      - id: 1.2.15
+        text: "Ensure that the admission control plugin PodSecurityPolicy is set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "PodSecurityPolicy"
+        remediation: |
+          Follow the documentation and create Pod Security Policy objects as per your environment.
+          Then, edit the API server pod specification file $apiserverconf
+          on the master node and set the --enable-admission-plugins parameter to a
+          value that includes PodSecurityPolicy:
+          --enable-admission-plugins=...,PodSecurityPolicy,...
+          Then restart the API Server.
+        scored: true
+
+      - id: 1.2.16
+        text: "Ensure that the admission control plugin NodeRestriction is set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "NodeRestriction"
+        remediation: |
+          Follow the Kubernetes documentation and configure NodeRestriction plug-in on kubelets.
+          Then, edit the API server pod specification file $apiserverconf
+          on the master node and set the --enable-admission-plugins parameter to a
+          value that includes NodeRestriction.
+          --enable-admission-plugins=...,NodeRestriction,...
+        scored: true
+
+      - id: 1.2.17
+        text: "Ensure that the --insecure-bind-address argument is not set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--insecure-bind-address"
+              set: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and remove the --insecure-bind-address parameter.
+        scored: true
+
+      - id: 1.2.18
+        text: "Ensure that the --insecure-port argument is set to 0 (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--insecure-port"
+              compare:
+                op: eq
+                value: 0
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the below parameter.
+          --insecure-port=0
+        scored: true
+
+      - id: 1.2.19
+        text: "Ensure that the --secure-port argument is not set to 0 (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--secure-port"
+              compare:
+                op: gt
+                value: 0
+            - flag: "--secure-port"
+              set: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and either remove the --secure-port parameter or
+          set it to a different (non-zero) desired port.
+        scored: true
+
+      - id: 1.2.20
+        text: "Ensure that the --profiling argument is set to false (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--profiling"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the below parameter.
+          --profiling=false
+        scored: true
+
+      - id: 1.2.21
+        text: "Ensure that the --audit-log-path argument is set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-log-path"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --audit-log-path parameter to a suitable path and
+          file where you would like audit logs to be written, for example:
+          --audit-log-path=/var/log/apiserver/audit.log
+        scored: true
+
+      - id: 1.2.22
+        text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-log-maxage"
+              compare:
+                op: gte
+                value: 30
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --audit-log-maxage parameter to 30 or as an appropriate number of days:
+          --audit-log-maxage=30
+        scored: true
+
+      - id: 1.2.23
+        text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-log-maxbackup"
+              compare:
+                op: gte
+                value: 10
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --audit-log-maxbackup parameter to 10 or to an appropriate
+          value.
+          --audit-log-maxbackup=10
+        scored: true
+
+      - id: 1.2.24
+        text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-log-maxsize"
+              compare:
+                op: gte
+                value: 100
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --audit-log-maxsize parameter to an appropriate size in MB.
+          For example, to set it as 100 MB:
+          --audit-log-maxsize=100
+        scored: true
+
+      - id: 1.2.25
+        text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        type: manual
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          and set the below parameter as appropriate and if needed.
+          For example,
+          --request-timeout=300s
+        scored: false
+
+      - id: 1.2.26
+        text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--service-account-lookup"
+              set: false
+            - flag: "--service-account-lookup"
+              compare:
+                op: eq
+                value: true
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the below parameter.
+          --service-account-lookup=true
+          Alternatively, you can delete the --service-account-lookup parameter from this file so
+          that the default takes effect.
+        scored: true
+
+      - id: 1.2.27
+        text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--service-account-key-file"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --service-account-key-file parameter
+          to the public key file for service accounts:
+          --service-account-key-file=<filename>
+        scored: true
+
+      - id: 1.2.28
+        text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--etcd-certfile"
+            - flag: "--etcd-keyfile"
+        remediation: |
+          Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
+          Then, edit the API server pod specification file $apiserverconf
+          on the master node and set the etcd certificate and key file parameters.
+          --etcd-certfile=<path/to/client-certificate-file>
+          --etcd-keyfile=<path/to/client-key-file>
+        scored: true
+
+      - id: 1.2.29
+        text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--tls-cert-file"
+            - flag: "--tls-private-key-file"
+        remediation: |
+          Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
+          Then, edit the API server pod specification file $apiserverconf
+          on the master node and set the TLS certificate and private key file parameters.
+          --tls-cert-file=<path/to/tls-certificate-file>
+          --tls-private-key-file=<path/to/tls-key-file>
+        scored: true
+
+      - id: 1.2.30
+        text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--client-ca-file"
+        remediation: |
+          Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
+          Then, edit the API server pod specification file $apiserverconf
+          on the master node and set the client certificate authority file.
+          --client-ca-file=<path/to/client-ca-file>
+        scored: true
+
+      - id: 1.2.31
+        text: "Ensure that the --etcd-cafile argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--etcd-cafile"
+        remediation: |
+          Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
+          Then, edit the API server pod specification file $apiserverconf
+          on the master node and set the etcd certificate authority file parameter.
+          --etcd-cafile=<path/to/ca-file>
+        scored: true
+
+      - id: 1.2.32
+        text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--encryption-provider-config"
+        remediation: |
+          Follow the Kubernetes documentation and configure a EncryptionConfig file.
+          Then, edit the API server pod specification file $apiserverconf
+          on the master node and set the --encryption-provider-config parameter to the path of that file: --encryption-provider-config=</path/to/EncryptionConfig/File>
+        scored: false
+
+      - id: 1.2.33
+        text: "Ensure that encryption providers are appropriately configured (Manual)"
+        audit: |
+          ENCRYPTION_PROVIDER_CONFIG=$(ps -ef | grep $apiserverbin | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
+          if test -e $ENCRYPTION_PROVIDER_CONFIG; then grep -A1 'providers:' $ENCRYPTION_PROVIDER_CONFIG | tail -n1 | grep -o "[A-Za-z]*" | sed 's/^/provider=/'; fi
+        tests:
+          test_items:
+            - flag: "provider"
+              compare:
+                op: valid_elements
+                value: "aescbc,kms,secretbox"
+        remediation: |
+          Follow the Kubernetes documentation and configure a EncryptionConfig file.
+          In this file, choose aescbc, kms or secretbox as the encryption provider.
+        scored: false
+
+      - id: 1.2.34
+        text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--tls-cipher-suites"
+              compare:
+                op: valid_elements
+                value: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256"
+        remediation: |
+          Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
+          on the master node and set the below parameter.
+          --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM
+          _SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM
+          _SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM
+          _SHA384
+        scored: false
+
+  - id: 1.3
+    text: "Controller Manager"
+    checks:
+      - id: 1.3.1
+        text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Manual)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--terminated-pod-gc-threshold"
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the master node and set the --terminated-pod-gc-threshold to an appropriate threshold,
+          for example:
+          --terminated-pod-gc-threshold=10
+        scored: false
+
+      - id: 1.3.2
+        text: "Ensure that the --profiling argument is set to false (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--profiling"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the master node and set the below parameter.
+          --profiling=false
+        scored: true
+
+      - id: 1.3.3
+        text: "Ensure that the --use-service-account-credentials argument is set to true (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--use-service-account-credentials"
+              compare:
+                op: noteq
+                value: false
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the master node to set the below parameter.
+          --use-service-account-credentials=true
+        scored: true
+
+      - id: 1.3.4
+        text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--service-account-private-key-file"
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the master node and set the --service-account-private-key-file parameter
+          to the private key file for service accounts.
+          --service-account-private-key-file=<filename>
+        scored: true
+
+      - id: 1.3.5
+        text: "Ensure that the --root-ca-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--root-ca-file"
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the master node and set the --root-ca-file parameter to the certificate bundle file`.
+          --root-ca-file=<path/to/file>
+        scored: true
+
+      - id: 1.3.6
+        text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--feature-gates"
+              compare:
+                op: nothave
+                value: "RotateKubeletServerCertificate=false"
+              set: true
+            - flag: "--feature-gates"
+              set: false
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the master node and set the --feature-gates parameter to include RotateKubeletServerCertificate=true.
+          --feature-gates=RotateKubeletServerCertificate=true
+        scored: true
+
+      - id: 1.3.7
+        text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--bind-address"
+              compare:
+                op: eq
+                value: "127.0.0.1"
+            - flag: "--bind-address"
+              set: false
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the master node and ensure the correct value for the --bind-address parameter
+        scored: true
+
+  - id: 1.4
+    text: "Scheduler"
+    checks:
+      - id: 1.4.1
+        text: "Ensure that the --profiling argument is set to false (Automated)"
+        audit: "/bin/ps -ef | grep $schedulerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--profiling"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the Scheduler pod specification file $schedulerconf file
+          on the master node and set the below parameter.
+          --profiling=false
+        scored: true
+
+      - id: 1.4.2
+        text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
+        audit: "/bin/ps -ef | grep $schedulerbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--bind-address"
+              compare:
+                op: eq
+                value: "127.0.0.1"
+            - flag: "--bind-address"
+              set: false
+        remediation: |
+          Edit the Scheduler pod specification file $schedulerconf
+          on the master node and ensure the correct value for the --bind-address parameter
+        scored: true

--- a/package/cfg/rke-cis-1.20-hardened/node.yaml
+++ b/package/cfg/rke-cis-1.20-hardened/node.yaml
@@ -1,6 +1,6 @@
 ---
 controls:
-version: "1.20"
+version: 1.20
 id: 4
 text: "Worker Node Security Configuration"
 type: "node"
@@ -10,6 +10,7 @@ groups:
     checks:
       - id: 4.1.1
         text: "Ensure that the kubelet service file permissions are set to 644 or more restrictive (Automated)"
+        type: "skip"
         audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c permissions=%a $kubeletsvc; fi'' '
         tests:
           test_items:
@@ -18,44 +19,71 @@ groups:
                 op: bitmask
                 value: "644"
         remediation: |
-          Run the below command (based on the file location on your system) on the each worker node.
-          For example,
-          chmod 644 $kubeletsvc
+          Cluster provisioned by RKE doesn’t require or maintain a configuration file for the kubelet service.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 4.1.2
         text: "Ensure that the kubelet service file ownership is set to root:root (Automated)"
+        type: "skip"
         audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc; fi'' '
         tests:
           test_items:
             - flag: root:root
         remediation: |
-          Run the below command (based on the file location on your system) on the each worker node.
-          For example,
-          chown root:root $kubeletsvc
+          Cluster provisioned by RKE doesn’t require or maintain a configuration file for the kubelet service.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 4.1.3
-        text: "If proxy kubeconfig file exists ensure permissions are set to 644 or more restrictive (Manual)"
-        audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c permissions=%a $proxykubeconfig; fi'' '
+        text: "If proxy kubeconfig file exists ensure permissions are set to 644 or more restrictive (Automated)"
+        audit: '/bin/sh -c ''if test -e /node$proxykubeconfig; then stat -c %a /node$proxykubeconfig; fi'' '
         tests:
-          bin_op: or
           test_items:
-            - flag: "permissions"
-              set: true
+            - flag: "644"
               compare:
-                op: bitmask
+                op: eq
                 value: "644"
-            - flag: "$proxykubeconfig"
-              set: false
+              set: true
+            - flag: "640"
+              compare:
+                op: eq
+                value: "640"
+              set: true
+            - flag: "600"
+              compare:
+                op: eq
+                value: "600"
+              set: true
+            - flag: "444"
+              compare:
+                op: eq
+                value: "444"
+              set: true
+            - flag: "440"
+              compare:
+                op: eq
+                value: "440"
+              set: true
+            - flag: "400"
+              compare:
+                op: eq
+                value: "400"
+              set: true
+            - flag: "000"
+              compare:
+                op: eq
+                value: "000"
+              set: true
+          bin_op: or
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
-          chmod 644 $proxykubeconfig
-        scored: false
+          chmod 644 $proykubeconfig
+        scored: true
 
       - id: 4.1.4
-        text: "If proxy kubeconfig file exists ensure ownership is set to root:root (Manual)"
+        text: "Ensure that the proxy kubeconfig file ownership is set to root:root (Automated)"
         audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c %U:%G $proxykubeconfig; fi'' '
         tests:
           bin_op: or
@@ -66,7 +94,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example, chown root:root $proxykubeconfig
-        scored: false
+        scored: true
 
       - id: 4.1.5
         text: "Ensure that the --kubeconfig kubelet.conf file permissions are set to 644 or more restrictive (Automated)"
@@ -85,10 +113,14 @@ groups:
 
       - id: 4.1.6
         text: "Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root (Automated)"
-        audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c %U:%G $kubeletkubeconfig; fi'' '
+        audit: '/bin/sh -c ''if test -e /node$kubeletkubeconfig; then stat -c %U:%G /node$kubeletkubeconfig; fi'' '
         tests:
           test_items:
             - flag: root:root
+              set: true
+              compare:
+                op: eq
+                value: root:root
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
@@ -96,11 +128,8 @@ groups:
         scored: true
 
       - id: 4.1.7
-        text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Manual)"
-        audit: |
-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
-          if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
-          if test -e $CAFILE; then stat -c permissions=%a $CAFILE; fi
+        text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Automated)"
+        audit: "check_cafile_permissions.sh"
         tests:
           test_items:
             - flag: "permissions"
@@ -110,14 +139,11 @@ groups:
         remediation: |
           Run the following command to modify the file permissions of the
           --client-ca-file chmod 644 <filename>
-        scored: false
+        scored: true
 
       - id: 4.1.8
-        text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
-        audit: |
-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
-          if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
-          if test -e $CAFILE; then stat -c %U:%G $CAFILE; fi
+        text: "Ensure that the client certificate authorities file ownership is set to root:root (Automated)"
+        audit: "check_cafile_ownership.sh"
         tests:
           test_items:
             - flag: root:root
@@ -127,10 +153,11 @@ groups:
         remediation: |
           Run the following command to modify the ownership of the --client-ca-file.
           chown root:root <filename>
-        scored: false
+        scored: true
 
       - id: 4.1.9
         text: "Ensure that the kubelet --config configuration file has permissions set to 644 or more restrictive (Automated)"
+        type: "skip"
         audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c permissions=%a $kubeletconf; fi'' '
         tests:
           test_items:
@@ -141,10 +168,14 @@ groups:
         remediation: |
           Run the following command (using the config file location identified in the Audit step)
           chmod 644 $kubeletconf
+
+          Clusters provisioned by RKE doesn’t require or maintain a configuration file for the kubelet.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 4.1.10
         text: "Ensure that the kubelet --config configuration file ownership is set to root:root (Automated)"
+        type: "skip"
         audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c %U:%G $kubeletconf; fi'' '
         tests:
           test_items:
@@ -152,6 +183,9 @@ groups:
         remediation: |
           Run the following command (using the config file location identified in the Audit step)
           chown root:root $kubeletconf
+
+          Clusters provisioned by RKE doesn’t require or maintain a configuration file for the kubelet.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
   - id: 4.2
@@ -223,7 +257,7 @@ groups:
         scored: true
 
       - id: 4.2.4
-        text: "Ensure that the --read-only-port argument is set to 0 (Manual)"
+        text: "Ensure that the --read-only-port argument is set to 0 (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/cat $kubeletconf"
         tests:
@@ -246,16 +280,17 @@ groups:
           Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
-        scored: false
+        scored: true
 
       - id: 4.2.5
-        text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
+        text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/cat $kubeletconf"
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
               path: '{.streamingConnectionIdleTimeout}'
+              set: true
               compare:
                 op: noteq
                 value: 0
@@ -273,7 +308,7 @@ groups:
           Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
-        scored: false
+        scored: true
 
       - id: 4.2.6
         text: "Ensure that the --protect-kernel-defaults argument is set to true (Automated)"
@@ -328,6 +363,7 @@ groups:
         # This is one of those properties that can only be set as a command line argument.
         # To check if the property is set as expected, we need to parse the kubelet command
         # instead reading the Kubelet Configuration file.
+        type: "skip"
         audit: "/bin/ps -fC $kubeletbin "
         tests:
           test_items:
@@ -340,10 +376,12 @@ groups:
           Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
+
+          Clusters provisioned by RKE set the --hostname-override to avoid any hostname configuration errors
         scored: false
 
       - id: 4.2.9
-        text: "Ensure that the --event-qps argument is set to 0 or a level which ensures appropriate event capture (Manual)"
+        text: "Ensure that the --event-qps argument is set to 0 or a level which ensures appropriate event capture (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/cat $kubeletconf"
         tests:
@@ -361,10 +399,10 @@ groups:
           Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
-        scored: false
+        scored: true
 
       - id: 4.2.10
-        text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
+        text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/cat $kubeletconf"
         tests:
@@ -385,10 +423,10 @@ groups:
           Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
-        scored: false
+        scored: true
 
       - id: 4.2.11
-        text: "Ensure that the --rotate-certificates argument is not set to false (Manual)"
+        text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/cat $kubeletconf"
         tests:
@@ -412,17 +450,18 @@ groups:
           Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
-        scored: false
+        scored: true
 
       - id: 4.2.12
-        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
+        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Automated)"
+        type: "skip"
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/cat $kubeletconf"
         tests:
-          bin_op: or
           test_items:
             - flag: RotateKubeletServerCertificate
               path: '{.featureGates.RotateKubeletServerCertificate}'
+              set: true
               compare:
                 op: nothave
                 value: false
@@ -436,10 +475,12 @@ groups:
           Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
-        scored: false
+
+          Clusters provisioned by RKE handles certificate rotation directly through RKE.
+        scored: true
 
       - id: 4.2.13
-        text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
+        text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/cat $kubeletconf"
         tests:
@@ -460,4 +501,4 @@ groups:
           Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
-        scored: false
+        scored: true

--- a/package/cfg/rke-cis-1.20-hardened/node.yaml
+++ b/package/cfg/rke-cis-1.20-hardened/node.yaml
@@ -1,0 +1,463 @@
+---
+controls:
+version: "1.20"
+id: 4
+text: "Worker Node Security Configuration"
+type: "node"
+groups:
+  - id: 4.1
+    text: "Worker Node Configuration Files"
+    checks:
+      - id: 4.1.1
+        text: "Ensure that the kubelet service file permissions are set to 644 or more restrictive (Automated)"
+        audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c permissions=%a $kubeletsvc; fi'' '
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chmod 644 $kubeletsvc
+        scored: true
+
+      - id: 4.1.2
+        text: "Ensure that the kubelet service file ownership is set to root:root (Automated)"
+        audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc; fi'' '
+        tests:
+          test_items:
+            - flag: root:root
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chown root:root $kubeletsvc
+        scored: true
+
+      - id: 4.1.3
+        text: "If proxy kubeconfig file exists ensure permissions are set to 644 or more restrictive (Manual)"
+        audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c permissions=%a $proxykubeconfig; fi'' '
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "permissions"
+              set: true
+              compare:
+                op: bitmask
+                value: "644"
+            - flag: "$proxykubeconfig"
+              set: false
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chmod 644 $proxykubeconfig
+        scored: false
+
+      - id: 4.1.4
+        text: "If proxy kubeconfig file exists ensure ownership is set to root:root (Manual)"
+        audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c %U:%G $proxykubeconfig; fi'' '
+        tests:
+          bin_op: or
+          test_items:
+            - flag: root:root
+            - flag: "$proxykubeconfig"
+              set: false
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example, chown root:root $proxykubeconfig
+        scored: false
+
+      - id: 4.1.5
+        text: "Ensure that the --kubeconfig kubelet.conf file permissions are set to 644 or more restrictive (Automated)"
+        audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c permissions=%a $kubeletkubeconfig; fi'' '
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chmod 644 $kubeletkubeconfig
+        scored: true
+
+      - id: 4.1.6
+        text: "Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root (Automated)"
+        audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c %U:%G $kubeletkubeconfig; fi'' '
+        tests:
+          test_items:
+            - flag: root:root
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chown root:root $kubeletkubeconfig
+        scored: true
+
+      - id: 4.1.7
+        text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Manual)"
+        audit: |
+          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
+          if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
+          if test -e $CAFILE; then stat -c permissions=%a $CAFILE; fi
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the following command to modify the file permissions of the
+          --client-ca-file chmod 644 <filename>
+        scored: false
+
+      - id: 4.1.8
+        text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
+        audit: |
+          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
+          if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
+          if test -e $CAFILE; then stat -c %U:%G $CAFILE; fi
+        tests:
+          test_items:
+            - flag: root:root
+              compare:
+                op: eq
+                value: root:root
+        remediation: |
+          Run the following command to modify the ownership of the --client-ca-file.
+          chown root:root <filename>
+        scored: false
+
+      - id: 4.1.9
+        text: "Ensure that the kubelet --config configuration file has permissions set to 644 or more restrictive (Automated)"
+        audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c permissions=%a $kubeletconf; fi'' '
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the following command (using the config file location identified in the Audit step)
+          chmod 644 $kubeletconf
+        scored: true
+
+      - id: 4.1.10
+        text: "Ensure that the kubelet --config configuration file ownership is set to root:root (Automated)"
+        audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c %U:%G $kubeletconf; fi'' '
+        tests:
+          test_items:
+            - flag: root:root
+        remediation: |
+          Run the following command (using the config file location identified in the Audit step)
+          chown root:root $kubeletconf
+        scored: true
+
+  - id: 4.2
+    text: "Kubelet"
+    checks:
+      - id: 4.2.1
+        text: "Ensure that the anonymous-auth argument is set to false (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: "--anonymous-auth"
+              path: '{.authentication.anonymous.enabled}'
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          If using a Kubelet config file, edit the file to set authentication: anonymous: enabled to
+          false.
+          If using executable arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          --anonymous-auth=false
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.2
+        text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --authorization-mode
+              path: '{.authorization.mode}'
+              compare:
+                op: nothave
+                value: AlwaysAllow
+        remediation: |
+          If using a Kubelet config file, edit the file to set authorization: mode to Webhook. If
+          using executable arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_AUTHZ_ARGS variable.
+          --authorization-mode=Webhook
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.3
+        text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --client-ca-file
+              path: '{.authentication.x509.clientCAFile}'
+        remediation: |
+          If using a Kubelet config file, edit the file to set authentication: x509: clientCAFile to
+          the location of the client CA file.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_AUTHZ_ARGS variable.
+          --client-ca-file=<path/to/client-ca-file>
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.4
+        text: "Ensure that the --read-only-port argument is set to 0 (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--read-only-port"
+              path: '{.readOnlyPort}'
+              compare:
+                op: eq
+                value: 0
+            - flag: "--read-only-port"
+              path: '{.readOnlyPort}'
+              set: false
+        remediation: |
+          If using a Kubelet config file, edit the file to set readOnlyPort to 0.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          --read-only-port=0
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.5
+        text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --streaming-connection-idle-timeout
+              path: '{.streamingConnectionIdleTimeout}'
+              compare:
+                op: noteq
+                value: 0
+            - flag: --streaming-connection-idle-timeout
+              path: '{.streamingConnectionIdleTimeout}'
+              set: false
+          bin_op: or
+        remediation: |
+          If using a Kubelet config file, edit the file to set streamingConnectionIdleTimeout to a
+          value other than 0.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          --streaming-connection-idle-timeout=5m
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.6
+        text: "Ensure that the --protect-kernel-defaults argument is set to true (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --protect-kernel-defaults
+              path: '{.protectKernelDefaults}'
+              compare:
+                op: eq
+                value: true
+        remediation: |
+          If using a Kubelet config file, edit the file to set protectKernelDefaults: true.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          --protect-kernel-defaults=true
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.7
+        text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --make-iptables-util-chains
+              path: '{.makeIPTablesUtilChains}'
+              compare:
+                op: eq
+                value: true
+            - flag: --make-iptables-util-chains
+              path: '{.makeIPTablesUtilChains}'
+              set: false
+          bin_op: or
+        remediation: |
+          If using a Kubelet config file, edit the file to set makeIPTablesUtilChains: true.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          remove the --make-iptables-util-chains argument from the
+          KUBELET_SYSTEM_PODS_ARGS variable.
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.8
+        text: "Ensure that the --hostname-override argument is not set (Manual)"
+        # This is one of those properties that can only be set as a command line argument.
+        # To check if the property is set as expected, we need to parse the kubelet command
+        # instead reading the Kubelet Configuration file.
+        audit: "/bin/ps -fC $kubeletbin "
+        tests:
+          test_items:
+            - flag: --hostname-override
+              set: false
+        remediation: |
+          Edit the kubelet service file $kubeletsvc
+          on each worker node and remove the --hostname-override argument from the
+          KUBELET_SYSTEM_PODS_ARGS variable.
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.9
+        text: "Ensure that the --event-qps argument is set to 0 or a level which ensures appropriate event capture (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --event-qps
+              path: '{.eventRecordQPS}'
+              compare:
+                op: eq
+                value: 0
+        remediation: |
+          If using a Kubelet config file, edit the file to set eventRecordQPS: to an appropriate level.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.10
+        text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --tls-cert-file
+              path: '{.tlsCertFile}'
+            - flag: --tls-private-key-file
+              path: '{.tlsPrivateKeyFile}'
+        remediation: |
+          If using a Kubelet config file, edit the file to set tlsCertFile to the location
+          of the certificate file to use to identify this Kubelet, and tlsPrivateKeyFile
+          to the location of the corresponding private key file.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameters in KUBELET_CERTIFICATE_ARGS variable.
+          --tls-cert-file=<path/to/tls-certificate-file>
+          --tls-private-key-file=<path/to/tls-key-file>
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.11
+        text: "Ensure that the --rotate-certificates argument is not set to false (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --rotate-certificates
+              path: '{.rotateCertificates}'
+              compare:
+                op: eq
+                value: true
+            - flag: --rotate-certificates
+              path: '{.rotateCertificates}'
+              set: false
+          bin_op: or
+        remediation: |
+          If using a Kubelet config file, edit the file to add the line rotateCertificates: true or
+          remove it altogether to use the default value.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          remove --rotate-certificates=false argument from the KUBELET_CERTIFICATE_ARGS
+          variable.
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.12
+        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: RotateKubeletServerCertificate
+              path: '{.featureGates.RotateKubeletServerCertificate}'
+              compare:
+                op: nothave
+                value: false
+            - flag: RotateKubeletServerCertificate
+              path: '{.featureGates.RotateKubeletServerCertificate}'
+              set: false
+        remediation: |
+          Edit the kubelet service file $kubeletsvc
+          on each worker node and set the below parameter in KUBELET_CERTIFICATE_ARGS variable.
+          --feature-gates=RotateKubeletServerCertificate=true
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.13
+        text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --tls-cipher-suites
+              path: '{range .tlsCipherSuites[:]}{}{'',''}{end}'
+              compare:
+                op: valid_elements
+                value: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+        remediation: |
+          If using a Kubelet config file, edit the file to set TLSCipherSuites: to
+          TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+          or to a subset of these values.
+          If using executable arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the --tls-cipher-suites parameter as follows, or to a subset of these values.
+          --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false

--- a/package/cfg/rke-cis-1.20-hardened/policies.yaml
+++ b/package/cfg/rke-cis-1.20-hardened/policies.yaml
@@ -1,0 +1,238 @@
+---
+controls:
+version: "1.20"
+id: 5
+text: "Kubernetes Policies"
+type: "policies"
+groups:
+  - id: 5.1
+    text: "RBAC and Service Accounts"
+    checks:
+      - id: 5.1.1
+        text: "Ensure that the cluster-admin role is only used where required (Manual)"
+        type: "manual"
+        remediation: |
+          Identify all clusterrolebindings to the cluster-admin role. Check if they are used and
+          if they need this role or if they could use a role with fewer privileges.
+          Where possible, first bind users to a lower privileged role and then remove the
+          clusterrolebinding to the cluster-admin role :
+          kubectl delete clusterrolebinding [name]
+        scored: false
+
+      - id: 5.1.2
+        text: "Minimize access to secrets (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove get, list and watch access to secret objects in the cluster.
+        scored: false
+
+      - id: 5.1.3
+        text: "Minimize wildcard use in Roles and ClusterRoles (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible replace any use of wildcards in clusterroles and roles with specific
+          objects or actions.
+        scored: false
+
+      - id: 5.1.4
+        text: "Minimize access to create pods (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove create access to pod objects in the cluster.
+        scored: false
+
+      - id: 5.1.5
+        text: "Ensure that default service accounts are not actively used. (Manual)"
+        type: "manual"
+        remediation: |
+          Create explicit service accounts wherever a Kubernetes workload requires specific access
+          to the Kubernetes API server.
+          Modify the configuration of each default service account to include this value
+          automountServiceAccountToken: false
+        scored: false
+
+      - id: 5.1.6
+        text: "Ensure that Service Account Tokens are only mounted where necessary (Manual)"
+        type: "manual"
+        remediation: |
+          Modify the definition of pods and service accounts which do not need to mount service
+          account tokens to disable it.
+        scored: false
+
+      - id: 5.1.7
+        text: "Avoid use of system:masters group (Manual)"
+        type: "manual"
+        remediation: |
+          Remove the system:masters group from all users in the cluster.
+        scored: false
+
+      - id: 5.1.8
+        text: "Limit use of the Bind, Impersonate and Escalate permissions in the Kubernetes cluster (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove the impersonate, bind and escalate rights from subjects.
+        scored: false
+
+  - id: 5.2
+    text: "Pod Security Policies"
+    checks:
+      - id: 5.2.1
+        text: "Minimize the admission of privileged containers (Automated)"
+        type: "manual"
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that
+          the .spec.privileged field is omitted or set to false.
+        scored: false
+
+      - id: 5.2.2
+        text: "Minimize the admission of containers wishing to share the host process ID namespace (Automated)"
+        type: "manual"
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that the
+          .spec.hostPID field is omitted or set to false.
+        scored: false
+
+      - id: 5.2.3
+        text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
+        type: "manual"
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that the
+          .spec.hostIPC field is omitted or set to false.
+        scored: false
+
+      - id: 5.2.4
+        text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
+        type: "manual"
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that the
+          .spec.hostNetwork field is omitted or set to false.
+        scored: false
+
+      - id: 5.2.5
+        text: "Minimize the admission of containers with allowPrivilegeEscalation (Automated)"
+        type: "manual"
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that the
+          .spec.allowPrivilegeEscalation field is omitted or set to false.
+        scored: false
+
+      - id: 5.2.6
+        text: "Minimize the admission of root containers (Automated)"
+        type: "manual"
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that the
+          .spec.runAsUser.rule is set to either MustRunAsNonRoot or MustRunAs with the range of
+          UIDs not including 0.
+        scored: false
+
+      - id: 5.2.7
+        text: "Minimize the admission of containers with the NET_RAW capability (Automated)"
+        type: "manual"
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that the
+          .spec.requiredDropCapabilities is set to include either NET_RAW or ALL.
+        scored: false
+
+      - id: 5.2.8
+        text: "Minimize the admission of containers with added capabilities (Automated)"
+        type: "manual"
+        remediation: |
+          Ensure that allowedCapabilities is not present in PSPs for the cluster unless
+          it is set to an empty array.
+        scored: false
+
+      - id: 5.2.9
+        text: "Minimize the admission of containers with capabilities assigned (Manual)"
+        type: "manual"
+        remediation: |
+          Review the use of capabilites in applications running on your cluster. Where a namespace
+          contains applicaions which do not require any Linux capabities to operate consider adding
+          a PSP which forbids the admission of containers which do not drop all capabilities.
+        scored: false
+
+  - id: 5.3
+    text: "Network Policies and CNI"
+    checks:
+      - id: 5.3.1
+        text: "Ensure that the CNI in use supports Network Policies (Manual)"
+        type: "manual"
+        remediation: |
+          If the CNI plugin in use does not support network policies, consideration should be given to
+          making use of a different plugin, or finding an alternate mechanism for restricting traffic
+          in the Kubernetes cluster.
+        scored: false
+
+      - id: 5.3.2
+        text: "Ensure that all Namespaces have Network Policies defined (Manual)"
+        type: "manual"
+        remediation: |
+          Follow the documentation and create NetworkPolicy objects as you need them.
+        scored: false
+
+  - id: 5.4
+    text: "Secrets Management"
+    checks:
+      - id: 5.4.1
+        text: "Prefer using secrets as files over secrets as environment variables (Manual)"
+        type: "manual"
+        remediation: |
+          if possible, rewrite application code to read secrets from mounted secret files, rather than
+          from environment variables.
+        scored: false
+
+      - id: 5.4.2
+        text: "Consider external secret storage (Manual)"
+        type: "manual"
+        remediation: |
+          Refer to the secrets management options offered by your cloud provider or a third-party
+          secrets management solution.
+        scored: false
+
+  - id: 5.5
+    text: "Extensible Admission Control"
+    checks:
+      - id: 5.5.1
+        text: "Configure Image Provenance using ImagePolicyWebhook admission controller (Manual)"
+        type: "manual"
+        remediation: |
+          Follow the Kubernetes documentation and setup image provenance.
+        scored: false
+
+  - id: 5.7
+    text: "General Policies"
+    checks:
+      - id: 5.7.1
+        text: "Create administrative boundaries between resources using namespaces (Manual)"
+        type: "manual"
+        remediation: |
+          Follow the documentation and create namespaces for objects in your deployment as you need
+          them.
+        scored: false
+
+      - id: 5.7.2
+        text: "Ensure that the seccomp profile is set to docker/default in your pod definitions (Manual)"
+        type: "manual"
+        remediation: |
+          Use security context to enable the docker/default seccomp profile in your pod definitions.
+          An example is as below:
+            securityContext:
+              seccompProfile:
+                type: RuntimeDefault
+        scored: false
+
+      - id: 5.7.3
+        text: "Apply Security Context to Your Pods and Containers (Manual)"
+        type: "manual"
+        remediation: |
+          Follow the Kubernetes documentation and apply security contexts to your pods. For a
+          suggested list of security contexts, you may refer to the CIS Security Benchmark for Docker
+          Containers.
+        scored: false
+
+      - id: 5.7.4
+        text: "The default namespace should not be used (Manual)"
+        type: "manual"
+        remediation: |
+          Ensure that namespaces are created to allow for appropriate segregation of Kubernetes
+          resources and that all new resources are created in a specific namespace.
+        scored: false

--- a/package/cfg/rke-cis-1.20-hardened/policies.yaml
+++ b/package/cfg/rke-cis-1.20-hardened/policies.yaml
@@ -1,6 +1,6 @@
 ---
 controls:
-version: "1.20"
+version: 1.20
 id: 5
 text: "Kubernetes Policies"
 type: "policies"
@@ -42,14 +42,21 @@ groups:
         scored: false
 
       - id: 5.1.5
-        text: "Ensure that default service accounts are not actively used. (Manual)"
-        type: "manual"
+        text: "Ensure that default service accounts are not actively used. (Automated)"
+        audit: check_for_default_sa.sh
+        tests:
+          test_items:
+            - flag: "true"
+              compare:
+                op: eq
+                value: "true"
+              set: true
         remediation: |
           Create explicit service accounts wherever a Kubernetes workload requires specific access
           to the Kubernetes API server.
           Modify the configuration of each default service account to include this value
           automountServiceAccountToken: false
-        scored: false
+        scored: true
 
       - id: 5.1.6
         text: "Ensure that Service Account Tokens are only mounted where necessary (Manual)"
@@ -77,7 +84,7 @@ groups:
     text: "Pod Security Policies"
     checks:
       - id: 5.2.1
-        text: "Minimize the admission of privileged containers (Automated)"
+        text: "Minimize the admission of privileged containers (Manual)"
         type: "manual"
         remediation: |
           Create a PSP as described in the Kubernetes documentation, ensuring that
@@ -86,38 +93,66 @@ groups:
 
       - id: 5.2.2
         text: "Minimize the admission of containers wishing to share the host process ID namespace (Automated)"
-        type: "manual"
+        audit: "kubectl get psp -o json | jq .items[] | jq -r 'select((.spec.hostPID == null) or (.spec.hostPID == false))' | jq .metadata.name | wc -l | xargs -I {} echo '--count={}'"
+        tests:
+          test_items:
+            - flag: "count"
+              compare:
+                op: gt
+                value: "0"
+              set: true
         remediation: |
           Create a PSP as described in the Kubernetes documentation, ensuring that the
           .spec.hostPID field is omitted or set to false.
-        scored: false
+        scored: true
 
       - id: 5.2.3
         text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
-        type: "manual"
+        audit: "kubectl get psp -o json | jq .items[] | jq -r 'select((.spec.hostIPC == null) or (.spec.hostIPC == false))' | jq .metadata.name | wc -l | xargs -I {} echo '--count={}'"
+        tests:
+          test_items:
+            - flag: "count"
+              compare:
+                op: gt
+                value: "0"
+              set: true
         remediation: |
           Create a PSP as described in the Kubernetes documentation, ensuring that the
           .spec.hostIPC field is omitted or set to false.
-        scored: false
+        scored: true
 
       - id: 5.2.4
         text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
-        type: "manual"
+        audit: "kubectl get psp -o json | jq .items[] | jq -r 'select((.spec.hostNetwork == null) or (.spec.hostNetwork == false))' | jq .metadata.name | wc -l | xargs -I {} echo '--count={}'"
+        tests:
+          test_items:
+            - flag: "count"
+              compare:
+                op: gt
+                value: "0"
+              set: true
         remediation: |
           Create a PSP as described in the Kubernetes documentation, ensuring that the
           .spec.hostNetwork field is omitted or set to false.
-        scored: false
+        scored: true
 
       - id: 5.2.5
         text: "Minimize the admission of containers with allowPrivilegeEscalation (Automated)"
-        type: "manual"
+        audit: "kubectl get psp -o json | jq .items[] | jq -r 'select((.spec.allowPrivilegeEscalation == null) or (.spec.allowPrivilegeEscalation == false))' | jq .metadata.name | wc -l | xargs -I {} echo '--count={}'"
+        tests:
+          test_items:
+            - flag: "count"
+              compare:
+                op: gt
+                value: "0"
+              set: true
         remediation: |
           Create a PSP as described in the Kubernetes documentation, ensuring that the
           .spec.allowPrivilegeEscalation field is omitted or set to false.
-        scored: false
+        scored: true
 
       - id: 5.2.6
-        text: "Minimize the admission of root containers (Automated)"
+        text: "Minimize the admission of root containers (Manual)"
         type: "manual"
         remediation: |
           Create a PSP as described in the Kubernetes documentation, ensuring that the
@@ -126,7 +161,7 @@ groups:
         scored: false
 
       - id: 5.2.7
-        text: "Minimize the admission of containers with the NET_RAW capability (Automated)"
+        text: "Minimize the admission of containers with the NET_RAW capability (Manual)"
         type: "manual"
         remediation: |
           Create a PSP as described in the Kubernetes documentation, ensuring that the
@@ -134,7 +169,7 @@ groups:
         scored: false
 
       - id: 5.2.8
-        text: "Minimize the admission of containers with added capabilities (Automated)"
+        text: "Minimize the admission of containers with added capabilities (Manual)"
         type: "manual"
         remediation: |
           Ensure that allowedCapabilities is not present in PSPs for the cluster unless
@@ -163,11 +198,18 @@ groups:
         scored: false
 
       - id: 5.3.2
-        text: "Ensure that all Namespaces have Network Policies defined (Manual)"
-        type: "manual"
+        text: "Ensure that all Namespaces have Network Policies defined (Automated)"
+        audit: check_for_network_policies.sh
+        tests:
+          test_items:
+            - flag: "true"
+              compare:
+                op: eq
+                value: "true"
+              set: true
         remediation: |
           Follow the documentation and create NetworkPolicy objects as you need them.
-        scored: false
+        scored: true
 
   - id: 5.4
     text: "Secrets Management"
@@ -230,9 +272,16 @@ groups:
         scored: false
 
       - id: 5.7.4
-        text: "The default namespace should not be used (Manual)"
-        type: "manual"
+        text: "The default namespace should not be used (Automated)"
+        audit: check_for_default_ns.sh
+        tests:
+          test_items:
+            - flag: "true"
+              compare:
+                op: eq
+                value: "true"
+              set: true
         remediation: |
           Ensure that namespaces are created to allow for appropriate segregation of Kubernetes
           resources and that all new resources are created in a specific namespace.
-        scored: false
+        scored: true

--- a/package/cfg/rke-cis-1.20-permissive/config.yaml
+++ b/package/cfg/rke-cis-1.20-permissive/config.yaml
@@ -1,0 +1,2 @@
+---
+## Version-specific settings that override the values in cfg/config.yaml

--- a/package/cfg/rke-cis-1.20-permissive/config.yaml
+++ b/package/cfg/rke-cis-1.20-permissive/config.yaml
@@ -1,2 +1,10 @@
 ---
 ## Version-specific settings that override the values in cfg/config.yaml
+
+node:
+  kubelet:
+    defaultkubeconfig: "/etc/kubernetes/ssl/kubecfg-kube-node.yaml"
+    defaultcafile: "/etc/kubernetes/ssl/kube-ca.pem"
+
+  proxy:
+    defaultkubeconfig: "/etc/kubernetes/ssl/kubecfg-kube-proxy.yaml"

--- a/package/cfg/rke-cis-1.20-permissive/controlplane.yaml
+++ b/package/cfg/rke-cis-1.20-permissive/controlplane.yaml
@@ -1,0 +1,39 @@
+---
+controls:
+version: "1.20"
+id: 3
+text: "Control Plane Configuration"
+type: "controlplane"
+groups:
+  - id: 3.1
+    text: "Authentication and Authorization"
+    checks:
+      - id: 3.1.1
+        text: "Client certificate authentication should not be used for users (Manual)"
+        type: "manual"
+        remediation: |
+          Alternative mechanisms provided by Kubernetes such as the use of OIDC should be
+          implemented in place of client certificates.
+        scored: false
+
+  - id: 3.2
+    text: "Logging"
+    checks:
+      - id: 3.2.1
+        text: "Ensure that a minimal audit policy is created (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-policy-file"
+              set: true
+        remediation: |
+          Create an audit policy file for your cluster.
+        scored: false
+
+      - id: 3.2.2
+        text: "Ensure that the audit policy covers key security concerns (Manual)"
+        type: "manual"
+        remediation: |
+          Consider modification of the audit policy in use on the cluster to include these items, at a
+          minimum.
+        scored: false

--- a/package/cfg/rke-cis-1.20-permissive/controlplane.yaml
+++ b/package/cfg/rke-cis-1.20-permissive/controlplane.yaml
@@ -1,6 +1,6 @@
 ---
 controls:
-version: "1.20"
+version: 1.20
 id: 3
 text: "Control Plane Configuration"
 type: "controlplane"
@@ -20,7 +20,7 @@ groups:
     text: "Logging"
     checks:
       - id: 3.2.1
-        text: "Ensure that a minimal audit policy is created (Manual)"
+        text: "Ensure that a minimal audit policy is created (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -28,7 +28,7 @@ groups:
               set: true
         remediation: |
           Create an audit policy file for your cluster.
-        scored: false
+        scored: true
 
       - id: 3.2.2
         text: "Ensure that the audit policy covers key security concerns (Manual)"

--- a/package/cfg/rke-cis-1.20-permissive/etcd.yaml
+++ b/package/cfg/rke-cis-1.20-permissive/etcd.yaml
@@ -1,0 +1,135 @@
+---
+controls:
+version: "1.20"
+id: 2
+text: "Etcd Node Configuration"
+type: "etcd"
+groups:
+  - id: 2
+    text: "Etcd Node Configuration Files"
+    checks:
+      - id: 2.1
+        text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--cert-file"
+              env: "ETCD_CERT_FILE"
+            - flag: "--key-file"
+              env: "ETCD_KEY_FILE"
+        remediation: |
+          Follow the etcd service documentation and configure TLS encryption.
+          Then, edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml
+          on the master node and set the below parameters.
+          --cert-file=</path/to/ca-file>
+          --key-file=</path/to/key-file>
+        scored: true
+
+      - id: 2.2
+        text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          test_items:
+            - flag: "--client-cert-auth"
+              env: "ETCD_CLIENT_CERT_AUTH"
+              compare:
+                op: eq
+                value: true
+        remediation: |
+          Edit the etcd pod specification file $etcdconf on the master
+          node and set the below parameter.
+          --client-cert-auth="true"
+        scored: true
+
+      - id: 2.3
+        text: "Ensure that the --auto-tls argument is not set to true (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--auto-tls"
+              env: "ETCD_AUTO_TLS"
+              set: false
+            - flag: "--auto-tls"
+              env: "ETCD_AUTO_TLS"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the etcd pod specification file $etcdconf on the master
+          node and either remove the --auto-tls parameter or set it to false.
+            --auto-tls=false
+        scored: true
+
+      - id: 2.4
+        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are
+        set as appropriate (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--peer-cert-file"
+              env: "ETCD_PEER_CERT_FILE"
+            - flag: "--peer-key-file"
+              env: "ETCD_PEER_KEY_FILE"
+        remediation: |
+          Follow the etcd service documentation and configure peer TLS encryption as appropriate
+          for your etcd cluster.
+          Then, edit the etcd pod specification file $etcdconf on the
+          master node and set the below parameters.
+          --peer-client-file=</path/to/peer-cert-file>
+          --peer-key-file=</path/to/peer-key-file>
+        scored: true
+
+      - id: 2.5
+        text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          test_items:
+            - flag: "--peer-client-cert-auth"
+              env: "ETCD_PEER_CLIENT_CERT_AUTH"
+              compare:
+                op: eq
+                value: true
+        remediation: |
+          Edit the etcd pod specification file $etcdconf on the master
+          node and set the below parameter.
+          --peer-client-cert-auth=true
+        scored: true
+
+      - id: 2.6
+        text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--peer-auto-tls"
+              env: "ETCD_PEER_AUTO_TLS"
+              set: false
+            - flag: "--peer-auto-tls"
+              env: "ETCD_PEER_AUTO_TLS"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the etcd pod specification file $etcdconf on the master
+          node and either remove the --peer-auto-tls parameter or set it to false.
+          --peer-auto-tls=false
+        scored: true
+
+      - id: 2.7
+        text: "Ensure that a unique Certificate Authority is used for etcd (Manual)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          test_items:
+            - flag: "--trusted-ca-file"
+              env: "ETCD_TRUSTED_CA_FILE"
+        remediation: |
+          [Manual test]
+          Follow the etcd documentation and create a dedicated certificate authority setup for the
+          etcd service.
+          Then, edit the etcd pod specification file $etcdconf on the
+          master node and set the below parameter.
+          --trusted-ca-file=</path/to/ca-file>
+        scored: false

--- a/package/cfg/rke-cis-1.20-permissive/etcd.yaml
+++ b/package/cfg/rke-cis-1.20-permissive/etcd.yaml
@@ -1,10 +1,92 @@
 ---
 controls:
-version: "1.20"
+version: 1.20
 id: 2
 text: "Etcd Node Configuration"
 type: "etcd"
 groups:
+  - id: 1.1
+    text: "Master Node Configuration Files"
+    checks:
+    - id: 1.1.11
+      text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
+      audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c permissions=%a
+      tests:
+        test_items:
+          - flag: "permissions"
+            compare:
+              op: bitmask
+              value: "700"
+      remediation: |
+        On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+        from the below command:
+        ps -ef | grep etcd
+        Run the below command (based on the etcd data directory found above). For example,
+        chmod 700 /var/lib/etcd
+      scored: true
+
+    - id: 1.1.12
+      text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
+      audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G
+      tests:
+        test_items:
+          - flag: "etcd:etcd"
+      remediation: |
+        On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+        from the below command:
+        ps -ef | grep etcd
+        Run the below command (based on the etcd data directory found above).
+        For example, chown etcd:etcd /var/lib/etcd
+      scored: true
+    - id: 1.1.19
+      text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
+      audit: "check_files_owner_in_dir.sh /node/etc/kubernetes/ssl"
+      use_multiple_values: true
+      tests:
+        test_items:
+          - flag: "true"
+            compare:
+              op: eq
+              value: "true"
+            set: true
+      remediation: |
+        Run the below command (based on the file location on your system) on the master node.
+        For example,
+        chown -R root:root /etc/kubernetes/pki/
+      scored: true
+    - id: 1.1.20
+      text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Automated)"
+      audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/!(*key).pem"
+      use_multiple_values: true
+      tests:
+        test_items:
+          - flag: "true"
+            compare:
+              op: eq
+              value: "true"
+            set: true
+      remediation: |
+        Run the below command (based on the file location on your system) on the master node.
+        For example,
+        chmod -R 644 /etc/kubernetes/pki/*.crt
+      scored: true
+    - id: 1.1.21
+      text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Automated)"
+      audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/*key.pem 600"
+      use_multiple_values: true
+      tests:
+        test_items:
+          - flag: "true"
+            compare:
+              op: eq
+              value: "true"
+            set: true
+      remediation: |
+        Run the below command (based on the file location on your system) on the master node.
+        For example,
+        chmod -R 600 /etc/kubernetes/ssl/*key.pem
+      scored: true
+
   - id: 2
     text: "Etcd Node Configuration Files"
     checks:
@@ -16,8 +98,10 @@ groups:
           test_items:
             - flag: "--cert-file"
               env: "ETCD_CERT_FILE"
+              set: true
             - flag: "--key-file"
               env: "ETCD_KEY_FILE"
+              set: true
         remediation: |
           Follow the etcd service documentation and configure TLS encryption.
           Then, edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml
@@ -30,12 +114,16 @@ groups:
         text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
         audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
         tests:
+          bin_op: or
           test_items:
+            - flag: "--client-cert-auth"              
+              set: true
             - flag: "--client-cert-auth"
               env: "ETCD_CLIENT_CERT_AUTH"
               compare:
                 op: eq
                 value: true
+              set: true
         remediation: |
           Edit the etcd pod specification file $etcdconf on the master
           node and set the below parameter.
@@ -71,8 +159,10 @@ groups:
           test_items:
             - flag: "--peer-cert-file"
               env: "ETCD_PEER_CERT_FILE"
+              set: true
             - flag: "--peer-key-file"
               env: "ETCD_PEER_KEY_FILE"
+              set: true
         remediation: |
           Follow the etcd service documentation and configure peer TLS encryption as appropriate
           for your etcd cluster.
@@ -86,12 +176,16 @@ groups:
         text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
         audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
         tests:
+          bin_op: or
           test_items:
+            - flag: "--peer-client-cert-auth"
+              set: true
             - flag: "--peer-client-cert-auth"
               env: "ETCD_PEER_CLIENT_CERT_AUTH"
               compare:
                 op: eq
                 value: true
+              set: true  
         remediation: |
           Edit the etcd pod specification file $etcdconf on the master
           node and set the below parameter.
@@ -112,6 +206,7 @@ groups:
               compare:
                 op: eq
                 value: false
+              set: false  
         remediation: |
           Edit the etcd pod specification file $etcdconf on the master
           node and either remove the --peer-auto-tls parameter or set it to false.
@@ -119,12 +214,13 @@ groups:
         scored: true
 
       - id: 2.7
-        text: "Ensure that a unique Certificate Authority is used for etcd (Manual)"
+        text: "Ensure that a unique Certificate Authority is used for etcd (Automated)"
         audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
         tests:
           test_items:
             - flag: "--trusted-ca-file"
               env: "ETCD_TRUSTED_CA_FILE"
+              set: true
         remediation: |
           [Manual test]
           Follow the etcd documentation and create a dedicated certificate authority setup for the
@@ -132,4 +228,4 @@ groups:
           Then, edit the etcd pod specification file $etcdconf on the
           master node and set the below parameter.
           --trusted-ca-file=</path/to/ca-file>
-        scored: false
+        scored: true

--- a/package/cfg/rke-cis-1.20-permissive/master.yaml
+++ b/package/cfg/rke-cis-1.20-permissive/master.yaml
@@ -1,6 +1,6 @@
 ---
 controls:
-version: "1.20"
+version: 1.20
 id: 1
 text: "Master Node Security Configuration"
 type: "master"
@@ -10,6 +10,7 @@ groups:
     checks:
       - id: 1.1.1
         text: "Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $apiserverconf; then stat -c permissions=%a $apiserverconf; fi'"
         tests:
           test_items:
@@ -18,25 +19,25 @@ groups:
                 op: bitmask
                 value: "644"
         remediation: |
-          Run the below command (based on the file location on your system) on the
-          master node.
-          For example, chmod 644 $apiserverconf
+          Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.2
         text: "Ensure that the API server pod specification file ownership is set to root:root (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $apiserverconf; then stat -c %U:%G $apiserverconf; fi'"
         tests:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chown root:root $apiserverconf
+          Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.3
         text: "Ensure that the controller manager pod specification file permissions are set to 644 or more restrictive (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $controllermanagerconf; then stat -c permissions=%a $controllermanagerconf; fi'"
         tests:
           test_items:
@@ -45,25 +46,25 @@ groups:
                 op: bitmask
                 value: "644"
         remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chmod 644 $controllermanagerconf
+          Cluster provisioned by RKE doesn't require or maintain a configuration file for controller-manager.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.4
         text: "Ensure that the controller manager pod specification file ownership is set to root:root (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $controllermanagerconf; then stat -c %U:%G $controllermanagerconf; fi'"
         tests:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chown root:root $controllermanagerconf
+          Cluster provisioned by RKE doesn't require or maintain a configuration file for controller-manager.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.5
         text: "Ensure that the scheduler pod specification file permissions are set to 644 or more restrictive (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c permissions=%a $schedulerconf; fi'"
         tests:
           test_items:
@@ -72,25 +73,25 @@ groups:
                 op: bitmask
                 value: "644"
         remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chmod 644 $schedulerconf
+          Cluster provisioned by RKE doesn't require or maintain a configuration file for controller-manager.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.6
         text: "Ensure that the scheduler pod specification file ownership is set to root:root (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c %U:%G $schedulerconf; fi'"
         tests:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chown root:root $schedulerconf
+          Cluster provisioned by RKE doesn't require or maintain a configuration file for scheduler.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.7
         text: "Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
         use_multiple_values: true
         tests:
@@ -100,22 +101,21 @@ groups:
                 op: bitmask
                 value: "644"
         remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chmod 644 $etcdconf
+          Cluster provisioned by RKE doesn't require or maintain a configuration file for scheduler.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.8
         text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c %U:%G; fi'"
         use_multiple_values: true
         tests:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chown root:root $etcdconf
+          Cluster provisioned by RKE doesn't require or maintain a configuration file for scheduler.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.9
@@ -151,39 +151,11 @@ groups:
           chown root:root <path/to/cni/files>
         scored: false
 
-      - id: 1.1.11
-        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c permissions=%a
-        tests:
-          test_items:
-            - flag: "permissions"
-              compare:
-                op: bitmask
-                value: "700"
-        remediation: |
-          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-          from the below command:
-          ps -ef | grep etcd
-          Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
-        scored: true
-
-      - id: 1.1.12
-        text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
-        audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G
-        tests:
-          test_items:
-            - flag: "etcd:etcd"
-        remediation: |
-          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-          from the below command:
-          ps -ef | grep etcd
-          Run the below command (based on the etcd data directory found above).
-          For example, chown etcd:etcd /var/lib/etcd
-        scored: true
+      
 
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 644 or more restrictive (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c permissions=%a /etc/kubernetes/admin.conf; fi'"
         tests:
           test_items:
@@ -192,25 +164,23 @@ groups:
                 op: bitmask
                 value: "644"
         remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chmod 644 /etc/kubernetes/admin.conf
+          Cluster provisioned by RKE does not store the kubernetes default kubeconfig credentials file on the nodes.
         scored: true
 
       - id: 1.1.14
         text: "Ensure that the admin.conf file ownership is set to root:root (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c %U:%G /etc/kubernetes/admin.conf; fi'"
         tests:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chown root:root /etc/kubernetes/admin.conf
+          Cluster provisioned by RKE does not store the kubernetes default kubeconfig credentials file on the nodes.
         scored: true
 
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c permissions=%a $schedulerkubeconfig; fi'"
         tests:
           test_items:
@@ -219,25 +189,25 @@ groups:
                 op: bitmask
                 value: "644"
         remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chmod 644 $schedulerkubeconfig
+          Cluster provisioned by RKE doesn't require or maintain a configuration file for scheduler.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c %U:%G $schedulerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chown root:root $schedulerkubeconfig
+          Cluster provisioned by RKE doesn't require or maintain a configuration file for scheduler.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c permissions=%a $controllermanagerkubeconfig; fi'"
         tests:
           test_items:
@@ -246,73 +216,29 @@ groups:
                 op: bitmask
                 value: "644"
         remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chmod 644 $controllermanagerkubeconfig
+          Cluster provisioned by RKE doesn't require or maintain a configuration file for scheduler.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.18
         text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c %U:%G $controllermanagerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chown root:root $controllermanagerkubeconfig
+          Cluster provisioned by RKE doesn't require or maintain a configuration file for scheduler.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
-      - id: 1.1.19
-        text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
-        audit: "find /etc/kubernetes/pki/ | xargs stat -c %U:%G"
-        use_multiple_values: true
-        tests:
-          test_items:
-            - flag: "root:root"
-        remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chown -R root:root /etc/kubernetes/pki/
-        scored: true
-
-      - id: 1.1.20
-        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Manual)"
-        audit: "find /etc/kubernetes/pki/ -name '*.crt' | xargs stat -c permissions=%a"
-        use_multiple_values: true
-        tests:
-          test_items:
-            - flag: "permissions"
-              compare:
-                op: bitmask
-                value: "644"
-        remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chmod -R 644 /etc/kubernetes/pki/*.crt
-        scored: false
-
-      - id: 1.1.21
-        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "find /etc/kubernetes/pki/ -name '*.key' | xargs stat -c permissions=%a"
-        use_multiple_values: true
-        tests:
-          test_items:
-            - flag: "permissions"
-              compare:
-                op: bitmask
-                value: "600"
-        remediation: |
-          Run the below command (based on the file location on your system) on the master node.
-          For example,
-          chmod -R 600 /etc/kubernetes/pki/*.key
-        scored: false
+      
 
   - id: 1.2
     text: "API Server"
     checks:
       - id: 1.2.1
-        text: "Ensure that the --anonymous-auth argument is set to false (Manual)"
+        text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -320,11 +246,12 @@ groups:
               compare:
                 op: eq
                 value: false
+              set: true  
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the below parameter.
           --anonymous-auth=false
-        scored: false
+        scored: true
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
@@ -363,7 +290,9 @@ groups:
           bin_op: and
           test_items:
             - flag: "--kubelet-client-certificate"
+              set: true
             - flag: "--kubelet-client-key"
+              set: true
         remediation: |
           Follow the Kubernetes documentation and set up the TLS connection between the
           apiserver and kubelets. Then, edit API server pod specification file
@@ -375,16 +304,19 @@ groups:
 
       - id: 1.2.5
         text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
+        type: "skip"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
             - flag: "--kubelet-certificate-authority"
+              set: true
         remediation: |
           Follow the Kubernetes documentation and setup the TLS connection between
           the apiserver and kubelets. Then, edit the API server pod specification file
           $apiserverconf on the master node and set the
           --kubelet-certificate-authority parameter to the path to the cert file for the certificate authority.
           --kubelet-certificate-authority=<ca-string>
+          When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
         scored: true
 
       - id: 1.2.6
@@ -396,6 +328,7 @@ groups:
               compare:
                 op: nothave
                 value: "AlwaysAllow"
+              set: true  
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the --authorization-mode parameter to values other than AlwaysAllow.
@@ -412,6 +345,7 @@ groups:
               compare:
                 op: has
                 value: "Node"
+              set: true  
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the --authorization-mode parameter to a value that includes Node.
@@ -427,6 +361,7 @@ groups:
               compare:
                 op: has
                 value: "RBAC"
+              set: true  
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the --authorization-mode parameter to a value that includes RBAC,
@@ -443,6 +378,7 @@ groups:
               compare:
                 op: has
                 value: "EventRateLimit"
+              set: true  
         remediation: |
           Follow the Kubernetes documentation and set the desired limits in a configuration file.
           Then, edit the API server pod specification file $apiserverconf
@@ -461,6 +397,7 @@ groups:
               compare:
                 op: nothave
                 value: AlwaysAdmit
+              set: true  
             - flag: "--enable-admission-plugins"
               set: false
         remediation: |
@@ -471,6 +408,7 @@ groups:
 
       - id: 1.2.11
         text: "Ensure that the admission control plugin AlwaysPullImages is set (Manual)"
+        type: "manual"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -487,6 +425,7 @@ groups:
 
       - id: 1.2.12
         text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)"
+        type: "manual"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           bin_op: or
@@ -516,6 +455,7 @@ groups:
               compare:
                 op: nothave
                 value: "ServiceAccount"
+              set: true  
             - flag: "--disable-admission-plugins"
               set: false
         remediation: |
@@ -535,6 +475,7 @@ groups:
               compare:
                 op: nothave
                 value: "NamespaceLifecycle"
+              set: true  
             - flag: "--disable-admission-plugins"
               set: false
         remediation: |
@@ -545,6 +486,7 @@ groups:
 
       - id: 1.2.15
         text: "Ensure that the admission control plugin PodSecurityPolicy is set (Automated)"
+        type: "skip"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -552,6 +494,7 @@ groups:
               compare:
                 op: has
                 value: "PodSecurityPolicy"
+              set: true  
         remediation: |
           Follow the documentation and create Pod Security Policy objects as per your environment.
           Then, edit the API server pod specification file $apiserverconf
@@ -559,6 +502,7 @@ groups:
           value that includes PodSecurityPolicy:
           --enable-admission-plugins=...,PodSecurityPolicy,...
           Then restart the API Server.
+          Enabling Pod Security Policy can cause applications to unexpectedly fail.
         scored: true
 
       - id: 1.2.16
@@ -570,6 +514,7 @@ groups:
               compare:
                 op: has
                 value: "NodeRestriction"
+              set: true  
         remediation: |
           Follow the Kubernetes documentation and configure NodeRestriction plug-in on kubelets.
           Then, edit the API server pod specification file $apiserverconf
@@ -599,6 +544,7 @@ groups:
               compare:
                 op: eq
                 value: 0
+              set: true  
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the below parameter.
@@ -615,6 +561,7 @@ groups:
               compare:
                 op: gt
                 value: 0
+              set: true  
             - flag: "--secure-port"
               set: false
         remediation: |
@@ -632,6 +579,7 @@ groups:
               compare:
                 op: eq
                 value: false
+              set: true  
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the below parameter.
@@ -644,6 +592,7 @@ groups:
         tests:
           test_items:
             - flag: "--audit-log-path"
+              set: true
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the --audit-log-path parameter to a suitable path and
@@ -660,6 +609,7 @@ groups:
               compare:
                 op: gte
                 value: 30
+              set: true  
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the --audit-log-maxage parameter to 30 or as an appropriate number of days:
@@ -675,6 +625,7 @@ groups:
               compare:
                 op: gte
                 value: 10
+              set: true  
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the --audit-log-maxbackup parameter to 10 or to an appropriate
@@ -691,6 +642,7 @@ groups:
               compare:
                 op: gte
                 value: 100
+              set: true  
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the --audit-log-maxsize parameter to an appropriate size in MB.
@@ -699,15 +651,21 @@ groups:
         scored: true
 
       - id: 1.2.25
-        text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"
+        text: "Ensure that the --request-timeout argument is set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
-        type: manual
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--request-timeout"
+              set: false
+            - flag: "--request-timeout"
+              set: true
         remediation: |
           Edit the API server pod specification file $apiserverconf
           and set the below parameter as appropriate and if needed.
           For example,
           --request-timeout=300s
-        scored: false
+        scored: true
 
       - id: 1.2.26
         text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
@@ -721,6 +679,7 @@ groups:
               compare:
                 op: eq
                 value: true
+              set: true  
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the below parameter.
@@ -735,6 +694,7 @@ groups:
         tests:
           test_items:
             - flag: "--service-account-key-file"
+              set: true
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the --service-account-key-file parameter
@@ -749,7 +709,9 @@ groups:
           bin_op: and
           test_items:
             - flag: "--etcd-certfile"
+              set: true
             - flag: "--etcd-keyfile"
+              set: true
         remediation: |
           Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
           Then, edit the API server pod specification file $apiserverconf
@@ -765,7 +727,9 @@ groups:
           bin_op: and
           test_items:
             - flag: "--tls-cert-file"
+              set: true
             - flag: "--tls-private-key-file"
+              set: true
         remediation: |
           Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
           Then, edit the API server pod specification file $apiserverconf
@@ -780,6 +744,7 @@ groups:
         tests:
           test_items:
             - flag: "--client-ca-file"
+              set: true
         remediation: |
           Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
           Then, edit the API server pod specification file $apiserverconf
@@ -793,6 +758,7 @@ groups:
         tests:
           test_items:
             - flag: "--etcd-cafile"
+              set: true
         remediation: |
           Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
           Then, edit the API server pod specification file $apiserverconf
@@ -802,18 +768,22 @@ groups:
 
       - id: 1.2.32
         text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
+        type: "skip"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
             - flag: "--encryption-provider-config"
+              set: true
         remediation: |
           Follow the Kubernetes documentation and configure a EncryptionConfig file.
           Then, edit the API server pod specification file $apiserverconf
           on the master node and set the --encryption-provider-config parameter to the path of that file: --encryption-provider-config=</path/to/EncryptionConfig/File>
+          Enabling encryption changes how data can be recovered as data is encrypted.
         scored: false
 
       - id: 1.2.33
         text: "Ensure that encryption providers are appropriately configured (Manual)"
+        type: "skip"
         audit: |
           ENCRYPTION_PROVIDER_CONFIG=$(ps -ef | grep $apiserverbin | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
           if test -e $ENCRYPTION_PROVIDER_CONFIG; then grep -A1 'providers:' $ENCRYPTION_PROVIDER_CONFIG | tail -n1 | grep -o "[A-Za-z]*" | sed 's/^/provider=/'; fi
@@ -826,10 +796,12 @@ groups:
         remediation: |
           Follow the Kubernetes documentation and configure a EncryptionConfig file.
           In this file, choose aescbc, kms or secretbox as the encryption provider.
+          Enabling encryption changes how data can be recovered as data is encrypted.
         scored: false
 
       - id: 1.2.34
         text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Manual)"
+        type: "manual"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -850,17 +822,18 @@ groups:
     text: "Controller Manager"
     checks:
       - id: 1.3.1
-        text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Manual)"
+        text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
         tests:
           test_items:
             - flag: "--terminated-pod-gc-threshold"
+              set: true
         remediation: |
           Edit the Controller Manager pod specification file $controllermanagerconf
           on the master node and set the --terminated-pod-gc-threshold to an appropriate threshold,
           for example:
           --terminated-pod-gc-threshold=10
-        scored: false
+        scored: true
 
       - id: 1.3.2
         text: "Ensure that the --profiling argument is set to false (Automated)"
@@ -871,6 +844,7 @@ groups:
               compare:
                 op: eq
                 value: false
+              set: true  
         remediation: |
           Edit the Controller Manager pod specification file $controllermanagerconf
           on the master node and set the below parameter.
@@ -886,6 +860,7 @@ groups:
               compare:
                 op: noteq
                 value: false
+              set: true  
         remediation: |
           Edit the Controller Manager pod specification file $controllermanagerconf
           on the master node to set the below parameter.
@@ -898,6 +873,7 @@ groups:
         tests:
           test_items:
             - flag: "--service-account-private-key-file"
+              set: true
         remediation: |
           Edit the Controller Manager pod specification file $controllermanagerconf
           on the master node and set the --service-account-private-key-file parameter
@@ -911,6 +887,7 @@ groups:
         tests:
           test_items:
             - flag: "--root-ca-file"
+              set: true
         remediation: |
           Edit the Controller Manager pod specification file $controllermanagerconf
           on the master node and set the --root-ca-file parameter to the certificate bundle file`.
@@ -919,6 +896,7 @@ groups:
 
       - id: 1.3.6
         text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
+        type: "skip"
         audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
         tests:
           bin_op: or
@@ -934,6 +912,7 @@ groups:
           Edit the Controller Manager pod specification file $controllermanagerconf
           on the master node and set the --feature-gates parameter to include RotateKubeletServerCertificate=true.
           --feature-gates=RotateKubeletServerCertificate=true
+          Cluster provisioned by RKE handles certificate rotation directly through RKE.
         scored: true
 
       - id: 1.3.7
@@ -946,6 +925,7 @@ groups:
               compare:
                 op: eq
                 value: "127.0.0.1"
+              set: true  
             - flag: "--bind-address"
               set: false
         remediation: |
@@ -965,6 +945,7 @@ groups:
               compare:
                 op: eq
                 value: false
+              set: true  
         remediation: |
           Edit the Scheduler pod specification file $schedulerconf file
           on the master node and set the below parameter.
@@ -981,6 +962,7 @@ groups:
               compare:
                 op: eq
                 value: "127.0.0.1"
+              set: true  
             - flag: "--bind-address"
               set: false
         remediation: |

--- a/package/cfg/rke-cis-1.20-permissive/master.yaml
+++ b/package/cfg/rke-cis-1.20-permissive/master.yaml
@@ -1,0 +1,989 @@
+---
+controls:
+version: "1.20"
+id: 1
+text: "Master Node Security Configuration"
+type: "master"
+groups:
+  - id: 1.1
+    text: "Master Node Configuration Files"
+    checks:
+      - id: 1.1.1
+        text: "Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $apiserverconf; then stat -c permissions=%a $apiserverconf; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the
+          master node.
+          For example, chmod 644 $apiserverconf
+        scored: true
+
+      - id: 1.1.2
+        text: "Ensure that the API server pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $apiserverconf; then stat -c %U:%G $apiserverconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown root:root $apiserverconf
+        scored: true
+
+      - id: 1.1.3
+        text: "Ensure that the controller manager pod specification file permissions are set to 644 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $controllermanagerconf; then stat -c permissions=%a $controllermanagerconf; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod 644 $controllermanagerconf
+        scored: true
+
+      - id: 1.1.4
+        text: "Ensure that the controller manager pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $controllermanagerconf; then stat -c %U:%G $controllermanagerconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown root:root $controllermanagerconf
+        scored: true
+
+      - id: 1.1.5
+        text: "Ensure that the scheduler pod specification file permissions are set to 644 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c permissions=%a $schedulerconf; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod 644 $schedulerconf
+        scored: true
+
+      - id: 1.1.6
+        text: "Ensure that the scheduler pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c %U:%G $schedulerconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown root:root $schedulerconf
+        scored: true
+
+      - id: 1.1.7
+        text: "Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod 644 $etcdconf
+        scored: true
+
+      - id: 1.1.8
+        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c %U:%G; fi'"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown root:root $etcdconf
+        scored: true
+
+      - id: 1.1.9
+        text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Manual)"
+        audit: |
+          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
+          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod 644 <path/to/cni/files>
+        scored: false
+
+      - id: 1.1.10
+        text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
+        audit: |
+          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
+          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown root:root <path/to/cni/files>
+        scored: false
+
+      - id: 1.1.11
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
+        audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c permissions=%a
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "700"
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the below command:
+          ps -ef | grep etcd
+          Run the below command (based on the etcd data directory found above). For example,
+          chmod 700 /var/lib/etcd
+        scored: true
+
+      - id: 1.1.12
+        text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
+        audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G
+        tests:
+          test_items:
+            - flag: "etcd:etcd"
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the below command:
+          ps -ef | grep etcd
+          Run the below command (based on the etcd data directory found above).
+          For example, chown etcd:etcd /var/lib/etcd
+        scored: true
+
+      - id: 1.1.13
+        text: "Ensure that the admin.conf file permissions are set to 644 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c permissions=%a /etc/kubernetes/admin.conf; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod 644 /etc/kubernetes/admin.conf
+        scored: true
+
+      - id: 1.1.14
+        text: "Ensure that the admin.conf file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c %U:%G /etc/kubernetes/admin.conf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown root:root /etc/kubernetes/admin.conf
+        scored: true
+
+      - id: 1.1.15
+        text: "Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c permissions=%a $schedulerkubeconfig; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod 644 $schedulerkubeconfig
+        scored: true
+
+      - id: 1.1.16
+        text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c %U:%G $schedulerkubeconfig; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown root:root $schedulerkubeconfig
+        scored: true
+
+      - id: 1.1.17
+        text: "Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c permissions=%a $controllermanagerkubeconfig; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod 644 $controllermanagerkubeconfig
+        scored: true
+
+      - id: 1.1.18
+        text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c %U:%G $controllermanagerkubeconfig; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown root:root $controllermanagerkubeconfig
+        scored: true
+
+      - id: 1.1.19
+        text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
+        audit: "find /etc/kubernetes/pki/ | xargs stat -c %U:%G"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chown -R root:root /etc/kubernetes/pki/
+        scored: true
+
+      - id: 1.1.20
+        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Manual)"
+        audit: "find /etc/kubernetes/pki/ -name '*.crt' | xargs stat -c permissions=%a"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod -R 644 /etc/kubernetes/pki/*.crt
+        scored: false
+
+      - id: 1.1.21
+        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
+        audit: "find /etc/kubernetes/pki/ -name '*.key' | xargs stat -c permissions=%a"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the master node.
+          For example,
+          chmod -R 600 /etc/kubernetes/pki/*.key
+        scored: false
+
+  - id: 1.2
+    text: "API Server"
+    checks:
+      - id: 1.2.1
+        text: "Ensure that the --anonymous-auth argument is set to false (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--anonymous-auth"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the below parameter.
+          --anonymous-auth=false
+        scored: false
+
+      - id: 1.2.2
+        text: "Ensure that the --token-auth-file parameter is not set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--token-auth-file"
+              set: false
+        remediation: |
+          Follow the documentation and configure alternate mechanisms for authentication. Then,
+          edit the API server pod specification file $apiserverconf
+          on the master node and remove the --token-auth-file=<filename> parameter.
+        scored: true
+
+      - id: 1.2.3
+        text: "Ensure that the --kubelet-https argument is set to true (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--kubelet-https"
+              compare:
+                op: eq
+                value: true
+            - flag: "--kubelet-https"
+              set: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and remove the --kubelet-https parameter.
+        scored: true
+
+      - id: 1.2.4
+        text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--kubelet-client-certificate"
+            - flag: "--kubelet-client-key"
+        remediation: |
+          Follow the Kubernetes documentation and set up the TLS connection between the
+          apiserver and kubelets. Then, edit API server pod specification file
+          $apiserverconf on the master node and set the
+          kubelet client certificate and key parameters as below.
+          --kubelet-client-certificate=<path/to/client-certificate-file>
+          --kubelet-client-key=<path/to/client-key-file>
+        scored: true
+
+      - id: 1.2.5
+        text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--kubelet-certificate-authority"
+        remediation: |
+          Follow the Kubernetes documentation and setup the TLS connection between
+          the apiserver and kubelets. Then, edit the API server pod specification file
+          $apiserverconf on the master node and set the
+          --kubelet-certificate-authority parameter to the path to the cert file for the certificate authority.
+          --kubelet-certificate-authority=<ca-string>
+        scored: true
+
+      - id: 1.2.6
+        text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--authorization-mode"
+              compare:
+                op: nothave
+                value: "AlwaysAllow"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --authorization-mode parameter to values other than AlwaysAllow.
+          One such example could be as below.
+          --authorization-mode=RBAC
+        scored: true
+
+      - id: 1.2.7
+        text: "Ensure that the --authorization-mode argument includes Node (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--authorization-mode"
+              compare:
+                op: has
+                value: "Node"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --authorization-mode parameter to a value that includes Node.
+          --authorization-mode=Node,RBAC
+        scored: true
+
+      - id: 1.2.8
+        text: "Ensure that the --authorization-mode argument includes RBAC (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--authorization-mode"
+              compare:
+                op: has
+                value: "RBAC"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --authorization-mode parameter to a value that includes RBAC,
+          for example:
+          --authorization-mode=Node,RBAC
+        scored: true
+
+      - id: 1.2.9
+        text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "EventRateLimit"
+        remediation: |
+          Follow the Kubernetes documentation and set the desired limits in a configuration file.
+          Then, edit the API server pod specification file $apiserverconf
+          and set the below parameters.
+          --enable-admission-plugins=...,EventRateLimit,...
+          --admission-control-config-file=<path/to/configuration/file>
+        scored: false
+
+      - id: 1.2.10
+        text: "Ensure that the admission control plugin AlwaysAdmit is not set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: nothave
+                value: AlwaysAdmit
+            - flag: "--enable-admission-plugins"
+              set: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and either remove the --enable-admission-plugins parameter, or set it to a
+          value that does not include AlwaysAdmit.
+        scored: true
+
+      - id: 1.2.11
+        text: "Ensure that the admission control plugin AlwaysPullImages is set (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "AlwaysPullImages"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --enable-admission-plugins parameter to include
+          AlwaysPullImages.
+          --enable-admission-plugins=...,AlwaysPullImages,...
+        scored: false
+
+      - id: 1.2.12
+        text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "SecurityContextDeny"
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "PodSecurityPolicy"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --enable-admission-plugins parameter to include
+          SecurityContextDeny, unless PodSecurityPolicy is already in place.
+          --enable-admission-plugins=...,SecurityContextDeny,...
+        scored: false
+
+      - id: 1.2.13
+        text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--disable-admission-plugins"
+              compare:
+                op: nothave
+                value: "ServiceAccount"
+            - flag: "--disable-admission-plugins"
+              set: false
+        remediation: |
+          Follow the documentation and create ServiceAccount objects as per your environment.
+          Then, edit the API server pod specification file $apiserverconf
+          on the master node and ensure that the --disable-admission-plugins parameter is set to a
+          value that does not include ServiceAccount.
+        scored: true
+
+      - id: 1.2.14
+        text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--disable-admission-plugins"
+              compare:
+                op: nothave
+                value: "NamespaceLifecycle"
+            - flag: "--disable-admission-plugins"
+              set: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --disable-admission-plugins parameter to
+          ensure it does not include NamespaceLifecycle.
+        scored: true
+
+      - id: 1.2.15
+        text: "Ensure that the admission control plugin PodSecurityPolicy is set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "PodSecurityPolicy"
+        remediation: |
+          Follow the documentation and create Pod Security Policy objects as per your environment.
+          Then, edit the API server pod specification file $apiserverconf
+          on the master node and set the --enable-admission-plugins parameter to a
+          value that includes PodSecurityPolicy:
+          --enable-admission-plugins=...,PodSecurityPolicy,...
+          Then restart the API Server.
+        scored: true
+
+      - id: 1.2.16
+        text: "Ensure that the admission control plugin NodeRestriction is set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "NodeRestriction"
+        remediation: |
+          Follow the Kubernetes documentation and configure NodeRestriction plug-in on kubelets.
+          Then, edit the API server pod specification file $apiserverconf
+          on the master node and set the --enable-admission-plugins parameter to a
+          value that includes NodeRestriction.
+          --enable-admission-plugins=...,NodeRestriction,...
+        scored: true
+
+      - id: 1.2.17
+        text: "Ensure that the --insecure-bind-address argument is not set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--insecure-bind-address"
+              set: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and remove the --insecure-bind-address parameter.
+        scored: true
+
+      - id: 1.2.18
+        text: "Ensure that the --insecure-port argument is set to 0 (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--insecure-port"
+              compare:
+                op: eq
+                value: 0
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the below parameter.
+          --insecure-port=0
+        scored: true
+
+      - id: 1.2.19
+        text: "Ensure that the --secure-port argument is not set to 0 (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--secure-port"
+              compare:
+                op: gt
+                value: 0
+            - flag: "--secure-port"
+              set: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and either remove the --secure-port parameter or
+          set it to a different (non-zero) desired port.
+        scored: true
+
+      - id: 1.2.20
+        text: "Ensure that the --profiling argument is set to false (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--profiling"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the below parameter.
+          --profiling=false
+        scored: true
+
+      - id: 1.2.21
+        text: "Ensure that the --audit-log-path argument is set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-log-path"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --audit-log-path parameter to a suitable path and
+          file where you would like audit logs to be written, for example:
+          --audit-log-path=/var/log/apiserver/audit.log
+        scored: true
+
+      - id: 1.2.22
+        text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-log-maxage"
+              compare:
+                op: gte
+                value: 30
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --audit-log-maxage parameter to 30 or as an appropriate number of days:
+          --audit-log-maxage=30
+        scored: true
+
+      - id: 1.2.23
+        text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-log-maxbackup"
+              compare:
+                op: gte
+                value: 10
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --audit-log-maxbackup parameter to 10 or to an appropriate
+          value.
+          --audit-log-maxbackup=10
+        scored: true
+
+      - id: 1.2.24
+        text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-log-maxsize"
+              compare:
+                op: gte
+                value: 100
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --audit-log-maxsize parameter to an appropriate size in MB.
+          For example, to set it as 100 MB:
+          --audit-log-maxsize=100
+        scored: true
+
+      - id: 1.2.25
+        text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        type: manual
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          and set the below parameter as appropriate and if needed.
+          For example,
+          --request-timeout=300s
+        scored: false
+
+      - id: 1.2.26
+        text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--service-account-lookup"
+              set: false
+            - flag: "--service-account-lookup"
+              compare:
+                op: eq
+                value: true
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the below parameter.
+          --service-account-lookup=true
+          Alternatively, you can delete the --service-account-lookup parameter from this file so
+          that the default takes effect.
+        scored: true
+
+      - id: 1.2.27
+        text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--service-account-key-file"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the master node and set the --service-account-key-file parameter
+          to the public key file for service accounts:
+          --service-account-key-file=<filename>
+        scored: true
+
+      - id: 1.2.28
+        text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--etcd-certfile"
+            - flag: "--etcd-keyfile"
+        remediation: |
+          Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
+          Then, edit the API server pod specification file $apiserverconf
+          on the master node and set the etcd certificate and key file parameters.
+          --etcd-certfile=<path/to/client-certificate-file>
+          --etcd-keyfile=<path/to/client-key-file>
+        scored: true
+
+      - id: 1.2.29
+        text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--tls-cert-file"
+            - flag: "--tls-private-key-file"
+        remediation: |
+          Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
+          Then, edit the API server pod specification file $apiserverconf
+          on the master node and set the TLS certificate and private key file parameters.
+          --tls-cert-file=<path/to/tls-certificate-file>
+          --tls-private-key-file=<path/to/tls-key-file>
+        scored: true
+
+      - id: 1.2.30
+        text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--client-ca-file"
+        remediation: |
+          Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
+          Then, edit the API server pod specification file $apiserverconf
+          on the master node and set the client certificate authority file.
+          --client-ca-file=<path/to/client-ca-file>
+        scored: true
+
+      - id: 1.2.31
+        text: "Ensure that the --etcd-cafile argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--etcd-cafile"
+        remediation: |
+          Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
+          Then, edit the API server pod specification file $apiserverconf
+          on the master node and set the etcd certificate authority file parameter.
+          --etcd-cafile=<path/to/ca-file>
+        scored: true
+
+      - id: 1.2.32
+        text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--encryption-provider-config"
+        remediation: |
+          Follow the Kubernetes documentation and configure a EncryptionConfig file.
+          Then, edit the API server pod specification file $apiserverconf
+          on the master node and set the --encryption-provider-config parameter to the path of that file: --encryption-provider-config=</path/to/EncryptionConfig/File>
+        scored: false
+
+      - id: 1.2.33
+        text: "Ensure that encryption providers are appropriately configured (Manual)"
+        audit: |
+          ENCRYPTION_PROVIDER_CONFIG=$(ps -ef | grep $apiserverbin | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
+          if test -e $ENCRYPTION_PROVIDER_CONFIG; then grep -A1 'providers:' $ENCRYPTION_PROVIDER_CONFIG | tail -n1 | grep -o "[A-Za-z]*" | sed 's/^/provider=/'; fi
+        tests:
+          test_items:
+            - flag: "provider"
+              compare:
+                op: valid_elements
+                value: "aescbc,kms,secretbox"
+        remediation: |
+          Follow the Kubernetes documentation and configure a EncryptionConfig file.
+          In this file, choose aescbc, kms or secretbox as the encryption provider.
+        scored: false
+
+      - id: 1.2.34
+        text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--tls-cipher-suites"
+              compare:
+                op: valid_elements
+                value: "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256"
+        remediation: |
+          Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
+          on the master node and set the below parameter.
+          --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM
+          _SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM
+          _SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM
+          _SHA384
+        scored: false
+
+  - id: 1.3
+    text: "Controller Manager"
+    checks:
+      - id: 1.3.1
+        text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Manual)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--terminated-pod-gc-threshold"
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the master node and set the --terminated-pod-gc-threshold to an appropriate threshold,
+          for example:
+          --terminated-pod-gc-threshold=10
+        scored: false
+
+      - id: 1.3.2
+        text: "Ensure that the --profiling argument is set to false (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--profiling"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the master node and set the below parameter.
+          --profiling=false
+        scored: true
+
+      - id: 1.3.3
+        text: "Ensure that the --use-service-account-credentials argument is set to true (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--use-service-account-credentials"
+              compare:
+                op: noteq
+                value: false
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the master node to set the below parameter.
+          --use-service-account-credentials=true
+        scored: true
+
+      - id: 1.3.4
+        text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--service-account-private-key-file"
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the master node and set the --service-account-private-key-file parameter
+          to the private key file for service accounts.
+          --service-account-private-key-file=<filename>
+        scored: true
+
+      - id: 1.3.5
+        text: "Ensure that the --root-ca-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--root-ca-file"
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the master node and set the --root-ca-file parameter to the certificate bundle file`.
+          --root-ca-file=<path/to/file>
+        scored: true
+
+      - id: 1.3.6
+        text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--feature-gates"
+              compare:
+                op: nothave
+                value: "RotateKubeletServerCertificate=false"
+              set: true
+            - flag: "--feature-gates"
+              set: false
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the master node and set the --feature-gates parameter to include RotateKubeletServerCertificate=true.
+          --feature-gates=RotateKubeletServerCertificate=true
+        scored: true
+
+      - id: 1.3.7
+        text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--bind-address"
+              compare:
+                op: eq
+                value: "127.0.0.1"
+            - flag: "--bind-address"
+              set: false
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the master node and ensure the correct value for the --bind-address parameter
+        scored: true
+
+  - id: 1.4
+    text: "Scheduler"
+    checks:
+      - id: 1.4.1
+        text: "Ensure that the --profiling argument is set to false (Automated)"
+        audit: "/bin/ps -ef | grep $schedulerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--profiling"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the Scheduler pod specification file $schedulerconf file
+          on the master node and set the below parameter.
+          --profiling=false
+        scored: true
+
+      - id: 1.4.2
+        text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
+        audit: "/bin/ps -ef | grep $schedulerbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--bind-address"
+              compare:
+                op: eq
+                value: "127.0.0.1"
+            - flag: "--bind-address"
+              set: false
+        remediation: |
+          Edit the Scheduler pod specification file $schedulerconf
+          on the master node and ensure the correct value for the --bind-address parameter
+        scored: true

--- a/package/cfg/rke-cis-1.20-permissive/node.yaml
+++ b/package/cfg/rke-cis-1.20-permissive/node.yaml
@@ -1,6 +1,6 @@
 ---
 controls:
-version: "1.20"
+version: 1.20
 id: 4
 text: "Worker Node Security Configuration"
 type: "node"
@@ -10,6 +10,7 @@ groups:
     checks:
       - id: 4.1.1
         text: "Ensure that the kubelet service file permissions are set to 644 or more restrictive (Automated)"
+        type: "skip"
         audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c permissions=%a $kubeletsvc; fi'' '
         tests:
           test_items:
@@ -18,25 +19,24 @@ groups:
                 op: bitmask
                 value: "644"
         remediation: |
-          Run the below command (based on the file location on your system) on the each worker node.
-          For example,
-          chmod 644 $kubeletsvc
+          Cluster provisioned by RKE doesn’t require or maintain a configuration file for the kubelet service.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 4.1.2
         text: "Ensure that the kubelet service file ownership is set to root:root (Automated)"
+        type: "skip"
         audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc; fi'' '
         tests:
           test_items:
             - flag: root:root
         remediation: |
-          Run the below command (based on the file location on your system) on the each worker node.
-          For example,
-          chown root:root $kubeletsvc
+          Cluster provisioned by RKE doesn’t require or maintain a configuration file for the kubelet service.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 4.1.3
-        text: "If proxy kubeconfig file exists ensure permissions are set to 644 or more restrictive (Manual)"
+        text: "If proxy kubeconfig file exists ensure permissions are set to 644 or more restrictive (Automated)"
         audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c permissions=%a $proxykubeconfig; fi'' '
         tests:
           bin_op: or
@@ -52,10 +52,10 @@ groups:
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
           chmod 644 $proxykubeconfig
-        scored: false
+        scored: true
 
       - id: 4.1.4
-        text: "If proxy kubeconfig file exists ensure ownership is set to root:root (Manual)"
+        text: "If proxy kubeconfig file exists ensure ownership is set to root:root (Automated)"
         audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c %U:%G $proxykubeconfig; fi'' '
         tests:
           bin_op: or
@@ -66,7 +66,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example, chown root:root $proxykubeconfig
-        scored: false
+        scored: true
 
       - id: 4.1.5
         text: "Ensure that the --kubeconfig kubelet.conf file permissions are set to 644 or more restrictive (Automated)"
@@ -96,11 +96,8 @@ groups:
         scored: true
 
       - id: 4.1.7
-        text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Manual)"
-        audit: |
-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
-          if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
-          if test -e $CAFILE; then stat -c permissions=%a $CAFILE; fi
+        text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Automated)"
+        audit: "check_cafile_permissions.sh"
         tests:
           test_items:
             - flag: "permissions"
@@ -110,14 +107,11 @@ groups:
         remediation: |
           Run the following command to modify the file permissions of the
           --client-ca-file chmod 644 <filename>
-        scored: false
+        scored: true
 
       - id: 4.1.8
-        text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
-        audit: |
-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
-          if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
-          if test -e $CAFILE; then stat -c %U:%G $CAFILE; fi
+        text: "Ensure that the client certificate authorities file ownership is set to root:root (Automated)"
+        audit: "check_cafile_ownership.sh"
         tests:
           test_items:
             - flag: root:root
@@ -127,10 +121,11 @@ groups:
         remediation: |
           Run the following command to modify the ownership of the --client-ca-file.
           chown root:root <filename>
-        scored: false
+        scored: true
 
       - id: 4.1.9
         text: "Ensure that the kubelet --config configuration file has permissions set to 644 or more restrictive (Automated)"
+        type: "skip"
         audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c permissions=%a $kubeletconf; fi'' '
         tests:
           test_items:
@@ -139,19 +134,20 @@ groups:
                 op: bitmask
                 value: "644"
         remediation: |
-          Run the following command (using the config file location identified in the Audit step)
-          chmod 644 $kubeletconf
+          Clusters provisioned by RKE doesn’t require or maintain a configuration file for the kubelet.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 4.1.10
         text: "Ensure that the kubelet --config configuration file ownership is set to root:root (Automated)"
+        type: "skip"
         audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c %U:%G $kubeletconf; fi'' '
         tests:
           test_items:
             - flag: root:root
         remediation: |
-          Run the following command (using the config file location identified in the Audit step)
-          chown root:root $kubeletconf
+          Clusters provisioned by RKE doesn’t require or maintain a configuration file for the kubelet.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
   - id: 4.2
@@ -223,7 +219,7 @@ groups:
         scored: true
 
       - id: 4.2.4
-        text: "Ensure that the --read-only-port argument is set to 0 (Manual)"
+        text: "Ensure that the --read-only-port argument is set to 0 (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/cat $kubeletconf"
         tests:
@@ -246,10 +242,10 @@ groups:
           Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
-        scored: false
+        scored: true
 
       - id: 4.2.5
-        text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
+        text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/cat $kubeletconf"
         tests:
@@ -273,10 +269,11 @@ groups:
           Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
-        scored: false
+        scored: true
 
       - id: 4.2.6
         text: "Ensure that the --protect-kernel-defaults argument is set to true (Automated)"
+        type: "skip"
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/cat $kubeletconf"
         tests:
@@ -295,6 +292,7 @@ groups:
           Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
+          System level configurations are required prior to provisioning the cluster in order for this argument to be set to true.
         scored: true
 
       - id: 4.2.7
@@ -328,6 +326,7 @@ groups:
         # This is one of those properties that can only be set as a command line argument.
         # To check if the property is set as expected, we need to parse the kubelet command
         # instead reading the Kubelet Configuration file.
+        type: "skip"
         audit: "/bin/ps -fC $kubeletbin "
         tests:
           test_items:
@@ -340,10 +339,11 @@ groups:
           Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
+          Clusters provisioned by RKE set the --hostname-override to avoid any hostname configuration errors          
         scored: false
 
       - id: 4.2.9
-        text: "Ensure that the --event-qps argument is set to 0 or a level which ensures appropriate event capture (Manual)"
+        text: "Ensure that the --event-qps argument is set to 0 or a level which ensures appropriate event capture (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/cat $kubeletconf"
         tests:
@@ -361,10 +361,11 @@ groups:
           Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
-        scored: false
+        scored: true
 
       - id: 4.2.10
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
+        type: "skip"
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/cat $kubeletconf"
         tests:
@@ -385,10 +386,11 @@ groups:
           Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
+          When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
         scored: false
 
       - id: 4.2.11
-        text: "Ensure that the --rotate-certificates argument is not set to false (Manual)"
+        text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/cat $kubeletconf"
         tests:
@@ -412,10 +414,11 @@ groups:
           Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
-        scored: false
+        scored: true
 
       - id: 4.2.12
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
+        type: "skip"
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/cat $kubeletconf"
         tests:
@@ -436,10 +439,11 @@ groups:
           Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
+          Clusters provisioned by RKE handles certificate rotation directly through RKE.          
         scored: false
 
       - id: 4.2.13
-        text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
+        text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/cat $kubeletconf"
         tests:
@@ -460,4 +464,4 @@ groups:
           Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
-        scored: false
+        scored: true

--- a/package/cfg/rke-cis-1.20-permissive/node.yaml
+++ b/package/cfg/rke-cis-1.20-permissive/node.yaml
@@ -1,0 +1,463 @@
+---
+controls:
+version: "1.20"
+id: 4
+text: "Worker Node Security Configuration"
+type: "node"
+groups:
+  - id: 4.1
+    text: "Worker Node Configuration Files"
+    checks:
+      - id: 4.1.1
+        text: "Ensure that the kubelet service file permissions are set to 644 or more restrictive (Automated)"
+        audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c permissions=%a $kubeletsvc; fi'' '
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chmod 644 $kubeletsvc
+        scored: true
+
+      - id: 4.1.2
+        text: "Ensure that the kubelet service file ownership is set to root:root (Automated)"
+        audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc; fi'' '
+        tests:
+          test_items:
+            - flag: root:root
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chown root:root $kubeletsvc
+        scored: true
+
+      - id: 4.1.3
+        text: "If proxy kubeconfig file exists ensure permissions are set to 644 or more restrictive (Manual)"
+        audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c permissions=%a $proxykubeconfig; fi'' '
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "permissions"
+              set: true
+              compare:
+                op: bitmask
+                value: "644"
+            - flag: "$proxykubeconfig"
+              set: false
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chmod 644 $proxykubeconfig
+        scored: false
+
+      - id: 4.1.4
+        text: "If proxy kubeconfig file exists ensure ownership is set to root:root (Manual)"
+        audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c %U:%G $proxykubeconfig; fi'' '
+        tests:
+          bin_op: or
+          test_items:
+            - flag: root:root
+            - flag: "$proxykubeconfig"
+              set: false
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example, chown root:root $proxykubeconfig
+        scored: false
+
+      - id: 4.1.5
+        text: "Ensure that the --kubeconfig kubelet.conf file permissions are set to 644 or more restrictive (Automated)"
+        audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c permissions=%a $kubeletkubeconfig; fi'' '
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chmod 644 $kubeletkubeconfig
+        scored: true
+
+      - id: 4.1.6
+        text: "Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root (Automated)"
+        audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c %U:%G $kubeletkubeconfig; fi'' '
+        tests:
+          test_items:
+            - flag: root:root
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chown root:root $kubeletkubeconfig
+        scored: true
+
+      - id: 4.1.7
+        text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Manual)"
+        audit: |
+          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
+          if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
+          if test -e $CAFILE; then stat -c permissions=%a $CAFILE; fi
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the following command to modify the file permissions of the
+          --client-ca-file chmod 644 <filename>
+        scored: false
+
+      - id: 4.1.8
+        text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
+        audit: |
+          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
+          if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
+          if test -e $CAFILE; then stat -c %U:%G $CAFILE; fi
+        tests:
+          test_items:
+            - flag: root:root
+              compare:
+                op: eq
+                value: root:root
+        remediation: |
+          Run the following command to modify the ownership of the --client-ca-file.
+          chown root:root <filename>
+        scored: false
+
+      - id: 4.1.9
+        text: "Ensure that the kubelet --config configuration file has permissions set to 644 or more restrictive (Automated)"
+        audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c permissions=%a $kubeletconf; fi'' '
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the following command (using the config file location identified in the Audit step)
+          chmod 644 $kubeletconf
+        scored: true
+
+      - id: 4.1.10
+        text: "Ensure that the kubelet --config configuration file ownership is set to root:root (Automated)"
+        audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c %U:%G $kubeletconf; fi'' '
+        tests:
+          test_items:
+            - flag: root:root
+        remediation: |
+          Run the following command (using the config file location identified in the Audit step)
+          chown root:root $kubeletconf
+        scored: true
+
+  - id: 4.2
+    text: "Kubelet"
+    checks:
+      - id: 4.2.1
+        text: "Ensure that the anonymous-auth argument is set to false (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: "--anonymous-auth"
+              path: '{.authentication.anonymous.enabled}'
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          If using a Kubelet config file, edit the file to set authentication: anonymous: enabled to
+          false.
+          If using executable arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          --anonymous-auth=false
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.2
+        text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --authorization-mode
+              path: '{.authorization.mode}'
+              compare:
+                op: nothave
+                value: AlwaysAllow
+        remediation: |
+          If using a Kubelet config file, edit the file to set authorization: mode to Webhook. If
+          using executable arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_AUTHZ_ARGS variable.
+          --authorization-mode=Webhook
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.3
+        text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --client-ca-file
+              path: '{.authentication.x509.clientCAFile}'
+        remediation: |
+          If using a Kubelet config file, edit the file to set authentication: x509: clientCAFile to
+          the location of the client CA file.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_AUTHZ_ARGS variable.
+          --client-ca-file=<path/to/client-ca-file>
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.4
+        text: "Ensure that the --read-only-port argument is set to 0 (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--read-only-port"
+              path: '{.readOnlyPort}'
+              compare:
+                op: eq
+                value: 0
+            - flag: "--read-only-port"
+              path: '{.readOnlyPort}'
+              set: false
+        remediation: |
+          If using a Kubelet config file, edit the file to set readOnlyPort to 0.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          --read-only-port=0
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.5
+        text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --streaming-connection-idle-timeout
+              path: '{.streamingConnectionIdleTimeout}'
+              compare:
+                op: noteq
+                value: 0
+            - flag: --streaming-connection-idle-timeout
+              path: '{.streamingConnectionIdleTimeout}'
+              set: false
+          bin_op: or
+        remediation: |
+          If using a Kubelet config file, edit the file to set streamingConnectionIdleTimeout to a
+          value other than 0.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          --streaming-connection-idle-timeout=5m
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.6
+        text: "Ensure that the --protect-kernel-defaults argument is set to true (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --protect-kernel-defaults
+              path: '{.protectKernelDefaults}'
+              compare:
+                op: eq
+                value: true
+        remediation: |
+          If using a Kubelet config file, edit the file to set protectKernelDefaults: true.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          --protect-kernel-defaults=true
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.7
+        text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --make-iptables-util-chains
+              path: '{.makeIPTablesUtilChains}'
+              compare:
+                op: eq
+                value: true
+            - flag: --make-iptables-util-chains
+              path: '{.makeIPTablesUtilChains}'
+              set: false
+          bin_op: or
+        remediation: |
+          If using a Kubelet config file, edit the file to set makeIPTablesUtilChains: true.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          remove the --make-iptables-util-chains argument from the
+          KUBELET_SYSTEM_PODS_ARGS variable.
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.8
+        text: "Ensure that the --hostname-override argument is not set (Manual)"
+        # This is one of those properties that can only be set as a command line argument.
+        # To check if the property is set as expected, we need to parse the kubelet command
+        # instead reading the Kubelet Configuration file.
+        audit: "/bin/ps -fC $kubeletbin "
+        tests:
+          test_items:
+            - flag: --hostname-override
+              set: false
+        remediation: |
+          Edit the kubelet service file $kubeletsvc
+          on each worker node and remove the --hostname-override argument from the
+          KUBELET_SYSTEM_PODS_ARGS variable.
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.9
+        text: "Ensure that the --event-qps argument is set to 0 or a level which ensures appropriate event capture (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --event-qps
+              path: '{.eventRecordQPS}'
+              compare:
+                op: eq
+                value: 0
+        remediation: |
+          If using a Kubelet config file, edit the file to set eventRecordQPS: to an appropriate level.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.10
+        text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --tls-cert-file
+              path: '{.tlsCertFile}'
+            - flag: --tls-private-key-file
+              path: '{.tlsPrivateKeyFile}'
+        remediation: |
+          If using a Kubelet config file, edit the file to set tlsCertFile to the location
+          of the certificate file to use to identify this Kubelet, and tlsPrivateKeyFile
+          to the location of the corresponding private key file.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameters in KUBELET_CERTIFICATE_ARGS variable.
+          --tls-cert-file=<path/to/tls-certificate-file>
+          --tls-private-key-file=<path/to/tls-key-file>
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.11
+        text: "Ensure that the --rotate-certificates argument is not set to false (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --rotate-certificates
+              path: '{.rotateCertificates}'
+              compare:
+                op: eq
+                value: true
+            - flag: --rotate-certificates
+              path: '{.rotateCertificates}'
+              set: false
+          bin_op: or
+        remediation: |
+          If using a Kubelet config file, edit the file to add the line rotateCertificates: true or
+          remove it altogether to use the default value.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          remove --rotate-certificates=false argument from the KUBELET_CERTIFICATE_ARGS
+          variable.
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.12
+        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: RotateKubeletServerCertificate
+              path: '{.featureGates.RotateKubeletServerCertificate}'
+              compare:
+                op: nothave
+                value: false
+            - flag: RotateKubeletServerCertificate
+              path: '{.featureGates.RotateKubeletServerCertificate}'
+              set: false
+        remediation: |
+          Edit the kubelet service file $kubeletsvc
+          on each worker node and set the below parameter in KUBELET_CERTIFICATE_ARGS variable.
+          --feature-gates=RotateKubeletServerCertificate=true
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.13
+        text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --tls-cipher-suites
+              path: '{range .tlsCipherSuites[:]}{}{'',''}{end}'
+              compare:
+                op: valid_elements
+                value: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+        remediation: |
+          If using a Kubelet config file, edit the file to set TLSCipherSuites: to
+          TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+          or to a subset of these values.
+          If using executable arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the --tls-cipher-suites parameter as follows, or to a subset of these values.
+          --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false

--- a/package/cfg/rke-cis-1.20-permissive/policies.yaml
+++ b/package/cfg/rke-cis-1.20-permissive/policies.yaml
@@ -1,0 +1,238 @@
+---
+controls:
+version: "1.20"
+id: 5
+text: "Kubernetes Policies"
+type: "policies"
+groups:
+  - id: 5.1
+    text: "RBAC and Service Accounts"
+    checks:
+      - id: 5.1.1
+        text: "Ensure that the cluster-admin role is only used where required (Manual)"
+        type: "manual"
+        remediation: |
+          Identify all clusterrolebindings to the cluster-admin role. Check if they are used and
+          if they need this role or if they could use a role with fewer privileges.
+          Where possible, first bind users to a lower privileged role and then remove the
+          clusterrolebinding to the cluster-admin role :
+          kubectl delete clusterrolebinding [name]
+        scored: false
+
+      - id: 5.1.2
+        text: "Minimize access to secrets (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove get, list and watch access to secret objects in the cluster.
+        scored: false
+
+      - id: 5.1.3
+        text: "Minimize wildcard use in Roles and ClusterRoles (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible replace any use of wildcards in clusterroles and roles with specific
+          objects or actions.
+        scored: false
+
+      - id: 5.1.4
+        text: "Minimize access to create pods (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove create access to pod objects in the cluster.
+        scored: false
+
+      - id: 5.1.5
+        text: "Ensure that default service accounts are not actively used. (Manual)"
+        type: "manual"
+        remediation: |
+          Create explicit service accounts wherever a Kubernetes workload requires specific access
+          to the Kubernetes API server.
+          Modify the configuration of each default service account to include this value
+          automountServiceAccountToken: false
+        scored: false
+
+      - id: 5.1.6
+        text: "Ensure that Service Account Tokens are only mounted where necessary (Manual)"
+        type: "manual"
+        remediation: |
+          Modify the definition of pods and service accounts which do not need to mount service
+          account tokens to disable it.
+        scored: false
+
+      - id: 5.1.7
+        text: "Avoid use of system:masters group (Manual)"
+        type: "manual"
+        remediation: |
+          Remove the system:masters group from all users in the cluster.
+        scored: false
+
+      - id: 5.1.8
+        text: "Limit use of the Bind, Impersonate and Escalate permissions in the Kubernetes cluster (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove the impersonate, bind and escalate rights from subjects.
+        scored: false
+
+  - id: 5.2
+    text: "Pod Security Policies"
+    checks:
+      - id: 5.2.1
+        text: "Minimize the admission of privileged containers (Automated)"
+        type: "manual"
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that
+          the .spec.privileged field is omitted or set to false.
+        scored: false
+
+      - id: 5.2.2
+        text: "Minimize the admission of containers wishing to share the host process ID namespace (Automated)"
+        type: "manual"
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that the
+          .spec.hostPID field is omitted or set to false.
+        scored: false
+
+      - id: 5.2.3
+        text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
+        type: "manual"
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that the
+          .spec.hostIPC field is omitted or set to false.
+        scored: false
+
+      - id: 5.2.4
+        text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
+        type: "manual"
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that the
+          .spec.hostNetwork field is omitted or set to false.
+        scored: false
+
+      - id: 5.2.5
+        text: "Minimize the admission of containers with allowPrivilegeEscalation (Automated)"
+        type: "manual"
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that the
+          .spec.allowPrivilegeEscalation field is omitted or set to false.
+        scored: false
+
+      - id: 5.2.6
+        text: "Minimize the admission of root containers (Automated)"
+        type: "manual"
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that the
+          .spec.runAsUser.rule is set to either MustRunAsNonRoot or MustRunAs with the range of
+          UIDs not including 0.
+        scored: false
+
+      - id: 5.2.7
+        text: "Minimize the admission of containers with the NET_RAW capability (Automated)"
+        type: "manual"
+        remediation: |
+          Create a PSP as described in the Kubernetes documentation, ensuring that the
+          .spec.requiredDropCapabilities is set to include either NET_RAW or ALL.
+        scored: false
+
+      - id: 5.2.8
+        text: "Minimize the admission of containers with added capabilities (Automated)"
+        type: "manual"
+        remediation: |
+          Ensure that allowedCapabilities is not present in PSPs for the cluster unless
+          it is set to an empty array.
+        scored: false
+
+      - id: 5.2.9
+        text: "Minimize the admission of containers with capabilities assigned (Manual)"
+        type: "manual"
+        remediation: |
+          Review the use of capabilites in applications running on your cluster. Where a namespace
+          contains applicaions which do not require any Linux capabities to operate consider adding
+          a PSP which forbids the admission of containers which do not drop all capabilities.
+        scored: false
+
+  - id: 5.3
+    text: "Network Policies and CNI"
+    checks:
+      - id: 5.3.1
+        text: "Ensure that the CNI in use supports Network Policies (Manual)"
+        type: "manual"
+        remediation: |
+          If the CNI plugin in use does not support network policies, consideration should be given to
+          making use of a different plugin, or finding an alternate mechanism for restricting traffic
+          in the Kubernetes cluster.
+        scored: false
+
+      - id: 5.3.2
+        text: "Ensure that all Namespaces have Network Policies defined (Manual)"
+        type: "manual"
+        remediation: |
+          Follow the documentation and create NetworkPolicy objects as you need them.
+        scored: false
+
+  - id: 5.4
+    text: "Secrets Management"
+    checks:
+      - id: 5.4.1
+        text: "Prefer using secrets as files over secrets as environment variables (Manual)"
+        type: "manual"
+        remediation: |
+          if possible, rewrite application code to read secrets from mounted secret files, rather than
+          from environment variables.
+        scored: false
+
+      - id: 5.4.2
+        text: "Consider external secret storage (Manual)"
+        type: "manual"
+        remediation: |
+          Refer to the secrets management options offered by your cloud provider or a third-party
+          secrets management solution.
+        scored: false
+
+  - id: 5.5
+    text: "Extensible Admission Control"
+    checks:
+      - id: 5.5.1
+        text: "Configure Image Provenance using ImagePolicyWebhook admission controller (Manual)"
+        type: "manual"
+        remediation: |
+          Follow the Kubernetes documentation and setup image provenance.
+        scored: false
+
+  - id: 5.7
+    text: "General Policies"
+    checks:
+      - id: 5.7.1
+        text: "Create administrative boundaries between resources using namespaces (Manual)"
+        type: "manual"
+        remediation: |
+          Follow the documentation and create namespaces for objects in your deployment as you need
+          them.
+        scored: false
+
+      - id: 5.7.2
+        text: "Ensure that the seccomp profile is set to docker/default in your pod definitions (Manual)"
+        type: "manual"
+        remediation: |
+          Use security context to enable the docker/default seccomp profile in your pod definitions.
+          An example is as below:
+            securityContext:
+              seccompProfile:
+                type: RuntimeDefault
+        scored: false
+
+      - id: 5.7.3
+        text: "Apply Security Context to Your Pods and Containers (Manual)"
+        type: "manual"
+        remediation: |
+          Follow the Kubernetes documentation and apply security contexts to your pods. For a
+          suggested list of security contexts, you may refer to the CIS Security Benchmark for Docker
+          Containers.
+        scored: false
+
+      - id: 5.7.4
+        text: "The default namespace should not be used (Manual)"
+        type: "manual"
+        remediation: |
+          Ensure that namespaces are created to allow for appropriate segregation of Kubernetes
+          resources and that all new resources are created in a specific namespace.
+        scored: false

--- a/package/cfg/rke-cis-1.20-permissive/policies.yaml
+++ b/package/cfg/rke-cis-1.20-permissive/policies.yaml
@@ -1,6 +1,6 @@
 ---
 controls:
-version: "1.20"
+version: 1.20
 id: 5
 text: "Kubernetes Policies"
 type: "policies"
@@ -42,8 +42,16 @@ groups:
         scored: false
 
       - id: 5.1.5
-        text: "Ensure that default service accounts are not actively used. (Manual)"
-        type: "manual"
+        text: "Ensure that default service accounts are not actively used. (Automated)"
+        type: "skip"
+        audit: check_for_default_sa.sh
+        tests:
+          test_items:
+            - flag: "true"
+              compare:
+                op: eq
+                value: "true"
+              set: true
         remediation: |
           Create explicit service accounts wherever a Kubernetes workload requires specific access
           to the Kubernetes API server.
@@ -86,7 +94,7 @@ groups:
 
       - id: 5.2.2
         text: "Minimize the admission of containers wishing to share the host process ID namespace (Automated)"
-        type: "manual"
+        type: "skip"
         remediation: |
           Create a PSP as described in the Kubernetes documentation, ensuring that the
           .spec.hostPID field is omitted or set to false.
@@ -94,7 +102,7 @@ groups:
 
       - id: 5.2.3
         text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
-        type: "manual"
+        type: "skip"
         remediation: |
           Create a PSP as described in the Kubernetes documentation, ensuring that the
           .spec.hostIPC field is omitted or set to false.
@@ -102,7 +110,7 @@ groups:
 
       - id: 5.2.4
         text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
-        type: "manual"
+        type: "skip"
         remediation: |
           Create a PSP as described in the Kubernetes documentation, ensuring that the
           .spec.hostNetwork field is omitted or set to false.
@@ -110,7 +118,7 @@ groups:
 
       - id: 5.2.5
         text: "Minimize the admission of containers with allowPrivilegeEscalation (Automated)"
-        type: "manual"
+        type: "skip"
         remediation: |
           Create a PSP as described in the Kubernetes documentation, ensuring that the
           .spec.allowPrivilegeEscalation field is omitted or set to false.
@@ -164,7 +172,7 @@ groups:
 
       - id: 5.3.2
         text: "Ensure that all Namespaces have Network Policies defined (Manual)"
-        type: "manual"
+        type: "skip"
         remediation: |
           Follow the documentation and create NetworkPolicy objects as you need them.
         scored: false
@@ -231,7 +239,7 @@ groups:
 
       - id: 5.7.4
         text: "The default namespace should not be used (Manual)"
-        type: "manual"
+        type: "skip"
         remediation: |
           Ensure that namespaces are created to allow for appropriate segregation of Kubernetes
           resources and that all new resources are created in a specific namespace.


### PR DESCRIPTION
This PR introduces upstream [cis-1.20](https://github.com/aquasecurity/kube-bench/tree/main/cfg/cis-1.20) benchmark profiles for the security scan for rke1 cluster :

- `rke-cis-1.20-permissive`
- `rke-cis-1.20-hardened`


Linked Issue:
https://github.com/rancher/cis-operator/issues/135