### PR TITLE
Fix for 5.3.1 scans failing for calico, cilium CNI

### DIFF
--- a/package/cfg/rke2-cis-1.20-hardened/policies.yaml
+++ b/package/cfg/rke2-cis-1.20-hardened/policies.yaml
@@ -211,7 +211,7 @@ groups:
     checks:
       - id: 5.3.1
         text: "Ensure that the CNI in use supports Network Policies (Automated)"
-        audit: "kubectl get pods -n kube-system -l k8s-app=canal -o json | jq .items[] | jq .metadata.name | wc -l | xargs -I {} echo '--count={}'"
+        audit: "kubectl get pods --all-namespaces --selector='k8s-app in (calico-node, canal, cilium)' -o name | wc -l | xargs -I {} echo '--count={}'"
         tests:
           test_items:
             - flag: "count"

--- a/package/cfg/rke2-cis-1.23-hardened/policies.yaml
+++ b/package/cfg/rke2-cis-1.23-hardened/policies.yaml
@@ -242,7 +242,7 @@ groups:
     checks:
       - id: 5.3.1
         text: "Ensure that the CNI in use supports Network Policies (Automated)"
-        audit: "kubectl get pods -n kube-system -l k8s-app=canal -o json | jq .items[] | jq .metadata.name | wc -l | xargs -I {} echo '--count={}'"
+        audit: "kubectl get pods --all-namespaces --selector='k8s-app in (calico-node, canal, cilium)' -o name | wc -l | xargs -I {} echo '--count={}'"
         tests:
           test_items:
             - flag: "count"

--- a/package/cfg/rke2-cis-1.5-hardened/policies.yaml
+++ b/package/cfg/rke2-cis-1.5-hardened/policies.yaml
@@ -197,7 +197,7 @@ groups:
   checks:
     - id: 5.3.1
       text: "Ensure that the CNI in use supports Network Policies (Not Scored)"
-      audit: "kubectl get pods -n kube-system -l k8s-app=canal -o json | jq .items[] | jq .metadata.name | wc -l | xargs -I {} echo '--count={}'"
+      audit: "kubectl get pods --all-namespaces --selector='k8s-app in (calico-node, canal, cilium)' -o name | wc -l | xargs -I {} echo '--count={}'"
       tests:
         test_items:
           - flag: "count"

--- a/package/cfg/rke2-cis-1.6-hardened/policies.yaml
+++ b/package/cfg/rke2-cis-1.6-hardened/policies.yaml
@@ -197,7 +197,7 @@ groups:
     checks:
       - id: 5.3.1
         text: "Ensure that the CNI in use supports Network Policies (Automated)"
-        audit: "kubectl get pods -n kube-system -l k8s-app=canal -o json | jq .items[] | jq .metadata.name | wc -l | xargs -I {} echo '--count={}'"
+        audit: "kubectl get pods --all-namespaces --selector='k8s-app in (calico-node, canal, cilium)' -o name | wc -l | xargs -I {} echo '--count={}'"
         tests:
           test_items:
             - flag: "count"


### PR DESCRIPTION
[https://github.com/rancher/cis-operator/issues/154](https://github.com/rancher/cis-operator/issues/154)

Fix for 5.3.1 scans failing for calico and cilium CNIs