### PR TITLE
Fix scan failures after updating kube-bench to v0.6.8 and Go version to 1.17

### DIFF
--- a/package/cfg/k3s-cis-1.20-hardened/etcd.yaml
+++ b/package/cfg/k3s-cis-1.20-hardened/etcd.yaml
@@ -32,8 +32,11 @@ groups:
         text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
         audit: "check_for_k3s_etcd.sh 2.2"
         tests:
+          bin_op: or
           test_items:
             - flag: "--client-cert-auth"
+              set: true
+            - flag: "client-cert-auth"
               env: "ETCD_CLIENT_CERT_AUTH"
               compare:
                 op: eq
@@ -89,8 +92,11 @@ groups:
         text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
         audit: "check_for_k3s_etcd.sh 2.5"
         tests:
+          bin_op: or
           test_items:
-            - flag: "--peer-client-cert-auth"
+            - flag: "--client-cert-auth"
+              set: true
+            - flag: "client-cert-auth"
               env: "ETCD_PEER_CLIENT_CERT_AUTH"
               compare:
                 op: eq

--- a/package/cfg/k3s-cis-1.20-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.20-hardened/master.yaml
@@ -227,7 +227,7 @@ groups:
 
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c permissions=%a $schedulerkubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -242,7 +242,7 @@ groups:
 
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
-        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c %U:%G $schedulerkubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c %U:%G /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
         tests:
           test_items:
             - flag: "root:root"
@@ -254,7 +254,7 @@ groups:
 
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c permissions=%a $controllermanagerkubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/controller.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/controller.kubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -285,7 +285,7 @@ groups:
 
       - id: 1.1.19
         text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
-        audit: "find /etc/kubernetes/pki/ | xargs stat -c %U:%G"
+        audit: "find /var/lib/rancher/k3s/server/tls | xargs stat -c %U:%G"
         use_multiple_values: true
         tests:
           test_items:
@@ -349,7 +349,7 @@ groups:
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'token-auth-file'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           test_items:
             - flag: "--token-auth-file"
@@ -549,7 +549,7 @@ groups:
 
       - id: 1.2.14
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'disable-admission-plugins'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           bin_op: or
           test_items:
@@ -602,7 +602,7 @@ groups:
 
       - id: 1.2.17
         text: "Ensure that the --insecure-bind-address argument is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'insecure-bind-address'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           test_items:
             - flag: "--insecure-bind-address"

--- a/package/cfg/k3s-cis-1.20-permissive/etcd.yaml
+++ b/package/cfg/k3s-cis-1.20-permissive/etcd.yaml
@@ -32,12 +32,16 @@ groups:
         text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
         audit: "check_for_k3s_etcd.sh 2.2"
         tests:
+          bin_op: or
           test_items:
             - flag: "--client-cert-auth"
+              set: true
+            - flag: "client-cert-auth"
               env: "ETCD_CLIENT_CERT_AUTH"
               compare:
                 op: eq
                 value: true
+              set: true
         remediation: |
           Edit the etcd pod specification file $etcdconf on the master
           node and set the below parameter.
@@ -89,12 +93,16 @@ groups:
         text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
         audit: "check_for_k3s_etcd.sh 2.5"
         tests:
+          bin_op: or
           test_items:
-            - flag: "--peer-client-cert-auth"
+            - flag: "--client-cert-auth"
+              set: true
+            - flag: "client-cert-auth"
               env: "ETCD_PEER_CLIENT_CERT_AUTH"
               compare:
                 op: eq
                 value: true
+              set: true
         remediation: |
           Edit the etcd pod specification file $etcdconf on the master
           node and set the below parameter.

--- a/package/cfg/k3s-cis-1.20-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.20-permissive/master.yaml
@@ -227,7 +227,7 @@ groups:
 
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c permissions=%a $schedulerkubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -242,7 +242,7 @@ groups:
 
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
-        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c %U:%G $schedulerkubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c %U:%G /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
         tests:
           test_items:
             - flag: "root:root"
@@ -254,7 +254,7 @@ groups:
 
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c permissions=%a $controllermanagerkubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/controller.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/controller.kubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -285,7 +285,7 @@ groups:
 
       - id: 1.1.19
         text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
-        audit: "find /etc/kubernetes/pki/ | xargs stat -c %U:%G"
+        audit: "find /var/lib/rancher/k3s/server/tls | xargs stat -c %U:%G"
         use_multiple_values: true
         tests:
           test_items:
@@ -530,7 +530,7 @@ groups:
 
       - id: 1.2.13
         text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'ServiceAccount'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           bin_op: or
           test_items:
@@ -549,7 +549,7 @@ groups:
 
       - id: 1.2.14
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'disable-admission-plugins'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           bin_op: or
           test_items:
@@ -567,7 +567,7 @@ groups:
 
       - id: 1.2.15
         text: "Ensure that the admission control plugin PodSecurityPolicy is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -602,7 +602,7 @@ groups:
 
       - id: 1.2.17
         text: "Ensure that the --insecure-bind-address argument is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'insecure-bind-address'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           test_items:
             - flag: "--insecure-bind-address"
@@ -662,7 +662,7 @@ groups:
 
       - id: 1.2.21
         text: "Ensure that the --audit-log-path argument is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-path'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           test_items:
             - flag: "--audit-log-path"
@@ -675,7 +675,7 @@ groups:
 
       - id: 1.2.22
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-maxage'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           test_items:
             - flag: "--audit-log-maxage"
@@ -690,7 +690,7 @@ groups:
 
       - id: 1.2.23
         text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-maxbackup'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           test_items:
             - flag: "--audit-log-maxbackup"
@@ -706,7 +706,7 @@ groups:
 
       - id: 1.2.24
         text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-maxsize'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           test_items:
             - flag: "--audit-log-maxsize"
@@ -722,7 +722,7 @@ groups:
 
       - id: 1.2.25
         text: "Ensure that the --request-timeout argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'request-timeout'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           bin_op: or
           test_items:
@@ -738,7 +738,7 @@ groups:
 
       - id: 1.2.26
         text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'service-account-lookup'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           bin_op: or
           test_items:

--- a/package/cfg/k3s-cis-1.20-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.20-permissive/master.yaml
@@ -568,6 +568,7 @@ groups:
       - id: 1.2.15
         text: "Ensure that the admission control plugin PodSecurityPolicy is set (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        type: "skip"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -663,6 +664,7 @@ groups:
       - id: 1.2.21
         text: "Ensure that the --audit-log-path argument is set (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        type: "skip"
         tests:
           test_items:
             - flag: "--audit-log-path"
@@ -676,6 +678,7 @@ groups:
       - id: 1.2.22
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        type: "skip"
         tests:
           test_items:
             - flag: "--audit-log-maxage"
@@ -691,6 +694,7 @@ groups:
       - id: 1.2.23
         text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        type: "skip"
         tests:
           test_items:
             - flag: "--audit-log-maxbackup"
@@ -707,6 +711,7 @@ groups:
       - id: 1.2.24
         text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        type: "skip"
         tests:
           test_items:
             - flag: "--audit-log-maxsize"

--- a/package/cfg/k3s-cis-1.20-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.20-permissive/node.yaml
@@ -194,7 +194,7 @@ groups:
     checks:
       - id: 4.2.1
         text: "Ensure that the anonymous-auth argument is set to false (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth' | grep -v grep"
+        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "anonymous-auth" | grep -v grep; else echo "--anonymous-auth=false"; fi'' '
         tests:
           test_items:
             - flag: "--anonymous-auth"
@@ -217,7 +217,7 @@ groups:
 
       - id: 4.2.2
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode' | grep -v grep"
+        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode" | grep -v grep; else echo "--authorization-mode=Webhook"; fi'' '
         tests:
           test_items:
             - flag: --authorization-mode
@@ -239,7 +239,7 @@ groups:
 
       - id: 4.2.3
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-apiserver'| tail -n1 | grep 'client-ca-file' | grep -v grep "
+        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file" | grep -v grep; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
         tests:
           test_items:
             - flag: --client-ca-file

--- a/package/cfg/k3s-cis-1.23-hardened/etcd.yaml
+++ b/package/cfg/k3s-cis-1.23-hardened/etcd.yaml
@@ -32,8 +32,11 @@ groups:
         text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
         audit: "check_for_k3s_etcd.sh 2.2"
         tests:
+          bin_op: or
           test_items:
             - flag: "--client-cert-auth"
+              set: true
+            - flag: "client-cert-auth"
               env: "ETCD_CLIENT_CERT_AUTH"
               compare:
                 op: eq
@@ -89,8 +92,11 @@ groups:
         text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
         audit: "check_for_k3s_etcd.sh 2.5"
         tests:
+          bin_op: or
           test_items:
-            - flag: "--peer-client-cert-auth"
+            - flag: "--client-cert-auth"
+              set: true
+            - flag: "client-cert-auth"
               env: "ETCD_PEER_CLIENT_CERT_AUTH"
               compare:
                 op: eq

--- a/package/cfg/k3s-cis-1.23-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.23-hardened/master.yaml
@@ -217,7 +217,7 @@ groups:
 
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c permissions=%a $schedulerkubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -232,7 +232,7 @@ groups:
 
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
-        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c %U:%G $schedulerkubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c %U:%G /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
         tests:
           test_items:
             - flag: "root:root"
@@ -244,7 +244,7 @@ groups:
 
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c permissions=%a $controllermanagerkubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/controller.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/controller.kubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -275,7 +275,7 @@ groups:
 
       - id: 1.1.19
         text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
-        audit: "find /etc/kubernetes/pki/ | xargs stat -c %U:%G"
+        audit: "find /var/lib/rancher/k3s/server/tls | xargs stat -c %U:%G"
         use_multiple_values: true
         tests:
           test_items:
@@ -339,7 +339,7 @@ groups:
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'token-auth-file'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           test_items:
             - flag: "--token-auth-file"
@@ -556,7 +556,7 @@ groups:
 
       - id: 1.2.15
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'disable-admission-plugins'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           bin_op: or
           test_items:

--- a/package/cfg/k3s-cis-1.23-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.23-hardened/node.yaml
@@ -422,7 +422,7 @@ groups:
       - id: 4.2.11
         text: "Ensure that the --rotate-certificates argument is not set to false (Manual)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --rotate-certificates

--- a/package/cfg/k3s-cis-1.23-permissive/etcd.yaml
+++ b/package/cfg/k3s-cis-1.23-permissive/etcd.yaml
@@ -32,12 +32,16 @@ groups:
         text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
         audit: "check_for_k3s_etcd.sh 2.2"
         tests:
+          bin_op: or
           test_items:
             - flag: "--client-cert-auth"
+              set: true
+            - flag: "client-cert-auth"
               env: "ETCD_CLIENT_CERT_AUTH"
               compare:
                 op: eq
                 value: true
+              set: true
         remediation: |
           Edit the etcd pod specification file $etcdconf on the master
           node and set the below parameter.
@@ -89,12 +93,16 @@ groups:
         text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
         audit: "check_for_k3s_etcd.sh 2.5"
         tests:
+          bin_op: or
           test_items:
-            - flag: "--peer-client-cert-auth"
+            - flag: "--client-cert-auth"
+              set: true
+            - flag: "client-cert-auth"
               env: "ETCD_PEER_CLIENT_CERT_AUTH"
               compare:
                 op: eq
                 value: true
