### PR TITLE
Fix K8s 1.24 cluster specific test failures on RKE1 and K3s hardened cluster

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -28,7 +28,7 @@ RUN curl -sLf https://github.com/vmware-tanzu/sonobuoy/releases/download/v${sono
 RUN curl -sLf https://github.com/aquasecurity/kube-bench/releases/download/v${kube_bench_tag}/kube-bench_${kube_bench_tag}_linux_amd64.tar.gz | tar -xvzf - -C /usr/bin
 #RUN curl -sLf https://github.com/leodotcloud/kube-bench/releases/download/v${kube_bench_tag}/kube-bench.tar.gz | tar -xvzf - -C /usr/bin
 
-#COPY --from=intermediate /kube-bench/cfg /etc/kube-bench/cfg/
+COPY --from=intermediate /kube-bench/cfg /etc/kube-bench/cfg/
 
 COPY package/cfg/ /etc/kube-bench/cfg/
 COPY package/run.sh \

--- a/package/cfg/k3s-cis-1.20-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.20-hardened/master.yaml
@@ -614,13 +614,16 @@ groups:
 
       - id: 1.2.18
         text: "Ensure that the --insecure-port argument is set to 0 (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'insecure-port'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
+          bin_op: or
           test_items:
             - flag: "--insecure-port"
               compare:
                 op: eq
                 value: 0
+            - flag: "--insecure-port"
+              set: false
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the below parameter.

--- a/package/cfg/k3s-cis-1.6-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.6-hardened/master.yaml
@@ -612,13 +612,16 @@ groups:
 
       - id: 1.2.19
         text: "Ensure that the --insecure-port argument is set to 0 (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'insecure-port'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
+          bin_op: or
           test_items:
             - flag: "--insecure-port"
               compare:
                 op: eq
                 value: 0
+            - flag: "--insecure-port"
+              set: false
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the below parameter.

--- a/package/cfg/rke-cis-1.20-hardened/master.yaml
+++ b/package/cfg/rke-cis-1.20-hardened/master.yaml
@@ -579,14 +579,16 @@ groups:
 
       - id: 1.2.18
         text: "Ensure that the --insecure-port argument is set to 0 (Automated)"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "/bin/ps -ef | grep $apiserverbin"
         tests:
+          bin_op: or
           test_items:
             - flag: "--insecure-port"
               compare:
                 op: eq
                 value: 0
-              set: true
+            - flag: "--insecure-port"
+              set: false
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the below parameter.

--- a/package/cfg/rke-cis-1.20-hardened/node.yaml
+++ b/package/cfg/rke-cis-1.20-hardened/node.yaml
@@ -129,7 +129,7 @@ groups:
 
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Automated)"
-        audit: "check_cafile_permissions.sh"
+        audit: "stat -c permissions=%a /node/etc/kubernetes/ssl/kube-ca.pem"
         tests:
           test_items:
             - flag: "permissions"
@@ -143,7 +143,7 @@ groups:
 
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Automated)"
-        audit: "check_cafile_ownership.sh"
+        audit: "stat -c %U:%G /node/etc/kubernetes/ssl/kube-ca.pem"
         tests:
           test_items:
             - flag: root:root

--- a/package/cfg/rke-cis-1.23-hardened/node.yaml
+++ b/package/cfg/rke-cis-1.23-hardened/node.yaml
@@ -129,7 +129,7 @@ groups:
 
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Automated)"
-        audit: "check_cafile_permissions.sh"
+        audit: "stat -c permissions=%a /node/etc/kubernetes/ssl/kube-ca.pem"
         tests:
           test_items:
             - flag: "permissions"
@@ -143,7 +143,7 @@ groups:
 
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Automated)"
-        audit: "check_cafile_ownership.sh"
+        audit: "stat -c %U:%G /node/etc/kubernetes/ssl/kube-ca.pem"
         tests:
           test_items:
             - flag: root:root

