### PR TITLE
Fix v1.24 Cluster Scan Failures

### DIFF
--- a/package/cfg/k3s-cis-1.20-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.20-permissive/master.yaml
@@ -615,13 +615,16 @@ groups:
 
       - id: 1.2.18
         text: "Ensure that the --insecure-port argument is set to 0 (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'insecure-port'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
+          bin_op: or
           test_items:
             - flag: "--insecure-port"
               compare:
                 op: eq
                 value: 0
+            - flag: "--insecure-port"
+              set: false
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the below parameter.

--- a/package/cfg/k3s-cis-1.6-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.6-permissive/master.yaml
@@ -595,13 +595,16 @@ groups:
 
       - id: 1.2.19
         text: "Ensure that the --insecure-port argument is set to 0 (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'insecure-port'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
+          bin_op: or
           test_items:
             - flag: "--insecure-port"
               compare:
                 op: eq
                 value: 0
+            - flag: "--insecure-port"
+              set: false
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the below parameter.

--- a/package/cfg/rke-cis-1.20-permissive/master.yaml
+++ b/package/cfg/rke-cis-1.20-permissive/master.yaml
@@ -537,14 +537,16 @@ groups:
 
       - id: 1.2.18
         text: "Ensure that the --insecure-port argument is set to 0 (Automated)"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "/bin/ps -ef | grep $apiserverbin"
         tests:
+          bin_op: or
           test_items:
             - flag: "--insecure-port"
               compare:
                 op: eq
                 value: 0
-              set: true  
+            - flag: "--insecure-port"
+              set: false 
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the below parameter.

--- a/package/cfg/rke-cis-1.20-permissive/node.yaml
+++ b/package/cfg/rke-cis-1.20-permissive/node.yaml
@@ -97,7 +97,7 @@ groups:
 
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Automated)"
-        audit: "check_cafile_permissions.sh"
+        audit: "stat -c permissions=%a /node/etc/kubernetes/ssl/kube-ca.pem"
         tests:
           test_items:
             - flag: "permissions"
@@ -111,7 +111,7 @@ groups:
 
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Automated)"
-        audit: "check_cafile_ownership.sh"
+        audit: "stat -c %U:%G /node/etc/kubernetes/ssl/kube-ca.pem"
         tests:
           test_items:
             - flag: root:root

--- a/package/cfg/rke-cis-1.23-permissive/node.yaml
+++ b/package/cfg/rke-cis-1.23-permissive/node.yaml
@@ -98,7 +98,7 @@ groups:
 
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Automated)"
-        audit: "check_cafile_permissions.sh"
+        audit: "stat -c permissions=%a /node/etc/kubernetes/ssl/kube-ca.pem"
         tests:
           test_items:
             - flag: "permissions"
@@ -112,7 +112,7 @@ groups:
 
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Automated)"
-        audit: "check_cafile_ownership.sh"
+        audit: "stat -c %U:%G /node/etc/kubernetes/ssl/kube-ca.pem"
         tests:
           test_items:
             - flag: root:root

--- a/package/cfg/rke-cis-1.5-permissive/master.yaml
+++ b/package/cfg/rke-cis-1.5-permissive/master.yaml
@@ -853,14 +853,16 @@ groups:
 
       - id: 1.2.19
         text: "Ensure that the --insecure-port argument is set to 0 (Scored)"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "/bin/ps -ef | grep $apiserverbin"
         tests:
+          bin_op: or
           test_items:
             - flag: "--insecure-port"
               compare:
                 op: eq
                 value: 0
-              set: true
+            - flag: "--insecure-port"
+              set: false
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the below parameter.

--- a/package/cfg/rke-cis-1.6-permissive/master.yaml
+++ b/package/cfg/rke-cis-1.6-permissive/master.yaml
@@ -580,14 +580,16 @@ groups:
 
       - id: 1.2.19
         text: "Ensure that the --insecure-port argument is set to 0 (Automated)"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "/bin/ps -ef | grep $apiserverbin"
         tests:
+          bin_op: or
           test_items:
             - flag: "--insecure-port"
               compare:
                 op: eq
                 value: 0
-              set: true
+            - flag: "--insecure-port"
+              set: false
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the below parameter.