+              set: true
         remediation: |
           Edit the etcd pod specification file $etcdconf on the master
           node and set the below parameter.

--- a/package/cfg/k3s-cis-1.23-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.23-permissive/master.yaml
@@ -217,7 +217,7 @@ groups:
 
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c permissions=%a $schedulerkubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -232,7 +232,7 @@ groups:
 
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
-        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c %U:%G $schedulerkubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c %U:%G /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
         tests:
           test_items:
             - flag: "root:root"
@@ -244,7 +244,7 @@ groups:
 
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c permissions=%a $controllermanagerkubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/controller.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/controller.kubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -275,7 +275,7 @@ groups:
 
       - id: 1.1.19
         text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
-        audit: "find /etc/kubernetes/pki/ | xargs stat -c %U:%G"
+        audit: "find /var/lib/rancher/k3s/server/tls | xargs stat -c %U:%G"
         use_multiple_values: true
         tests:
           test_items:
@@ -538,7 +538,7 @@ groups:
 
       - id: 1.2.14
         text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'ServiceAccount'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           bin_op: or
           test_items:
@@ -557,7 +557,7 @@ groups:
 
       - id: 1.2.15
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'disable-admission-plugins'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           bin_op: or
           test_items:
@@ -625,7 +625,7 @@ groups:
 
       - id: 1.2.19
         text: "Ensure that the --audit-log-path argument is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-path'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           test_items:
             - flag: "--audit-log-path"
@@ -638,7 +638,7 @@ groups:
 
       - id: 1.2.20
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-maxage'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           test_items:
             - flag: "--audit-log-maxage"
@@ -654,7 +654,7 @@ groups:
 
       - id: 1.2.21
         text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-maxbackup'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           test_items:
             - flag: "--audit-log-maxbackup"
@@ -670,7 +670,7 @@ groups:
 
       - id: 1.2.22
         text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-maxsize'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           test_items:
             - flag: "--audit-log-maxsize"
@@ -700,7 +700,7 @@ groups:
 
       - id: 1.2.24
         text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'service-account-lookup'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           bin_op: or
           test_items:
@@ -720,7 +720,7 @@ groups:
 
       - id: 1.2.25
         text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'service-account-key-file'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           test_items:
             - flag: "--service-account-key-file"

--- a/package/cfg/k3s-cis-1.23-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.23-permissive/master.yaml
@@ -626,6 +626,7 @@ groups:
       - id: 1.2.19
         text: "Ensure that the --audit-log-path argument is set (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        type: "skip"
         tests:
           test_items:
             - flag: "--audit-log-path"
@@ -639,6 +640,7 @@ groups:
       - id: 1.2.20
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        type: "skip"
         tests:
           test_items:
             - flag: "--audit-log-maxage"
@@ -655,6 +657,7 @@ groups:
       - id: 1.2.21
         text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        type: "skip"
         tests:
           test_items:
             - flag: "--audit-log-maxbackup"
@@ -671,6 +674,7 @@ groups:
       - id: 1.2.22
         text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        type: "skip"
         tests:
           test_items:
             - flag: "--audit-log-maxsize"
@@ -685,12 +689,10 @@ groups:
 
       - id: 1.2.25
         text: "Ensure that the --request-timeout argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'request-timeout'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        type: "skip"
         tests:
-          bin_op: or
           test_items:
-            - flag: "--request-timeout"
-              set: false
             - flag: "--request-timeout"
         remediation: |
           Edit the API server pod specification file $apiserverconf
@@ -721,6 +723,7 @@ groups:
       - id: 1.2.25
         text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        type: "skip"
         tests:
           test_items:
             - flag: "--service-account-key-file"

--- a/package/cfg/k3s-cis-1.23-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.23-permissive/node.yaml
@@ -193,7 +193,7 @@ groups:
     checks:
       - id: 4.2.1
         text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth' | grep -v grep"
+        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "anonymous-auth" | grep -v grep; else echo "--anonymous-auth=false"; fi'' '
         tests:
           test_items:
             - flag: "--anonymous-auth"
@@ -216,7 +216,7 @@ groups:
 
       - id: 4.2.2
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode' | grep -v grep"
+        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode" | grep -v grep; else echo "--authorization-mode=Webhook"; fi'' '
         tests:
           test_items:
             - flag: --authorization-mode
@@ -238,7 +238,7 @@ groups:
 
       - id: 4.2.3
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-apiserver'| tail -n1 | grep 'client-ca-file' | grep -v grep "
+        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file" | grep -v grep; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
         tests:
           test_items:
             - flag: --client-ca-file

--- a/package/cfg/k3s-cis-1.6-hardened/etcd.yaml
+++ b/package/cfg/k3s-cis-1.6-hardened/etcd.yaml
@@ -30,11 +30,15 @@ groups:
         text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
         audit: "check_for_k3s_etcd.sh 2.2"
         tests:
+          bin_op: or
           test_items:
             - flag: "--client-cert-auth"
+              set: true
+            - flag: "client-cert-auth"
               compare:
                 op: eq
                 value: true
+              set: true
         remediation: |
           Edit the etcd pod specification file $etcdconf on the master
           node and set the below parameter.
@@ -82,11 +86,15 @@ groups:
         text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
         audit: "check_for_k3s_etcd.sh 2.5"
         tests:
+          bin_op: or
           test_items:
             - flag: "--client-cert-auth"
+              set: true
+            - flag: "client-cert-auth"
               compare:
                 op: eq
                 value: true
+              set: true
         remediation: |
           Edit the etcd pod specification file $etcdconf on the master
           node and set the below parameter.

--- a/package/cfg/k3s-cis-1.6-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.6-hardened/master.yaml
@@ -212,7 +212,7 @@ groups:
 
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c permissions=%a $schedulerkubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -227,7 +227,7 @@ groups:
 
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
-        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c %U:%G $schedulerkubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c %U:%G /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
         tests:
           test_items:
             - flag: "root:root"
@@ -239,7 +239,7 @@ groups:
 
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c permissions=%a $controllermanagerkubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/controller.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/controller.kubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -270,7 +270,7 @@ groups:
 
       - id: 1.1.19
         text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
-        audit: "find /etc/kubernetes/pki/ | xargs stat -c %U:%G"
+        audit: "find /var/lib/rancher/k3s/server/tls | xargs stat -c %U:%G"
         use_multiple_values: true
         tests:
           test_items:
@@ -334,7 +334,7 @@ groups:
 
       - id: 1.2.2
         text: "Ensure that the --basic-auth-file argument is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'basic-auth-file'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           test_items:
             - flag: "--basic-auth-file"
@@ -347,7 +347,7 @@ groups:
 
       - id: 1.2.3
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'token-auth-file'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           test_items:
             - flag: "--token-auth-file"
@@ -547,7 +547,7 @@ groups:
 
       - id: 1.2.15
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'disable-admission-plugins'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           bin_op: or
           test_items:
@@ -600,7 +600,7 @@ groups:
 
       - id: 1.2.18
         text: "Ensure that the --insecure-bind-address argument is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'insecure-bind-address'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           test_items:
             - flag: "--insecure-bind-address"

--- a/package/cfg/k3s-cis-1.6-permissive/etcd.yaml
+++ b/package/cfg/k3s-cis-1.6-permissive/etcd.yaml
@@ -5,6 +5,26 @@ id: 2
 text: "Etcd Node Configuration"
 type: "etcd"
 groups:
+  - id: 1.1
+    text: "Etcd Node Configuration Files "
+    checks:
+      - id: 1.1.11
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
+        audit: "check_for_k3s_etcd.sh 1.1.11"
+        tests:
+          test_items:
+            - flag: "700"
+              compare:
+                op: eq
+                value: "700"
+              set: true
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the below command:
+          ps -ef | grep etcd
+          Run the below command (based on the etcd data directory found above). For example,
+          chmod 700 /var/lib/etcd
+        scored: true  
   - id: 2
     text: "Etcd Node Configuration Files"
     checks:
@@ -30,11 +50,15 @@ groups:
         text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
         audit: "check_for_k3s_etcd.sh 2.2"
         tests:
+          bin_op: or
           test_items:
             - flag: "--client-cert-auth"
+              set: true
+            - flag: "client-cert-auth"
               compare:
                 op: eq
                 value: true
+              set: true
         remediation: |
           Edit the etcd pod specification file $etcdconf on the master
           node and set the below parameter.
@@ -82,11 +106,15 @@ groups:
         text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
         audit: "check_for_k3s_etcd.sh 2.5"
         tests:
+          bin_op: or
           test_items:
             - flag: "--client-cert-auth"
+              set: true
+            - flag: "client-cert-auth"
               compare:
                 op: eq
                 value: true
+              set: true
         remediation: |
           Edit the etcd pod specification file $etcdconf on the master
           node and set the below parameter.

--- a/package/cfg/k3s-cis-1.6-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.6-permissive/master.yaml
@@ -548,6 +548,7 @@ groups:
       - id: 1.2.16
         text: "Ensure that the admission control plugin PodSecurityPolicy is set (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        type: "skip"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -643,6 +644,7 @@ groups:
       - id: 1.2.22
         text: "Ensure that the --audit-log-path argument is set (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-path'"
+        type: "skip"
         tests:
           test_items:
             - flag: "--audit-log-path"
@@ -656,6 +658,7 @@ groups:
       - id: 1.2.23
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-maxage'"
+        type: "skip"
         tests:
           test_items:
             - flag: "--audit-log-maxage"
@@ -671,6 +674,7 @@ groups:
       - id: 1.2.24
         text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-maxbackup'"
+        type: "skip"
         tests:
           test_items:
             - flag: "--audit-log-maxbackup"
@@ -687,6 +691,7 @@ groups:
       - id: 1.2.25
         text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-maxsize'"
+        type: "skip"
         tests:
           test_items:
             - flag: "--audit-log-maxsize"

--- a/package/cfg/k3s-cis-1.6-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.6-permissive/master.yaml
@@ -144,24 +144,6 @@ groups:
           chown root:root <path/to/cni/files>
         scored: false
 
-      - id: 1.1.11
-        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: "check_for_k3s_etcd.sh 1.1.11"
-        tests:
-          test_items:
-            - flag: "700"
-              compare:
-                op: eq
-                value: "700"
-              set: true
-        remediation: |
-          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-          from the below command:
-          ps -ef | grep etcd
-          Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
-        scored: true
-
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
         audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G
@@ -212,7 +194,7 @@ groups:
 
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c permissions=%a $schedulerkubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -227,7 +209,7 @@ groups:
 
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
-        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c %U:%G $schedulerkubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c %U:%G /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
         tests:
           test_items:
             - flag: "root:root"
@@ -239,7 +221,7 @@ groups:
 
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c permissions=%a $controllermanagerkubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/controller.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/controller.kubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -270,7 +252,7 @@ groups:
 
       - id: 1.1.19
         text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
-        audit: "find /etc/kubernetes/pki/ | xargs stat -c %U:%G"
+        audit: "find /var/lib/rancher/k3s/server/tls | xargs stat -c %U:%G"
         use_multiple_values: true
         tests:
           test_items:
@@ -334,7 +316,7 @@ groups:
 
       - id: 1.2.2
         text: "Ensure that the --basic-auth-file argument is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'basic-auth-file'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           test_items:
             - flag: "--basic-auth-file"