--- a/package/cfg/rke-cis-1.5-hardened/master.yaml
+++ b/package/cfg/rke-cis-1.5-hardened/master.yaml
@@ -847,14 +847,16 @@ groups:
 
       - id: 1.2.19
         text: "Ensure that the --insecure-port argument is set to 0 (Scored)"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "/bin/ps -ef | grep $apiserverbin"
         tests:
+          bin_op: or
           test_items:
             - flag: "--insecure-port"
               compare:
                 op: eq
                 value: 0
-              set: true
+            - flag: "--insecure-port"
+              set: false
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the below parameter.

--- a/package/cfg/rke-cis-1.5-hardened/node.yaml
+++ b/package/cfg/rke-cis-1.5-hardened/node.yaml
@@ -200,44 +200,13 @@ groups:
 
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Scored)"
-        audit: '/bin/sh -c ''if test -e /node$kubeletcafile; then stat -c %a /node$kubeletcafile; fi'' '
+        audit: "stat -c permissions=%a /node/etc/kubernetes/ssl/kube-ca.pem"
         tests:
           test_items:
-            - flag: "644"
+            - flag: "permissions"
               compare:
-                op: eq
+                op: bitmask
                 value: "644"
-              set: true
-            - flag: "640"
-              compare:
-                op: eq
-                value: "640"
-              set: true
-            - flag: "600"
-              compare:
-                op: eq
-                value: "600"
-              set: true
-            - flag: "444"
-              compare:
-                op: eq
-                value: "444"
-              set: true
-            - flag: "440"
-              compare:
-                op: eq
-                value: "440"
-              set: true
-            - flag: "400"
-              compare:
-                op: eq
-                value: "400"
-              set: true
-            - flag: "000"
-              compare:
-                op: eq
-                value: "000"
-              set: true
           bin_op: or
         remediation: |
           Run the following command to modify the file permissions of the

--- a/package/cfg/rke-cis-1.6-hardened/master.yaml
+++ b/package/cfg/rke-cis-1.6-hardened/master.yaml
@@ -574,14 +574,16 @@ groups:
 
       - id: 1.2.19
         text: "Ensure that the --insecure-port argument is set to 0 (Automated)"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "/bin/ps -ef | grep $apiserverbin"
         tests:
+          bin_op: or
           test_items:
             - flag: "--insecure-port"
               compare:
                 op: eq
                 value: 0
-              set: true
+            - flag: "--insecure-port"
+              set: false
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the below parameter.

--- a/package/cfg/rke-cis-1.6-hardened/node.yaml
+++ b/package/cfg/rke-cis-1.6-hardened/node.yaml
@@ -129,7 +129,7 @@ groups:
 
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Automated)"
-        audit: "check_cafile_permissions.sh"
+        audit: "stat -c permissions=%a /node/etc/kubernetes/ssl/kube-ca.pem"
         tests:
           test_items:
             - flag: "permissions"
@@ -143,7 +143,7 @@ groups:
 
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Automated)"
-        audit: "check_cafile_ownership.sh"
+        audit: "stat -c %U:%G /node/etc/kubernetes/ssl/kube-ca.pem"
         tests:
           test_items:
             - flag: root:root


### PR DESCRIPTION
Related: https://github.com/rancher/cis-operator/issues/135
https://github.com/rancher/cis-operator/issues/153

After QA testing we found few failures as mentioned on the issue comments, this PR fixes them. Attaching the snapshots below
K3s-hardened CIS 1.6 and 1.20 fix:
![k3s-hardened](https://user-images.githubusercontent.com/32811240/179505745-ba36ffce-6733-4352-9fa9-056bc48aceb1.png)

RKE1-hardened 1.5 1.6 1.20 and 1.23 fix:
![RKE1-hardened-mn](https://user-images.githubusercontent.com/32811240/179505860-fb4ed654-fe8c-4792-a59c-62535c896af4.png)