--- a/package/cfg/rke-cis-1.6-permissive/node.yaml
+++ b/package/cfg/rke-cis-1.6-permissive/node.yaml
@@ -101,7 +101,7 @@ groups:
 
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Automated)"
-        audit: "check_cafile_permissions.sh"
+        audit: "stat -c permissions=%a /node/etc/kubernetes/ssl/kube-ca.pem"
         tests:
           test_items:
             - flag: "permissions"
@@ -115,7 +115,7 @@ groups:
 
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Automated)"
-        audit: "check_cafile_ownership.sh"
+        audit: "stat -c %U:%G /node/etc/kubernetes/ssl/kube-ca.pem"
         tests:
           test_items:
             - flag: root:root

--- a/package/cfg/rke2-cis-1.20-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.20-hardened/master.yaml
@@ -571,14 +571,16 @@ groups:
 
       - id: 1.2.18
         text: "Ensure that the --insecure-port argument is set to 0 (Automated)"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "/bin/ps -ef | grep $apiserverbin"
         tests:
+          bin_op: or
           test_items:
             - flag: "--insecure-port"
               compare:
                 op: eq
                 value: 0
-              set: true
+            - flag: "--insecure-port"
+              set: false
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the below parameter.

--- a/package/cfg/rke2-cis-1.20-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.20-permissive/master.yaml
@@ -580,14 +580,16 @@ groups:
 
       - id: 1.2.18
         text: "Ensure that the --insecure-port argument is set to 0 (Automated)"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "/bin/ps -ef | grep $apiserverbin"
         tests:
+          bin_op: or
           test_items:
             - flag: "--insecure-port"
               compare:
                 op: eq
                 value: 0
-              set: true
+            - flag: "--insecure-port"
+              set: false
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the below parameter.

--- a/package/cfg/rke2-cis-1.5-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.5-hardened/master.yaml
@@ -578,14 +578,16 @@ groups:
 
     - id: 1.2.19
       text: "Ensure that the --insecure-port argument is set to 0 (Scored)"
-      audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+      audit: "/bin/ps -ef | grep $apiserverbin"
       tests:
+        bin_op: or
         test_items:
           - flag: "--insecure-port"
             compare:
               op: eq
               value: 0
-            set: true
+          - flag: "--insecure-port"
+            set: false
       remediation: |
         Edit the API server pod specification file $apiserverconf
         on the master node and set the below parameter.

--- a/package/cfg/rke2-cis-1.5-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.5-permissive/master.yaml
@@ -578,14 +578,16 @@ groups:
 
     - id: 1.2.19
       text: "Ensure that the --insecure-port argument is set to 0 (Scored)"
-      audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+      audit: "/bin/ps -ef | grep $apiserverbin"
       tests:
+        bin_op: or
         test_items:
           - flag: "--insecure-port"
             compare:
               op: eq
               value: 0
-            set: true
+          - flag: "--insecure-port"
+            set: false
       remediation: |
         Edit the API server pod specification file $apiserverconf
         on the master node and set the below parameter.

--- a/package/cfg/rke2-cis-1.6-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.6-hardened/master.yaml
@@ -571,14 +571,16 @@ groups:
 
       - id: 1.2.19
         text: "Ensure that the --insecure-port argument is set to 0 (Automated)"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "/bin/ps -ef | grep $apiserverbin"
         tests:
+          bin_op: or
           test_items:
             - flag: "--insecure-port"
               compare:
                 op: eq
                 value: 0
-              set: true
+            - flag: "--insecure-port"
+              set: false
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the below parameter.

--- a/package/cfg/rke2-cis-1.6-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.6-permissive/master.yaml
@@ -594,14 +594,16 @@ groups:
 
       - id: 1.2.19
         text: "Ensure that the --insecure-port argument is set to 0 (Automated)"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "/bin/ps -ef | grep $apiserverbin"
         tests:
+          bin_op: or
           test_items:
             - flag: "--insecure-port"
               compare:
                 op: eq
                 value: 0
-              set: true
+            - flag: "--insecure-port"
+              set: false
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the master node and set the below parameter.


### PR DESCRIPTION
After QA validation, they found that the --insecure-port check is failing on every cluster. So this PR fixes them all.
check_cafile_permissions.sh script is also failing (on K8s 1.24 cluster) for RKE1 permissive profile scans, this PR fixes that as well.
Related:
https://github.com/rancher/cis-operator/issues/135
https://github.com/rancher/cis-operator/issues/153
Note: All the fixes are tested on respective clusters. 