@@ -347,7 +329,7 @@ groups:
 
       - id: 1.2.3
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'token-auth-file'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           test_items:
             - flag: "--token-auth-file"
@@ -528,7 +510,7 @@ groups:
 
       - id: 1.2.14
         text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'ServiceAccount'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           bin_op: or
           test_items:
@@ -547,7 +529,7 @@ groups:
 
       - id: 1.2.15
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'disable-admission-plugins'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           bin_op: or
           test_items:
@@ -600,7 +582,7 @@ groups:
 
       - id: 1.2.18
         text: "Ensure that the --insecure-bind-address argument is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'insecure-bind-address'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           test_items:
             - flag: "--insecure-bind-address"
@@ -720,7 +702,7 @@ groups:
 
       - id: 1.2.26
         text: "Ensure that the --request-timeout argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'request-timeout'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           bin_op: or
           test_items:
@@ -736,7 +718,7 @@ groups:
 
       - id: 1.2.27
         text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'service-account-lookup'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           bin_op: or
           test_items:

--- a/package/cfg/k3s-cis-1.6-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.6-permissive/node.yaml
@@ -190,7 +190,7 @@ groups:
     checks:
       - id: 4.2.1
         text: "Ensure that the anonymous-auth argument is set to false (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth' | grep -v grep"
+        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "anonymous-auth" | grep -v grep; else echo "--anonymous-auth=false"; fi'' '
         tests:
           test_items:
             - flag: "--anonymous-auth"
@@ -198,7 +198,6 @@ groups:
               compare:
                 op: eq
                 value: false
-              set: true
         remediation: |
           If using a Kubelet config file, edit the file to set authentication: anonymous: enabled to
           false.
@@ -213,7 +212,7 @@ groups:
 
       - id: 4.2.2
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode' | grep -v grep"
+        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode" | grep -v grep; else echo "--authorization-mode=Webhook"; fi'' '
         tests:
           test_items:
             - flag: --authorization-mode
@@ -235,7 +234,7 @@ groups:
 
       - id: 4.2.3
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-apiserver'| tail -n1 | grep 'client-ca-file' | grep -v grep "
+        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file" | grep -v grep; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
         tests:
           test_items:
             - flag: --client-ca-file

--- a/package/cfg/rke-cis-1.20-hardened/etcd.yaml
+++ b/package/cfg/rke-cis-1.20-hardened/etcd.yaml
@@ -10,13 +10,14 @@ groups:
     checks:
     - id: 1.1.11
       text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-      audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c permissions=%a
+      audit: "stat -c %a /node/var/lib/etcd"
       tests:
         test_items:
-          - flag: "permissions"
+          - flag: "700"
             compare:
-              op: bitmask
+              op: eq
               value: "700"
+            set: true
       remediation: |
         On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
         from the below command:
@@ -26,10 +27,11 @@ groups:
       scored: true
     - id: 1.1.12
       text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
-      audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G
+      audit: "stat -c %U:%G /node/var/lib/etcd"
       tests:
         test_items:
           - flag: "etcd:etcd"
+            set: true
       remediation: |
         On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
         from the below command:
@@ -54,7 +56,7 @@ groups:
       scored: true
     - id: 1.1.20
       text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Automated) "
-      audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/!(*key).pem"
+      audit: "check_files_permissions.sh '/node/etc/kubernetes/ssl/!(*key).pem'"
       tests:
         test_items:
           - flag: "true"
@@ -69,7 +71,7 @@ groups:
       scored: true
     - id: 1.1.21
       text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Automated)"
-      audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/*key.pem 600"
+      audit: "check_files_permissions.sh '/node/etc/kubernetes/ssl/*key.pem' 600"
       tests:
         test_items:
           - flag: "true"

--- a/package/cfg/rke-cis-1.20-hardened/master.yaml
+++ b/package/cfg/rke-cis-1.20-hardened/master.yaml
@@ -252,7 +252,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Automated) "
-        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/!(*key).pem"
+        audit: "check_files_permissions.sh '/node/etc/kubernetes/ssl/!(*key).pem'"
         tests:
           test_items:
             - flag: "true"
@@ -268,7 +268,7 @@ groups:
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Automated)"
-        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/*key.pem 600"
+        audit: "check_files_permissions.sh '/node/etc/kubernetes/ssl/*key.pem' 600"
         tests:
           test_items:
             - flag: "true"

--- a/package/cfg/rke-cis-1.20-hardened/node.yaml
+++ b/package/cfg/rke-cis-1.20-hardened/node.yaml
@@ -98,7 +98,7 @@ groups:
 
       - id: 4.1.5
         text: "Ensure that the --kubeconfig kubelet.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c permissions=%a $kubeletkubeconfig; fi'' '
+        audit: '/bin/sh -c ''if test -e /node$kubeletkubeconfig; then stat -c permissions=%a /node$kubeletkubeconfig; fi'' '
         tests:
           test_items:
             - flag: "permissions"
@@ -194,7 +194,7 @@ groups:
       - id: 4.2.1
         text: "Ensure that the anonymous-auth argument is set to false (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: "--anonymous-auth"
@@ -217,7 +217,7 @@ groups:
       - id: 4.2.2
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --authorization-mode
@@ -239,7 +239,7 @@ groups:
       - id: 4.2.3
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --client-ca-file
@@ -259,7 +259,7 @@ groups:
       - id: 4.2.4
         text: "Ensure that the --read-only-port argument is set to 0 (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           bin_op: or
           test_items:
@@ -285,7 +285,7 @@ groups:
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -313,7 +313,7 @@ groups:
       - id: 4.2.6
         text: "Ensure that the --protect-kernel-defaults argument is set to true (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --protect-kernel-defaults
@@ -335,7 +335,7 @@ groups:
       - id: 4.2.7
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --make-iptables-util-chains
@@ -383,7 +383,7 @@ groups:
       - id: 4.2.9
         text: "Ensure that the --event-qps argument is set to 0 or a level which ensures appropriate event capture (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --event-qps
@@ -404,7 +404,7 @@ groups:
       - id: 4.2.10
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --tls-cert-file
@@ -428,7 +428,7 @@ groups:
       - id: 4.2.11
         text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --rotate-certificates
@@ -456,7 +456,7 @@ groups:
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Automated)"
         type: "skip"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: RotateKubeletServerCertificate
@@ -482,7 +482,7 @@ groups:
       - id: 4.2.13
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --tls-cipher-suites

--- a/package/cfg/rke-cis-1.20-permissive/etcd.yaml
+++ b/package/cfg/rke-cis-1.20-permissive/etcd.yaml
@@ -10,13 +10,14 @@ groups:
     checks:
     - id: 1.1.11
       text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-      audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c permissions=%a
+      audit: stat -c %a /node/var/lib/etcd
       tests:
         test_items:
-          - flag: "permissions"
+          - flag: "700"
             compare:
-              op: bitmask
+              op: eq
               value: "700"
+            set: true
       remediation: |
         On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
         from the below command:
@@ -27,10 +28,12 @@ groups:
 
     - id: 1.1.12
       text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
-      audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G
+      type: "skip"
+      audit: stat -c %U:%G /node/var/lib/etcd
       tests:
         test_items:
           - flag: "etcd:etcd"
+            set: true
       remediation: |
         On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
         from the below command:
@@ -56,7 +59,7 @@ groups:
       scored: true
     - id: 1.1.20
       text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Automated)"
-      audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/!(*key).pem"
+      audit: "check_files_permissions.sh '/node/etc/kubernetes/ssl/!(*key).pem'"
       use_multiple_values: true
       tests:
         test_items:
@@ -72,7 +75,7 @@ groups:
       scored: true
     - id: 1.1.21
       text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Automated)"
-      audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/*key.pem 600"
+      audit: "check_files_permissions.sh '/node/etc/kubernetes/ssl/*key.pem' 600"
       use_multiple_values: true
       tests:
         test_items:

--- a/package/cfg/rke-cis-1.20-permissive/etcd.yaml
+++ b/package/cfg/rke-cis-1.20-permissive/etcd.yaml
@@ -154,8 +154,7 @@ groups:
         scored: true
 
       - id: 2.4
-        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are
-        set as appropriate (Automated)"
+        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
         audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
         tests:
           bin_op: and

--- a/package/cfg/rke-cis-1.20-permissive/node.yaml
+++ b/package/cfg/rke-cis-1.20-permissive/node.yaml
@@ -70,7 +70,7 @@ groups:
 
       - id: 4.1.5
         text: "Ensure that the --kubeconfig kubelet.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c permissions=%a $kubeletkubeconfig; fi'' '
+        audit: '/bin/sh -c ''if test -e /node$kubeletkubeconfig; then stat -c permissions=%a node$kubeletkubeconfig; fi'' '
         tests:
           test_items:
             - flag: "permissions"
@@ -85,7 +85,7 @@ groups:
 
       - id: 4.1.6
         text: "Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root (Automated)"
-        audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c %U:%G $kubeletkubeconfig; fi'' '
+        audit: '/bin/sh -c ''if test -e /node$kubeletkubeconfig; then stat -c %U:%G /node$kubeletkubeconfig; fi'' '
         tests:
           test_items:
             - flag: root:root
@@ -156,7 +156,7 @@ groups:
       - id: 4.2.1
         text: "Ensure that the anonymous-auth argument is set to false (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: "--anonymous-auth"
@@ -179,7 +179,7 @@ groups:
       - id: 4.2.2
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --authorization-mode
@@ -201,7 +201,7 @@ groups:
       - id: 4.2.3
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --client-ca-file
@@ -221,7 +221,7 @@ groups:
       - id: 4.2.4
         text: "Ensure that the --read-only-port argument is set to 0 (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           bin_op: or
           test_items:
@@ -247,7 +247,7 @@ groups:
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -275,7 +275,7 @@ groups:
         text: "Ensure that the --protect-kernel-defaults argument is set to true (Automated)"
         type: "skip"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --protect-kernel-defaults
@@ -298,7 +298,7 @@ groups:
       - id: 4.2.7
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --make-iptables-util-chains
@@ -345,7 +345,7 @@ groups:
       - id: 4.2.9
         text: "Ensure that the --event-qps argument is set to 0 or a level which ensures appropriate event capture (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --event-qps
@@ -367,7 +367,7 @@ groups:
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
         type: "skip"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --tls-cert-file
@@ -392,7 +392,7 @@ groups:
       - id: 4.2.11
         text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --rotate-certificates
@@ -420,7 +420,7 @@ groups:
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
         type: "skip"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           bin_op: or
           test_items:
@@ -445,7 +445,7 @@ groups:
       - id: 4.2.13
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --tls-cipher-suites

--- a/package/cfg/rke-cis-1.23-hardened/etcd.yaml
+++ b/package/cfg/rke-cis-1.23-hardened/etcd.yaml
@@ -10,13 +10,14 @@ groups:
     checks:
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c permissions=%a
+        audit: "stat -c %a /node/var/lib/etcd"
         tests:
           test_items:
-            - flag: "permissions"
+            - flag: "700"
               compare:
-                op: bitmask
+                op: eq
                 value: "700"
+              set: true
         remediation: |
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.
@@ -26,10 +27,12 @@ groups:
 
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
-        audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G
+        type: "skip"
+        audit: "stat -c %U:%G /node/var/lib/etcd"
         tests:
           test_items:
             - flag: "etcd:etcd"
+              set: true
         remediation: |
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.
@@ -55,7 +58,7 @@ groups:
       
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Automated) "
-        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/!(*key).pem"
+        audit: "check_files_permissions.sh '/node/etc/kubernetes/ssl/!(*key).pem'"
         tests:
           test_items:
             - flag: "true"
@@ -71,7 +74,7 @@ groups:
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Automated)"
-        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/*key.pem 600"
+        audit: "check_files_permissions.sh '/node/etc/kubernetes/ssl/*key.pem' 600"
         tests:
           test_items:
             - flag: "true"

--- a/package/cfg/rke-cis-1.23-hardened/master.yaml
+++ b/package/cfg/rke-cis-1.23-hardened/master.yaml
@@ -233,7 +233,7 @@ groups:
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Automated)"
-        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/*key.pem 600"
+        audit: "check_files_permissions.sh '/node/etc/kubernetes/ssl/*key.pem' 600"
         tests:
           test_items:
             - flag: "true"

--- a/package/cfg/rke-cis-1.23-hardened/node.yaml
+++ b/package/cfg/rke-cis-1.23-hardened/node.yaml
@@ -98,7 +98,7 @@ groups:
 
       - id: 4.1.5
         text: "Ensure that the --kubeconfig kubelet.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c permissions=%a $kubeletkubeconfig; fi'' '
+        audit: '/bin/sh -c ''if test -e /node$kubeletkubeconfig; then stat -c permissions=%a /node$kubeletkubeconfig; fi'' '
         tests:
           test_items:
             - flag: "permissions"
@@ -194,7 +194,7 @@ groups:
       - id: 4.2.1
         text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: "--anonymous-auth"
@@ -217,7 +217,7 @@ groups:
       - id: 4.2.2
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --authorization-mode
@@ -239,7 +239,7 @@ groups:
       - id: 4.2.3
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --client-ca-file
@@ -259,7 +259,7 @@ groups:
       - id: 4.2.4
         text: "Ensure that the --read-only-port argument is set to 0 (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           bin_op: or
           test_items:
@@ -285,7 +285,7 @@ groups:
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -313,7 +313,7 @@ groups:
       - id: 4.2.6
         text: "Ensure that the --protect-kernel-defaults argument is set to true (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --protect-kernel-defaults
@@ -335,7 +335,7 @@ groups:
       - id: 4.2.7
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --make-iptables-util-chains
@@ -383,7 +383,7 @@ groups:
       - id: 4.2.9
         text: "Ensure that the --event-qps argument is set to 0 or a level which ensures appropriate event capture (Manual)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --event-qps
@@ -404,7 +404,7 @@ groups:
       - id: 4.2.10
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --tls-cert-file
@@ -428,7 +428,7 @@ groups:
       - id: 4.2.11
         text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --rotate-certificates
@@ -456,7 +456,7 @@ groups:
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Automated)"
         type: "skip"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: RotateKubeletServerCertificate
@@ -482,7 +482,7 @@ groups:
       - id: 4.2.13
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --tls-cipher-suites

--- a/package/cfg/rke-cis-1.23-permissive/etcd.yaml
+++ b/package/cfg/rke-cis-1.23-permissive/etcd.yaml
@@ -10,13 +10,14 @@ groups:
     checks:
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c permissions=%a
+        audit: stat -c %a /node/var/lib/etcd
         tests:
           test_items:
-            - flag: "permissions"
+            - flag: "700"
               compare:
-                op: bitmask
+                op: eq
                 value: "700"
+              set: true
         remediation: |
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.
@@ -26,10 +27,12 @@ groups:
 
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
-        audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G
+        type: "skip"
+        audit: "stat -c %U:%G /node/var/lib/etcd"
         tests:
           test_items:
             - flag: "etcd:etcd"
+              set: true
         remediation: |
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.
@@ -39,11 +42,14 @@ groups:
 
       - id: 1.1.19
         text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
-        audit: "find /etc/kubernetes/pki/ | xargs stat -c %U:%G"
-        use_multiple_values: true
+        audit: "check_files_owner_in_dir.sh /node/etc/kubernetes/ssl"
         tests:
           test_items:
-            - flag: "root:root"
+            - flag: "true"
+              compare:
+                op: eq
+                value: "true"
+              set: true
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example,

--- a/package/cfg/rke-cis-1.23-permissive/node.yaml
+++ b/package/cfg/rke-cis-1.23-permissive/node.yaml
@@ -71,7 +71,7 @@ groups:
 
       - id: 4.1.5
         text: "Ensure that the --kubeconfig kubelet.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c permissions=%a $kubeletkubeconfig; fi'' '
+        audit: '/bin/sh -c ''if test -e /node$kubeletkubeconfig; then stat -c permissions=%a /node$kubeletkubeconfig; fi'' '
         tests:
           test_items:
             - flag: "permissions"
@@ -86,7 +86,7 @@ groups:
 
       - id: 4.1.6
         text: "Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root (Automated)"
-        audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c %U:%G $kubeletkubeconfig; fi'' '
+        audit: '/bin/sh -c ''if test -e /node$kubeletkubeconfig; then stat -c %U:%G /node$kubeletkubeconfig; fi'' '
         tests:
           test_items:
             - flag: root:root
@@ -157,7 +157,7 @@ groups:
       - id: 4.2.1
         text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: "--anonymous-auth"
@@ -180,7 +180,7 @@ groups:
       - id: 4.2.2
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --authorization-mode
@@ -202,7 +202,7 @@ groups:
       - id: 4.2.3
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --client-ca-file
@@ -222,7 +222,7 @@ groups:
       - id: 4.2.4
         text: "Ensure that the --read-only-port argument is set to 0 (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           bin_op: or
           test_items:
@@ -248,7 +248,7 @@ groups:
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -276,7 +276,7 @@ groups:
         text: "Ensure that the --protect-kernel-defaults argument is set to true (Automated)"
         type: "skip"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --protect-kernel-defaults
@@ -299,7 +299,7 @@ groups:
       - id: 4.2.7
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --make-iptables-util-chains
@@ -346,7 +346,7 @@ groups:
       - id: 4.2.9
         text: "Ensure that the --event-qps argument is set to 0 or a level which ensures appropriate event capture (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --event-qps
@@ -368,7 +368,7 @@ groups:
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
         type: "skip"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --tls-cert-file
@@ -393,7 +393,7 @@ groups:
       - id: 4.2.11
         text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --rotate-certificates
@@ -421,7 +421,7 @@ groups:
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
         type: "skip"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           bin_op: or
           test_items:
@@ -446,7 +446,7 @@ groups:
       - id: 4.2.13
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --tls-cipher-suites

--- a/package/cfg/rke-cis-1.5-hardened/etcd.yaml
+++ b/package/cfg/rke-cis-1.5-hardened/etcd.yaml
@@ -61,7 +61,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Scored) "
-        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/!(*key).pem"
+        audit: "check_files_permissions.sh '/node/etc/kubernetes/ssl/!(*key).pem'"
         tests:
           test_items:
             - flag: "true"
@@ -77,7 +77,7 @@ groups:
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Scored)"
-        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/*key.pem 600"
+        audit: "check_files_permissions.sh '/node/etc/kubernetes/ssl/*key.pem' 600"
         tests:
           test_items:
             - flag: "true"

--- a/package/cfg/rke-cis-1.5-hardened/master.yaml
+++ b/package/cfg/rke-cis-1.5-hardened/master.yaml
@@ -509,7 +509,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Scored) "
-        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/!(*key).pem"
+        audit: "check_files_permissions.sh '/node/etc/kubernetes/ssl/!(*key).pem'"
         tests:
           test_items:
             - flag: "true"
@@ -525,7 +525,7 @@ groups:
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Scored)"
-        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/*key.pem 600"
+        audit: "check_files_permissions.sh '/node/etc/kubernetes/ssl/*key.pem' 600"
         tests:
           test_items:
             - flag: "true"

--- a/package/cfg/rke-cis-1.5-hardened/node.yaml
+++ b/package/cfg/rke-cis-1.5-hardened/node.yaml
@@ -331,7 +331,7 @@ groups:
       - id: 4.2.1
         text: "Ensure that the --anonymous-auth argument is set to false (Scored)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: "--anonymous-auth"
@@ -355,7 +355,7 @@ groups:
       - id: 4.2.2
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Scored)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --authorization-mode
@@ -378,7 +378,7 @@ groups:
       - id: 4.2.3
         text: "Ensure that the --client-ca-file argument is set as appropriate (Scored)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --client-ca-file
@@ -399,7 +399,7 @@ groups:
       - id: 4.2.4
         text: "Ensure that the --read-only-port argument is set to 0 (Scored)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: "--read-only-port"
@@ -422,7 +422,7 @@ groups:
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Scored)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -450,7 +450,7 @@ groups:
       - id: 4.2.6
         text: "Ensure that the --protect-kernel-defaults argument is set to true (Scored)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --protect-kernel-defaults
@@ -473,7 +473,7 @@ groups:
       - id: 4.2.7
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Scored) "
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --make-iptables-util-chains
@@ -522,7 +522,7 @@ groups:
       - id: 4.2.9
         text: "Ensure that the --event-qps argument is set to 0 or a level which ensures appropriate event capture (Not Scored)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --event-qps
@@ -544,7 +544,7 @@ groups:
       - id: 4.2.10
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Scored)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --tls-cert-file
@@ -570,7 +570,7 @@ groups:
       - id: 4.2.11
         text: "Ensure that the --rotate-certificates argument is not set to false (Scored)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --rotate-certificates
@@ -599,7 +599,7 @@ groups:
         text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Scored)"
         type: "skip"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: RotateKubeletServerCertificate
@@ -622,7 +622,7 @@ groups:
       - id: 4.2.13
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Not Scored)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --tls-cipher-suites

--- a/package/cfg/rke-cis-1.5-permissive/etcd.yaml
+++ b/package/cfg/rke-cis-1.5-permissive/etcd.yaml
@@ -62,7 +62,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Scored) "
-        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/!(*key).pem"
+        audit: "check_files_permissions.sh '/node/etc/kubernetes/ssl/!(*key).pem' "
         tests:
           test_items:
             - flag: "true"
@@ -78,7 +78,7 @@ groups:
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Scored)"
-        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/*key.pem 600"
+        audit: "check_files_permissions.sh '/node/etc/kubernetes/ssl/*key.pem' 600"
         tests:
           test_items:
             - flag: "true"

--- a/package/cfg/rke-cis-1.5-permissive/master.yaml
+++ b/package/cfg/rke-cis-1.5-permissive/master.yaml
@@ -509,7 +509,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Scored) "
-        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/!(*key).pem"
+        audit: "check_files_permissions.sh '/node/etc/kubernetes/ssl/!(*key).pem' "
         tests:
           test_items:
             - flag: "true"
@@ -525,7 +525,7 @@ groups:
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Scored)"
-        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/*key.pem 600"
+        audit: "check_files_permissions.sh '/node/etc/kubernetes/ssl/*key.pem' 600"
         tests:
           test_items:
             - flag: "true"

--- a/package/cfg/rke-cis-1.5-permissive/node.yaml
+++ b/package/cfg/rke-cis-1.5-permissive/node.yaml
@@ -331,7 +331,7 @@ groups:
       - id: 4.2.1
         text: "Ensure that the --anonymous-auth argument is set to false (Scored)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: "--anonymous-auth"
@@ -355,7 +355,7 @@ groups:
       - id: 4.2.2
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Scored)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --authorization-mode
@@ -378,7 +378,7 @@ groups:
       - id: 4.2.3
         text: "Ensure that the --client-ca-file argument is set as appropriate (Scored)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --client-ca-file
@@ -399,7 +399,7 @@ groups:
       - id: 4.2.4
         text: "Ensure that the --read-only-port argument is set to 0 (Scored)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: "--read-only-port"
@@ -422,7 +422,7 @@ groups:
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Scored)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -451,7 +451,7 @@ groups:
         text: "Ensure that the --protect-kernel-defaults argument is set to true (Scored)"
         type: "skip"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --protect-kernel-defaults
@@ -475,7 +475,7 @@ groups:
       - id: 4.2.7
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Scored) "
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --make-iptables-util-chains
@@ -524,7 +524,7 @@ groups:
       - id: 4.2.9
         text: "Ensure that the --event-qps argument is set to 0 or a level which ensures appropriate event capture (Not Scored)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --event-qps
@@ -547,7 +547,7 @@ groups:
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Scored)"
         type: "skip"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --tls-cert-file
@@ -575,7 +575,7 @@ groups:
       - id: 4.2.11
         text: "Ensure that the --rotate-certificates argument is not set to false (Scored)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --rotate-certificates
@@ -604,7 +604,7 @@ groups:
         text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Scored)"
         type: "skip"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: RotateKubeletServerCertificate
@@ -627,7 +627,7 @@ groups:
       - id: 4.2.13
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Not Scored)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --tls-cipher-suites

--- a/package/cfg/rke-cis-1.6-hardened/etcd.yaml
+++ b/package/cfg/rke-cis-1.6-hardened/etcd.yaml
@@ -10,7 +10,7 @@ groups:
     checks:
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: stat -c %a /node/var/lib/etcd
+        audit: "stat -c %a /node/var/lib/etcd"
         tests:
           test_items:
             - flag: "700"
@@ -27,7 +27,7 @@ groups:
 
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
-        audit: stat -c %U:%G /node/var/lib/etcd
+        audit: "stat -c %U:%G /node/var/lib/etcd"
         tests:
           test_items:
             - flag: "etcd:etcd"
@@ -61,7 +61,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Automated) "
-        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/!(*key).pem"
+        audit: "check_files_permissions.sh '/node/etc/kubernetes/ssl/!(*key).pem'"
         tests:
           test_items:
             - flag: "true"
@@ -77,7 +77,7 @@ groups:
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Automated)"
-        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/*key.pem 600"
+        audit: "check_files_permissions.sh '/node/etc/kubernetes/ssl/*key.pem' 600"
         tests:
           test_items:
             - flag: "true"

--- a/package/cfg/rke-cis-1.6-hardened/master.yaml
+++ b/package/cfg/rke-cis-1.6-hardened/master.yaml
@@ -233,7 +233,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Automated) "
-        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/!(*key).pem"
+        audit: "check_files_permissions.sh '/node/etc/kubernetes/ssl/!(*key).pem'"
         tests:
           test_items:
             - flag: "true"
@@ -249,7 +249,7 @@ groups:
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Automated)"
-        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/*key.pem 600"
+        audit: "check_files_permissions.sh '/node/etc/kubernetes/ssl/*key.pem' 600"
         tests:
           test_items:
             - flag: "true"

--- a/package/cfg/rke-cis-1.6-hardened/node.yaml
+++ b/package/cfg/rke-cis-1.6-hardened/node.yaml
@@ -98,7 +98,7 @@ groups:
 
       - id: 4.1.5
         text: "Ensure that the --kubeconfig kubelet.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c permissions=%a $kubeletkubeconfig; fi'' '
+        audit: '/bin/sh -c ''if test -e /node$kubeletkubeconfig; then stat -c permissions=%a /node$kubeletkubeconfig; fi'' '
         tests:
           test_items:
             - flag: "permissions"
@@ -194,7 +194,7 @@ groups:
       - id: 4.2.1
         text: "Ensure that the anonymous-auth argument is set to false (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: "--anonymous-auth"
@@ -217,7 +217,7 @@ groups:
       - id: 4.2.2
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --authorization-mode
@@ -239,7 +239,7 @@ groups:
       - id: 4.2.3
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --client-ca-file
@@ -259,7 +259,7 @@ groups:
       - id: 4.2.4
         text: "Ensure that the --read-only-port argument is set to 0 (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           bin_op: or
           test_items:
@@ -285,7 +285,7 @@ groups:
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -313,7 +313,7 @@ groups:
       - id: 4.2.6
         text: "Ensure that the --protect-kernel-defaults argument is set to true (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --protect-kernel-defaults
@@ -335,7 +335,7 @@ groups:
       - id: 4.2.7
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --make-iptables-util-chains
@@ -383,7 +383,7 @@ groups:
       - id: 4.2.9
         text: "Ensure that the --event-qps argument is set to 0 or a level which ensures appropriate event capture (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --event-qps
@@ -404,7 +404,7 @@ groups:
       - id: 4.2.10
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --tls-cert-file
@@ -428,7 +428,7 @@ groups:
       - id: 4.2.11
         text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --rotate-certificates
@@ -456,7 +456,7 @@ groups:
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Automated)"
         type: "skip"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: RotateKubeletServerCertificate
@@ -479,7 +479,7 @@ groups:
       - id: 4.2.13
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --tls-cipher-suites

--- a/package/cfg/rke-cis-1.6-permissive/etcd.yaml
+++ b/package/cfg/rke-cis-1.6-permissive/etcd.yaml
@@ -28,7 +28,7 @@ groups:
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
         type: "skip"
-        audit: stat -c %U:%G /node/var/lib/etcd
+        audit: "stat -c %U:%G /node/var/lib/etcd"
         tests:
           test_items:
             - flag: "etcd:etcd"
@@ -62,7 +62,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Automated) "
-        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/!(*key).pem"
+        audit: "check_files_permissions.sh '/node/etc/kubernetes/ssl/!(*key).pem' "
         tests:
           test_items:
             - flag: "true"
@@ -78,7 +78,7 @@ groups:
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Automated)"
-        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/*key.pem 600"
+        audit: "check_files_permissions.sh '/node/etc/kubernetes/ssl/*key.pem' 600"
         tests:
           test_items:
             - flag: "true"

--- a/package/cfg/rke-cis-1.6-permissive/master.yaml
+++ b/package/cfg/rke-cis-1.6-permissive/master.yaml
@@ -233,7 +233,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Automated) "
-        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/!(*key).pem"
+        audit: "check_files_permissions.sh '/node/etc/kubernetes/ssl/!(*key).pem' "
         tests:
           test_items:
             - flag: "true"
@@ -249,7 +249,7 @@ groups:
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Automated)"
-        audit: "check_files_permissions.sh /node/etc/kubernetes/ssl/*key.pem 600"
+        audit: "check_files_permissions.sh '/node/etc/kubernetes/ssl/*key.pem' 600"
         tests:
           test_items:
             - flag: "true"

--- a/package/cfg/rke-cis-1.6-permissive/node.yaml
+++ b/package/cfg/rke-cis-1.6-permissive/node.yaml
@@ -70,7 +70,7 @@ groups:
 
       - id: 4.1.5
         text: "Ensure that the --kubeconfig kubelet.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c permissions=%a $kubeletkubeconfig; fi'' '
+        audit: '/bin/sh -c ''if test -e /node$kubeletkubeconfig; then stat -c permissions=%a /node$kubeletkubeconfig; fi'' '
         tests:
           test_items:
             - flag: "permissions"
@@ -85,10 +85,14 @@ groups:
 
       - id: 4.1.6
         text: "Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root (Automated)"
-        audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c %U:%G $kubeletkubeconfig; fi'' '
+        audit: '/bin/sh -c ''if test -e /node$kubeletkubeconfig; then stat -c %U:%G /node$kubeletkubeconfig; fi'' '
         tests:
           test_items:
             - flag: root:root
+              set: true
+              compare:
+                op: eq
+                value: root:root
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
@@ -156,7 +160,7 @@ groups:
       - id: 4.2.1
         text: "Ensure that the anonymous-auth argument is set to false (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: "--anonymous-auth"
@@ -179,7 +183,7 @@ groups:
       - id: 4.2.2
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --authorization-mode
@@ -201,7 +205,7 @@ groups:
       - id: 4.2.3
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --client-ca-file
@@ -221,7 +225,7 @@ groups:
       - id: 4.2.4
         text: "Ensure that the --read-only-port argument is set to 0 (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           bin_op: or
           test_items:
@@ -247,7 +251,7 @@ groups:
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -275,7 +279,7 @@ groups:
         text: "Ensure that the --protect-kernel-defaults argument is set to true (Automated)"
         type: "skip"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --protect-kernel-defaults
@@ -298,7 +302,7 @@ groups:
       - id: 4.2.7
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --make-iptables-util-chains
@@ -346,7 +350,7 @@ groups:
       - id: 4.2.9
         text: "Ensure that the --event-qps argument is set to 0 or a level which ensures appropriate event capture (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --event-qps
@@ -368,7 +372,7 @@ groups:
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
         type: "skip"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --tls-cert-file
@@ -394,7 +398,7 @@ groups:
       - id: 4.2.11
         text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --rotate-certificates
@@ -422,7 +426,7 @@ groups:
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
         type: "skip"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: RotateKubeletServerCertificate
@@ -444,7 +448,7 @@ groups:
       - id: 4.2.13
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --tls-cipher-suites

--- a/package/cfg/rke2-cis-1.20-hardened/etcd.yaml
+++ b/package/cfg/rke2-cis-1.20-hardened/etcd.yaml
@@ -42,7 +42,7 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c permissions=%a
+        audit: stat -c permissions=%a /var/lib/rancher/rke2/server/db/etcd
         tests:
           test_items:
             - flag: "permissions"

--- a/package/cfg/rke2-cis-1.20-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.20-hardened/master.yaml
@@ -10,13 +10,14 @@ groups:
     checks:
       - id: 1.1.1
         text: "Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Automated)"
-        audit: "stat -c %a /var/lib/rancher/rke2/agent/pod-manifests/kube-apiserver.yaml"
+        audit: "stat -c permissions=%a /var/lib/rancher/rke2/agent/pod-manifests/kube-apiserver.yaml"
         tests:
           test_items:
             - flag: "permissions"
               compare:
                 op: bitmask
                 value: "644"
+              set: true
         remediation: |
           Run the below command (based on the file location on your system) on the
           master node.
@@ -73,13 +74,14 @@ groups:
 
       - id: 1.1.5
         text: "Ensure that the scheduler pod specification file permissions are set to 644 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c %a $schedulerconf; fi'"
+        audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c permissions=%a $schedulerconf; fi'"
         tests:
           test_items:
             - flag: "permissions"
               compare:
                 op: eq
                 value: "644"
+              set: true  
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
@@ -134,7 +136,7 @@ groups:
 
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: stat -c %a /var/lib/rancher/rke2/server/cred/admin.kubeconfig
+        audit: stat -c permissions=%a /var/lib/rancher/rke2/server/cred/admin.kubeconfig
         tests:
           test_items:
             - flag: "permissions"
@@ -165,7 +167,7 @@ groups:
 
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: "stat -c %a /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig"
+        audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig"
         tests:
           test_items:
             - flag: "permissions"
@@ -196,7 +198,7 @@ groups:
 
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: "stat -c %a /var/lib/rancher/rke2/server/cred/controller.kubeconfig"
+        audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/cred/controller.kubeconfig"
         tests:
           test_items:
             - flag: "permissions"

--- a/package/cfg/rke2-cis-1.20-hardened/node.yaml
+++ b/package/cfg/rke2-cis-1.20-hardened/node.yaml
@@ -11,12 +11,14 @@ groups:
       - id: 4.1.1
         text: "Ensure that the kubelet service file permissions are set to 644 or more restrictive (Automated)"
         audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c permissions=%a $kubeletsvc; fi'' '
+        type: "skip"
         tests:
           test_items:
             - flag: "permissions"
               compare:
                 op: bitmask
                 value: "644"
+              set: true  
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
@@ -266,9 +268,10 @@ groups:
               compare:
                 op: noteq
                 value: 0
+              set: true
             - flag: --streaming-connection-idle-timeout
               path: '{.streamingConnectionIdleTimeout}'
-              set: true
+              set: false
           bin_op: or
         remediation: |
           If using a Kubelet config file, edit the file to set streamingConnectionIdleTimeout to a

--- a/package/cfg/rke2-cis-1.20-permissive/etcd.yaml
+++ b/package/cfg/rke2-cis-1.20-permissive/etcd.yaml
@@ -42,13 +42,14 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: stat -c %a /var/lib/rancher/rke2/server/db/etcd
+        audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/db/etcd"
         tests:
           test_items:
             - flag: "permissions"
               compare:
                 op: bitmask
                 value: "700"
+              set: true  
         remediation: |
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the below command:
@@ -60,7 +61,7 @@ groups:
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
         type: "skip"
-        audit: stat -c %U:%G /var/lib/rancher/rke2/server/db/etcd
+        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/db/etcd"
         tests:
           test_items:
             - flag: "etcd:etcd"
@@ -92,6 +93,7 @@ groups:
           --cert-file=</path/to/ca-file>
           --key-file=</path/to/key-file>
         scored: true
+        type: "skip"
 
       - id: 2.2
         text: "Ensure that the --client-cert-auth argument is set to true (Automated)"

--- a/package/cfg/rke2-cis-1.20-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.20-permissive/master.yaml
@@ -10,13 +10,14 @@ groups:
     checks:
       - id: 1.1.1
         text: "Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Automated)"
-        audit: "stat -c %a /var/lib/rancher/rke2/agent/pod-manifests/kube-apiserver.yaml"
+        audit: "stat -c permissions=%a /var/lib/rancher/rke2/agent/pod-manifests/kube-apiserver.yaml"
         tests:
           test_items:
             - flag: "permissions"
               compare:
                 op: eq
                 value: "644"
+              set: true  
         remediation: |
           Run the below command (based on the file location on your system) on the
           master node.
@@ -136,12 +137,12 @@ groups:
 
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: stat -c %a /var/lib/rancher/rke2/server/cred/admin.kubeconfig
+        audit: stat -c permissions=%a /var/lib/rancher/rke2/server/cred/admin.kubeconfig
         tests:
           test_items:
-            - flag: "644"
+            - flag: "permissions"
               compare:
-                op: eq
+                op: bitmask
                 value: "644"
               set: true
         remediation: |

--- a/package/cfg/rke2-cis-1.20-permissive/node.yaml
+++ b/package/cfg/rke2-cis-1.20-permissive/node.yaml
@@ -11,6 +11,7 @@ groups:
       - id: 4.1.1
         text: "Ensure that the kubelet service file permissions are set to 644 or more restrictive (Automated)"
         audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c permissions=%a $kubeletsvc; fi'' '
+        type: "skip"
         tests:
           test_items:
             - flag: "permissions"
@@ -284,12 +285,17 @@ groups:
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/cat $kubeletconf"
         tests:
-          test_items:
+          bin_op: or
+          test_items:          
             - flag: --protect-kernel-defaults
               path: '{.protectKernelDefaults}'
               compare:
                 op: eq
-                value: true
+                value: true                
+              set: true
+            - flag: --protect-kernel-defaults
+              path: '{.protectKernelDefaults}'
+              set: false
         remediation: |
           If using a Kubelet config file, edit the file to set protectKernelDefaults: true.
           If using command line arguments, edit the kubelet service file

--- a/package/cfg/rke2-cis-1.23-hardened/etcd.yaml
+++ b/package/cfg/rke2-cis-1.23-hardened/etcd.yaml
@@ -42,7 +42,7 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c permissions=%a
+        audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/db/etcd"
         tests:
           test_items:
             - flag: "permissions"
@@ -58,7 +58,7 @@ groups:
 
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
-        audit: stat -c %U:%G /var/lib/rancher/rke2/server/db/etcd
+        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/db/etcd"
         tests:
           test_items:
             - flag: "etcd:etcd"

--- a/package/cfg/rke2-cis-1.23-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.23-hardened/master.yaml
@@ -129,14 +129,14 @@ groups:
         scored: false
 
       - id: 1.1.13
-        text: "Ensure that the admin.conf file permissions are set to 600 or more restrictive (Automated)"
+        text: "Ensure that the admin.conf file permissions are set to 644 or more restrictive (Automated)"
         audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/cred/admin.kubeconfig"
         tests:
           test_items:
             - flag: "permissions"
               compare:
                 op: bitmask
-                value: "600"
+                value: "644"
               set: true  
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.

--- a/package/cfg/rke2-cis-1.23-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.23-hardened/master.yaml
@@ -10,13 +10,14 @@ groups:
     checks:
       - id: 1.1.1
         text: "Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Automated)"
-        audit: "stat -c %a /var/lib/rancher/rke2/agent/pod-manifests/kube-apiserver.yaml"
+        audit: "stat -c permissions=%a /var/lib/rancher/rke2/agent/pod-manifests/kube-apiserver.yaml"
         tests:
           test_items:
             - flag: "permissions"
               compare:
                 op: bitmask
                 value: "644"
+              set: true
         remediation: |
           Run the below command (based on the file location on your system) on the
           control plane node.
@@ -70,13 +71,14 @@ groups:
 
       - id: 1.1.5
         text: "Ensure that the scheduler pod specification file permissions are set to 644 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c %a $schedulerconf; fi'"
+        audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c permissions=%a $schedulerconf; fi'"
         tests:
           test_items:
             - flag: "permissions"
               compare:
                 op: eq
                 value: "644"
+              set: true  
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chmod 644 $schedulerconf
@@ -128,13 +130,14 @@ groups:
 
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: stat -c %a /var/lib/rancher/rke2/server/cred/admin.kubeconfig
+        audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/cred/admin.kubeconfig"
         tests:
           test_items:
             - flag: "permissions"
               compare:
                 op: bitmask
                 value: "600"
+              set: true  
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chmod 600 /etc/kubernetes/admin.conf
@@ -157,7 +160,7 @@ groups:
 
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: "stat -c %a /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig"
+        audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig"
         tests:
           test_items:
             - flag: "permissions"
@@ -188,7 +191,7 @@ groups:
 
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: "stat -c %a /var/lib/rancher/rke2/server/cred/controller.kubeconfig"
+        audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/cred/controller.kubeconfig"
         tests:
           test_items:
             - flag: "permissions"

--- a/package/cfg/rke2-cis-1.23-hardened/node.yaml
+++ b/package/cfg/rke2-cis-1.23-hardened/node.yaml
@@ -11,12 +11,14 @@ groups:
       - id: 4.1.1
         text: "Ensure that the kubelet service file permissions are set to 644 or more restrictive (Automated)"
         audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c permissions=%a $kubeletsvc; fi'' '
+        type: "skip"
         tests:
           test_items:
             - flag: "permissions"
               compare:
                 op: bitmask
                 value: "644"
+              set: true  
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example, chmod 644 $kubeletsvc
@@ -265,9 +267,10 @@ groups:
               compare:
                 op: noteq
                 value: 0
+              set: true
             - flag: --streaming-connection-idle-timeout
               path: '{.streamingConnectionIdleTimeout}'
-              set: true
+              set: false
           bin_op: or
         remediation: |
           If using a Kubelet config file, edit the file to set `streamingConnectionIdleTimeout` to a

--- a/package/cfg/rke2-cis-1.23-permissive/etcd.yaml
+++ b/package/cfg/rke2-cis-1.23-permissive/etcd.yaml
@@ -42,13 +42,14 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: stat -c %a /var/lib/rancher/rke2/server/db/etcd
+        audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/db/etcd"
         tests:
           test_items:
             - flag: "permissions"
               compare:
                 op: bitmask
                 value: "700"
+              set: true
         remediation: |
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.
@@ -59,7 +60,7 @@ groups:
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
         type: "skip"
-        audit: stat -c %U:%G /var/lib/rancher/rke2/server/db/etcd
+        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/db/etcd"
         tests:
           test_items:
             - flag: "etcd:etcd"
@@ -90,6 +91,7 @@ groups:
           --cert-file=</path/to/ca-file>
           --key-file=</path/to/key-file>
         scored: true
+        type: "skip"
 
       - id: 2.2
         text: "Ensure that the --client-cert-auth argument is set to true (Automated)"

--- a/package/cfg/rke2-cis-1.23-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.23-permissive/master.yaml
@@ -130,14 +130,14 @@ groups:
         scored: false
 
       - id: 1.1.13
-        text: "Ensure that the admin.conf file permissions are set to 600 or more restrictive (Automated)"
+        text: "Ensure that the admin.conf file permissions are set to 644 or more restrictive (Automated)"
         audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/cred/admin.kubeconfig"
         tests:
           test_items:
             - flag: "permissions"
               compare:
                 op: bitmask
-                value: "600"
+                value: "644"
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.

--- a/package/cfg/rke2-cis-1.23-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.23-permissive/master.yaml
@@ -10,13 +10,14 @@ groups:
     checks:
       - id: 1.1.1
         text: "Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Automated)"
-        audit: "stat -c %a /var/lib/rancher/rke2/agent/pod-manifests/kube-apiserver.yaml"
+        audit: "stat -c permissions=%a /var/lib/rancher/rke2/agent/pod-manifests/kube-apiserver.yaml"
         tests:
           test_items:
             - flag: "permissions"
               compare:
                 op: eq
                 value: "644"
+              set: true  
         remediation: |
           Run the below command (based on the file location on your system) on the
           control plane node.
@@ -130,13 +131,14 @@ groups:
 
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: stat -c %a /var/lib/rancher/rke2/server/cred/admin.kubeconfig
+        audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/cred/admin.kubeconfig"
         tests:
           test_items:
             - flag: "permissions"
               compare:
                 op: bitmask
                 value: "600"
+              set: true
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chmod 600 /etc/kubernetes/admin.conf

--- a/package/cfg/rke2-cis-1.23-permissive/node.yaml
+++ b/package/cfg/rke2-cis-1.23-permissive/node.yaml
@@ -11,6 +11,7 @@ groups:
       - id: 4.1.1
         text: "Ensure that the kubelet service file permissions are set to 644 or more restrictive (Automated)"
         audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c permissions=%a $kubeletsvc; fi'' '
+        type: "skip"
         tests:
           test_items:
             - flag: "permissions"
@@ -283,12 +284,17 @@ groups:
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/cat $kubeletconf"
         tests:
-          test_items:
+          bin_op: or
+          test_items:          
             - flag: --protect-kernel-defaults
               path: '{.protectKernelDefaults}'
               compare:
                 op: eq
-                value: true
+                value: true                
+              set: true
+            - flag: --protect-kernel-defaults
+              path: '{.protectKernelDefaults}'
+              set: false
         remediation: |
           If using a Kubelet config file, edit the file to set `protectKernelDefaults` to `true`.
           If using command line arguments, edit the kubelet service file

--- a/package/cfg/rke2-cis-1.5-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.5-hardened/master.yaml
@@ -127,12 +127,12 @@ groups:
 
     - id: 1.1.13
       text: "Ensure that the admin.conf file permissions are set to 644 or more restrictive (Scored)"
-      audit: stat -c %a /var/lib/rancher/rke2/server/cred/admin.kubeconfig
+      audit: stat -c permissions=%a /var/lib/rancher/rke2/server/cred/admin.kubeconfig
       tests:
         test_items:
-          - flag: "644"
+          - flag: "permissions"
             compare:
-              op: eq
+              op: bitmask
               value: "644"
             set: true
       remediation: |
@@ -239,7 +239,7 @@ groups:
 
     - id: 1.1.20
       text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Manual) "
-      audit: "check_files_permissions.sh /var/lib/rancher/rke2/server/tls/*.crt 644"
+      audit: "check_files_permissions.sh '/var/lib/rancher/rke2/server/tls/*.crt' 644"
       use_multiple_values: true
       tests:
         test_items:
@@ -256,7 +256,7 @@ groups:
 
     - id: 1.1.21
       text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Scored)"
-      audit: "check_files_permissions.sh /var/lib/rancher/rke2/server/tls/*.key 600"
+      audit: "check_files_permissions.sh '/var/lib/rancher/rke2/server/tls/*.key' 600"
       tests:
         test_items:
           - flag: "true"

--- a/package/cfg/rke2-cis-1.5-hardened/node.yaml
+++ b/package/cfg/rke2-cis-1.5-hardened/node.yaml
@@ -169,10 +169,10 @@ groups:
 
     - id: 4.1.7
       text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Manual)"
-      audit: "stat -c %a /var/lib/rancher/rke2/server/tls/server-ca.crt"
+      audit: "check_cafile_permissions.sh"
       tests:
         test_items:
-          - flag: "644"
+          - flag: "permissions"
             compare:
               op: bitmask
               value: "644"
@@ -180,7 +180,7 @@ groups:
       remediation: |
         Run the following command to modify the file permissions of the
         --client-ca-file chmod 644 <filename>
-      scored: false
+      scored: true
 
     - id: 4.1.8
       text: "Ensure that the client certificate authorities file ownership is set to root:root (Scored)"
@@ -353,6 +353,7 @@ groups:
       audit: "/bin/ps -fC $kubeletbin"
       audit_config: "/bin/cat $kubeletconf"
       tests:
+        bin_op: or
         test_items:
           - flag: --protect-kernel-defaults
             path: '{.protectKernelDefaults}'
@@ -360,6 +361,9 @@ groups:
             compare:
               op: eq
               value: true
+          - flag: --protect-kernel-defaults
+            path: '{.protectKernelDefaults}'
+            set: false              
       remediation: |
         If using a Kubelet config file, edit the file to set protectKernelDefaults: true.
         If using command line arguments, edit the kubelet service file

--- a/package/cfg/rke2-cis-1.5-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.5-permissive/master.yaml
@@ -127,12 +127,12 @@ groups:
 
     - id: 1.1.13
       text: "Ensure that the admin.conf file permissions are set to 644 or more restrictive (Scored)"
-      audit: stat -c %a /var/lib/rancher/rke2/server/cred/admin.kubeconfig
+      audit: stat -c permissions=%a /var/lib/rancher/rke2/server/cred/admin.kubeconfig
       tests:
         test_items:
-          - flag: "644"
+          - flag: "permissions"
             compare:
-              op: eq
+              op: bitmask
               value: "644"
             set: true
       remediation: |
@@ -256,7 +256,7 @@ groups:
 
     - id: 1.1.21
       text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Scored)"
-      audit: "check_files_permissions.sh /var/lib/rancher/rke2/server/tls/*.key 600"
+      audit: "check_files_permissions.sh '/var/lib/rancher/rke2/server/tls/*.key' 600"
       tests:
         test_items:
           - flag: "true"

--- a/package/cfg/rke2-cis-1.5-permissive/node.yaml
+++ b/package/cfg/rke2-cis-1.5-permissive/node.yaml
@@ -169,10 +169,10 @@ groups:
 
     - id: 4.1.7
       text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Manual)"
-      audit: "stat -c %a /var/lib/rancher/rke2/server/tls/server-ca.crt"
+      audit: "check_cafile_permissions.sh"
       tests:
         test_items:
-          - flag: "644"
+          - flag: "permissions"
             compare:
               op: bitmask
               value: "644"
@@ -180,7 +180,7 @@ groups:
       remediation: |
         Run the following command to modify the file permissions of the
         --client-ca-file chmod 644 <filename>
-      scored: false
+      scored: true
 
     - id: 4.1.8
       text: "Ensure that the client certificate authorities file ownership is set to root:root (Scored)"

--- a/package/cfg/rke2-cis-1.6-hardened/etcd.yaml
+++ b/package/cfg/rke2-cis-1.6-hardened/etcd.yaml
@@ -42,7 +42,7 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: stat -c %a /var/lib/rancher/rke2/server/db/etcd
+        audit: stat -c permissions=%a /var/lib/rancher/rke2/server/db/etcd
         tests:
           test_items:
             - flag: "permissions"

--- a/package/cfg/rke2-cis-1.6-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.6-hardened/master.yaml
@@ -10,13 +10,14 @@ groups:
     checks:
       - id: 1.1.1
         text: "Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Automated)"
-        audit: "stat -c %a /var/lib/rancher/rke2/agent/pod-manifests/kube-apiserver.yaml"
+        audit: "stat -c permissions=%a /var/lib/rancher/rke2/agent/pod-manifests/kube-apiserver.yaml"
         tests:
           test_items:
             - flag: "permissions"
               compare:
                 op: bitmask
                 value: "644"
+              set: true
         remediation: |
           Run the below command (based on the file location on your system) on the
           master node.
@@ -73,13 +74,14 @@ groups:
 
       - id: 1.1.5
         text: "Ensure that the scheduler pod specification file permissions are set to 644 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c %a $schedulerconf; fi'"
+        audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c permissions=%a $schedulerconf; fi'"
         tests:
           test_items:
             - flag: "permissions"
               compare:
                 op: eq
                 value: "644"
+              set: true  
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
@@ -121,7 +123,7 @@ groups:
 
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: stat -c %a /var/lib/rancher/rke2/server/cred/admin.kubeconfig
+        audit: stat -c permissions=%a /var/lib/rancher/rke2/server/cred/admin.kubeconfig
         tests:
           test_items:
             - flag: "permissions"
@@ -152,7 +154,7 @@ groups:
 
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: "stat -c %a /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig"
+        audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig"
         tests:
           test_items:
             - flag: "permissions"
@@ -183,7 +185,7 @@ groups:
 
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: "stat -c %a /var/lib/rancher/rke2/server/cred/controller.kubeconfig"
+        audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/cred/controller.kubeconfig"
         tests:
           test_items:
             - flag: "permissions"
@@ -231,7 +233,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Manual)"
-        audit: "check_files_permissions.sh /var/lib/rancher/rke2/server/tls/*.crt 644"
+        audit: "check_files_permissions.sh '/var/lib/rancher/rke2/server/tls/*.crt' 644"
         use_multiple_values: true
         tests:
           test_items:
@@ -248,7 +250,7 @@ groups:
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "check_files_permissions.sh /var/lib/rancher/rke2/server/tls/*.key 600"
+        audit: "check_files_permissions.sh '/var/lib/rancher/rke2/server/tls/*.key' 600"
         use_multiple_values: true
         tests:
           test_items:

--- a/package/cfg/rke2-cis-1.6-hardened/node.yaml
+++ b/package/cfg/rke2-cis-1.6-hardened/node.yaml
@@ -11,12 +11,14 @@ groups:
       - id: 4.1.1
         text: "Ensure that the kubelet service file permissions are set to 644 or more restrictive (Automated)"
         audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c permissions=%a $kubeletsvc; fi'' '
+        type: "skip"
         tests:
           test_items:
             - flag: "permissions"
               compare:
                 op: bitmask
                 value: "644"
+              set: true  
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
@@ -104,10 +106,10 @@ groups:
 
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Manual)"
-        audit: "stat -c %a /var/lib/rancher/rke2/server/tls/server-ca.crt"
+        audit: "check_cafile_permissions.sh"
         tests:
           test_items:
-            - flag: "644"
+            - flag: "permissions"
               compare:
                 op: bitmask
                 value: "644"
@@ -115,7 +117,7 @@ groups:
         remediation: |
           Run the following command to modify the file permissions of the
           --client-ca-file chmod 644 <filename>
-        scored: false
+        scored: true
 
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Automated)"
@@ -265,9 +267,10 @@ groups:
               compare:
                 op: noteq
                 value: 0
+              set: true
             - flag: --streaming-connection-idle-timeout
               path: '{.streamingConnectionIdleTimeout}'
-              set: true
+              set: false
           bin_op: or
         remediation: |
           If using a Kubelet config file, edit the file to set streamingConnectionIdleTimeout to a
@@ -286,12 +289,17 @@ groups:
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/cat $kubeletconf"
         tests:
+          bin_op: or
           test_items:
             - flag: --protect-kernel-defaults
               path: '{.protectKernelDefaults}'
               compare:
                 op: eq
                 value: true
+              set: true
+            - flag: --protect-kernel-defaults
+              path: '{.protectKernelDefaults}'
+              set: false              
         remediation: |
           If using a Kubelet config file, edit the file to set protectKernelDefaults: true.
           If using command line arguments, edit the kubelet service file

--- a/package/cfg/rke2-cis-1.6-hardened/policies.yaml
+++ b/package/cfg/rke2-cis-1.6-hardened/policies.yaml
@@ -209,7 +209,7 @@ groups:
           If the CNI plugin in use does not support network policies, consideration should be given to
           making use of a different plugin, or finding an alternate mechanism for restricting traffic
           in the Kubernetes cluster.
-        scored: True
+        scored: true
 
       - id: 5.3.2
         text: "Ensure that all Namespaces have Network Policies defined (Automated)"

--- a/package/cfg/rke2-cis-1.6-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.6-permissive/master.yaml
@@ -10,13 +10,14 @@ groups:
     checks:
       - id: 1.1.1
         text: "Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Automated)"
-        audit: "stat -c %a /var/lib/rancher/rke2/agent/pod-manifests/kube-apiserver.yaml"
+        audit: "stat -c permissions=%a /var/lib/rancher/rke2/agent/pod-manifests/kube-apiserver.yaml"
         tests:
           test_items:
             - flag: "permissions"
               compare:
                 op: eq
                 value: "644"
+              set: true  
         remediation: |
           Run the below command (based on the file location on your system) on the
           master node.
@@ -137,12 +138,12 @@ groups:
 
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: stat -c %a /var/lib/rancher/rke2/server/cred/admin.kubeconfig
+        audit: stat -c permissions=%a /var/lib/rancher/rke2/server/cred/admin.kubeconfig
         tests:
           test_items:
-            - flag: "644"
+            - flag: "permissions"
               compare:
-                op: eq
+                op: bitmask
                 value: "644"
               set: true
         remediation: |
@@ -267,7 +268,7 @@ groups:
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "check_files_permissions.sh /var/lib/rancher/rke2/server/tls/*.key 600"
+        audit: "check_files_permissions.sh '/var/lib/rancher/rke2/server/tls/*.key' 600"
         use_multiple_values: true
         tests:
           test_items:

--- a/package/cfg/rke2-cis-1.6-permissive/node.yaml
+++ b/package/cfg/rke2-cis-1.6-permissive/node.yaml
@@ -11,6 +11,7 @@ groups:
       - id: 4.1.1
         text: "Ensure that the kubelet service file permissions are set to 644 or more restrictive (Automated)"
         audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c permissions=%a $kubeletsvc; fi'' '
+        type: "skip"
         tests:
           test_items:
             - flag: "permissions"
@@ -100,10 +101,10 @@ groups:
 
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Manual)"
-        audit: "stat -c %a /var/lib/rancher/rke2/server/tls/server-ca.crt"
+        audit: "check_cafile_permissions.sh"
         tests:
           test_items:
-            - flag: "644"
+            - flag: "permissions"
               compare:
                 op: bitmask
                 value: "644"
@@ -111,7 +112,7 @@ groups:
         remediation: |
           Run the following command to modify the file permissions of the
           --client-ca-file chmod 644 <filename>
-        scored: false
+        scored: true
 
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
@@ -280,12 +281,17 @@ groups:
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/cat $kubeletconf"
         tests:
-          test_items:
+          bin_op: or
+          test_items:          
             - flag: --protect-kernel-defaults
               path: '{.protectKernelDefaults}'
               compare:
                 op: eq
-                value: true
+                value: true                
+              set: true
+            - flag: --protect-kernel-defaults
+              path: '{.protectKernelDefaults}'
+              set: false
         remediation: |
           If using a Kubelet config file, edit the file to set protectKernelDefaults: true.
           If using command line arguments, edit the kubelet service file

--- a/package/helper_scripts/check_cafile_ownership.sh
+++ b/package/helper_scripts/check_cafile_ownership.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
 CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
+CAFILE=/node$CAFILE
 if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
 if test -e $CAFILE; then stat -c %U:%G $CAFILE; fi

--- a/package/helper_scripts/check_cafile_permissions.sh
+++ b/package/helper_scripts/check_cafile_permissions.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
 CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
+CAFILE=/node$CAFILE
 if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
 if test -e $CAFILE; then stat -c permissions=%a $CAFILE; fi

--- a/package/helper_scripts/check_for_k3s_etcd.sh
+++ b/package/helper_scripts/check_for_k3s_etcd.sh
@@ -11,7 +11,7 @@ handle_error() {
 trap 'handle_error' ERR
 
 
-if [[ "$(journalctl -D /var/log/journal -u k3s | grep 'Managed etcd' | grep -v grep | wc -l)" -gt 0 ]]; then
+if [[ "$(journalctl -D /var/log/journal -u k3s | grep 'Managed etcd cluster initializing' | grep -v grep | wc -l)" -gt 0 ]]; then
     case $1 in 
         "1.1.11")
             echo $(stat -c %a /var/lib/rancher/k3s/server/db/etcd);;
@@ -20,13 +20,13 @@ if [[ "$(journalctl -D /var/log/journal -u k3s | grep 'Managed etcd' | grep -v g
         "2.1")
             echo $(grep -A 5 'client-transport-security' /var/lib/rancher/k3s/server/db/etcd/config | grep -E 'cert-file|key-file');;
         "2.2")
-            echo "$(grep -A 5 'client-transport-security' /var/lib/rancher/k3s/server/db/etcd/config | grep 'client-cert-auth')";;
+            echo $(grep -A 5 'client-transport-security' /var/lib/rancher/k3s/server/db/etcd/config | grep 'client-cert-auth');;
         "2.3")
             echo $(grep 'auto-tls' /var/lib/rancher/k3s/server/db/etcd/config);;
         "2.4")
             echo $(grep -A 5 'peer-transport-security' /var/lib/rancher/k3s/server/db/etcd/config | grep -E 'cert-file|key-file');;
         "2.5")
-            echo "$(grep -A 5 'peer-transport-security' /var/lib/rancher/k3s/server/db/etcd/config | grep 'client-cert-auth')";;
+            echo $(grep -A 5 'peer-transport-security' /var/lib/rancher/k3s/server/db/etcd/config | grep 'client-cert-auth');;
         "2.6")
             echo $(grep 'peer-auto-tls' /var/lib/rancher/k3s/server/db/etcd/config);;
         "2.7")
@@ -42,13 +42,13 @@ else
         "2.1")
             echo "cert-file AND key-file";;
         "2.2")
-            echo "true";;
+            echo "--client-cert-auth=true";;
         "2.3")
             echo "false";;
         "2.4")
             echo "peer-cert-file AND peer-key-file";;
         "2.5")
-            echo "true";;
+            echo "--client-cert-auth=true";;
         "2.6")
             echo "--peer-auto-tls=false";;
         "2.7")

--- a/package/run_sonobuoy_plugin.sh
+++ b/package/run_sonobuoy_plugin.sh
@@ -129,9 +129,13 @@ else
 fi
 
 KUBELET_PROC="kubelet"
+kubeletbin=$KUBELET_PROC
 if [ ! ${IS_RKE2} ]; then
   KUBE_APISERVER_PROC="/kubelet"
+  kubeletbin=$KUBE_APISERVER_PROC
 fi
+
+kubeletconf="/node/var/lib/kubelet/config"
 
 if [[ "${OVERRIDE_BENCHMARK_VERSION}" != "" ]]; then
   if [[ "$(pgrep -f ${KUBELET_PROC} | wc -l)" -gt 0 ]] || [[ "$(journalctl -D $JOURNAL_LOG -u k3s | grep 'Running kubelet' | grep -v grep | wc -l)" -gt 0 ]]; then


### PR DESCRIPTION
Related: https://github.com/rancher/cis-operator/issues/156
NOTE: Need to rebase after the following PRs gets merged https://github.com/rancher/security-scan/pull/85, and https://github.com/rancher/security-scan/pull/86
- K3s related fixes for all the profiles (all the fixed are pretty much same):
  - `2.2` and `2.5`: added `bin_op = or`. Some nodes that doesn't have ETCD, it'll thorow errors so it's helpful in cases like this.
  - `1.1.15`, `1.1.16`, : added the schedulerkubeconfig path `/var/lib/rancher/k3s/server/cred/scheduler.kubeconfig`
  - `1.1.17`: added the controllermanagerkubeconfig path `/var/lib/rancher/k3s/server/cred/controller.kubeconfig`
  - `1.1.19`: corrected PKI directory
  - `1.2.2`, `1.2.13`, `1.2.14`, `1.2.15`, `1.2.17`, `1.2.26`: added `-v grep` it's basically grepping the test item using the result of previous grep.
  - (k3s 1.6, 1.20, 1.23 permissive): `1.2.19`, `1.2.20`, `1.2.21`, `1.2.22`, `1.2.23`, `1.2.24`, `1.2.25`: Skipped because these are hardened tests and it'll fail in permissive profiles.
  - `4.2.1`: Modified the script a bit which will hardcode anonymous-auth to false when it doesn't find kube-apiserver on a node (when the node has only etcd role or worker role)
  - `4.2.2`: Modified the script a bit which will hardcode authorization-mode when it doesn't find kube-apiserver on a node (when the node has only etcd role or worker role)
  - `4.2.3`: Modified the script a bit which will hardcode client-ca-file when it doesn't find kube-apiserver on a node (when the node has only etcd role or worker role)
  - `1.1.11`: moved this test inside etcd.yaml for k3s 1.6 permissive profile cz 1.1.11 test is etcd based.

- RKE1 related fixes for all the profiles(all the fixed are pretty much same):
  - `1.1.11`, `1.1.12`: check only the permission of /node/var/lib/etcd
  - `1.1.20`, `1.1.21`: move the .pem path inside single quotes, else the command will throw error
  - `1.1.19`: edit the PKI dir to /node/etc/kubernetes/ssl
  - `4.1.5`, `4.1.6`, : add /node before $kubeletkubeconfig
  - `4.2.1`, `4.2.2`, `4.2.3`, `4.2.4`, `4.2.5`, `4.2.6`, `4.2.7`, `4.2.9`, `4.2.10`, `4.2.11`, `4.2.12`, : added the kubeletconf within a condition for audit_config
  - Edited `package/run_sonobuoy_plugin.sh` and set kubeletbin=kubelet

- RKE2 related fixes for all the profiles(all the fixed are pretty much same):
  - `1.1.11`: edited the audit to `stat -c permissions=%a /var/lib/rancher/rke2/server/db/etcd`
  - `1.1.1`, `1.1.5`, `1.1.13`, `1.1.15`, `1.1.17`: added `permissions=` in audit
  - `4.2.6`: added bin_op: or
  - `1.1.20`, `1.1.21`: move the `.pem` path inside single quotes, else the command will throw error
  - `4.1.7`: used `check_cafile_permissions.sh` in audit

K3s Hardened multi-node:
![k3s-hardened-mn](https://user-images.githubusercontent.com/32811240/177539435-bee39186-b7c1-4fd7-bd9d-ba9a6c089085.png)
K3s Permissive multi-node:
![k3s-permissive-mn](https://user-images.githubusercontent.com/32811240/177539483-71eaee7c-7610-4057-80af-763d50929a98.png)
K3s Permissive single-node:
![k3s-permissive-sn](https://user-images.githubusercontent.com/32811240/177539604-6d9fb92f-97bd-42bf-95e1-46daaac11ca2.png)
RKE1 Permissive multi-node:
![rke1-permissive-mn](https://user-images.githubusercontent.com/32811240/177539758-861d22a6-7655-45d4-a331-80bb86f2504b.png)
RKE1 Permissive single-node:
![rke1-permissive-sn](https://user-images.githubusercontent.com/32811240/177539796-58f4263f-d2ae-47d3-8ead-8a36813c44bd.png)
RKE2 Permissive multi-node: (`1.1.13` test is failing which is a genuine failure)
![rke2-permissive-mn](https://user-images.githubusercontent.com/32811240/177539837-e0647b5e-7481-470f-bcf3-f1b11d1f3568.png)
RKE2 Permissive single-node: (`1.1.13` test is failing which is a genuine failure)
![rke2-permissive-sn](https://user-images.githubusercontent.com/32811240/177539889-89ed7d1f-69f2-4480-bd63-9ffbcdf312e0.png)

