### PR TITLE
Fixing false positives / warnings

### DIFF
--- a/package/cfg/rke2-cis-1.23-hardened/etcd.yaml
+++ b/package/cfg/rke2-cis-1.23-hardened/etcd.yaml
@@ -188,12 +188,19 @@ groups:
         scored: true
 
       - id: 2.7
-        text: "Ensure that a unique Certificate Authority is used for etcd (Manual)"
+        text: "Ensure that a unique Certificate Authority is used for etcd (Automated)"
         audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        audit_config: "cat /var/lib/rancher/rke2/server/db/etcd/config"
         tests:
+          bin_op: or
           test_items:
             - flag: "--trusted-ca-file"
               env: "ETCD_TRUSTED_CA_FILE"
+            - path: "{.peer-transport-security.trusted-ca-file}"
+              compare:
+                op: eq
+                value: "/var/lib/rancher/rke2/server/tls/etcd/peer-ca.crt"
+              set: true
         remediation: |
           [Manual test]
           Follow the etcd documentation and create a dedicated certificate authority setup for the

--- a/package/cfg/rke2-cis-1.23-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.23-hardened/master.yaml
@@ -99,7 +99,7 @@ groups:
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Manual)"
         audit: |
-          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
+          ps -fC ${kubeletbin:-kubelet} | grep -- --cni-conf-dir || echo "/etc/cni/net.d" | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
           find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
         use_multiple_values: true
         tests:
@@ -116,7 +116,7 @@ groups:
       - id: 1.1.10
         text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
         audit: |
-          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
+          ps -fC ${kubeletbin:-kubelet} | grep -- --cni-conf-dir || echo "/etc/cni/net.d" | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
           find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
         use_multiple_values: true
         tests:
@@ -808,6 +808,7 @@ groups:
           TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_RSA_WITH_3DES_EDE_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,
           TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_256_GCM_SHA384
         scored: false
+        type: skip
 
   - id: 1.3
     text: "Controller Manager"

--- a/package/cfg/rke2-cis-1.23-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.23-hardened/master.yaml
@@ -239,7 +239,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Manual)"
-        audit: "check_files_permissions.sh /var/lib/rancher/rke2/server/tls/*.crt 644"
+        audit: "find /var/lib/rancher/rke2/server/tls/ -name '*.crt' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -256,7 +256,7 @@ groups:
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "check_files_permissions.sh /var/lib/rancher/rke2/server/tls/*.key 600"
+        audit: "find /var/lib/rancher/rke2/server/tls/ -name '*.key' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -276,7 +276,6 @@ groups:
       - id: 1.2.1
         text: "Ensure that the --anonymous-auth argument is set to false (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
-        type: manual
         tests:
           test_items:
             - flag: "--anonymous-auth"

--- a/package/cfg/rke2-cis-1.23-hardened/node.yaml
+++ b/package/cfg/rke2-cis-1.23-hardened/node.yaml
@@ -473,4 +473,3 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: false
-        type: skip

--- a/package/cfg/rke2-cis-1.23-hardened/node.yaml
+++ b/package/cfg/rke2-cis-1.23-hardened/node.yaml
@@ -350,6 +350,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: false
+        type: skip
 
       - id: 4.2.9
         text: "Ensure that the --event-qps argument is set to 0 or a level which ensures appropriate event capture (Manual)"
@@ -472,3 +473,4 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: false
+        type: skip

--- a/package/cfg/rke2-cis-1.23-permissive/etcd.yaml
+++ b/package/cfg/rke2-cis-1.23-permissive/etcd.yaml
@@ -193,12 +193,18 @@ groups:
         scored: true
 
       - id: 2.7
-        text: "Ensure that a unique Certificate Authority is used for etcd (Manual)"
+        text: "Ensure that a unique Certificate Authority is used for etcd (Automated)"
         audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        audit_config: "cat /var/lib/rancher/rke2/server/db/etcd/config"
         tests:
+          bin_op: or
           test_items:
             - flag: "--trusted-ca-file"
               env: "ETCD_TRUSTED_CA_FILE"
+            - path: "{.peer-transport-security.trusted-ca-file}"
+              compare:
+                op: eq
+                value: "/var/lib/rancher/rke2/server/tls/etcd/peer-ca.crt"
               set: true
         remediation: |
           [Manual test]

--- a/package/cfg/rke2-cis-1.23-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.23-permissive/master.yaml
@@ -99,7 +99,7 @@ groups:
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Manual)"
         audit: |
-          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
+          ps -fC ${kubeletbin:-kubelet} | grep -- --cni-conf-dir || echo "/etc/cni/net.d" | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
           find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
         use_multiple_values: true
         tests:
@@ -117,7 +117,7 @@ groups:
         text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
         type: "manual"
         audit: |
-          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
+          ps -fC ${kubeletbin:-kubelet} | grep -- --cni-conf-dir || echo "/etc/cni/net.d" | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
           find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
         use_multiple_values: true
         tests:
@@ -824,6 +824,7 @@ groups:
           TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_RSA_WITH_3DES_EDE_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,
           TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_256_GCM_SHA384
         scored: false
+        type: skip
 
   - id: 1.3
     text: "Controller Manager"

--- a/package/cfg/rke2-cis-1.23-permissive/node.yaml
+++ b/package/cfg/rke2-cis-1.23-permissive/node.yaml
@@ -471,4 +471,3 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: false
-        type: skip

--- a/package/cfg/rke2-cis-1.23-permissive/node.yaml
+++ b/package/cfg/rke2-cis-1.23-permissive/node.yaml
@@ -350,6 +350,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: false
+        type: skip
 
       - id: 4.2.9
         text: "Ensure that the --event-qps argument is set to 0 or a level which ensures appropriate event capture (Manual)"
@@ -470,3 +471,4 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: false
+        type: skip


### PR DESCRIPTION
Controls:
- 2.7: Add support for the config file instead of the process [docs](https://docs.rke2.io/security/cis_self_assessment16/#27)
- 1.1.9 + 1.1.10: Use the default location if none is specified: `/etc/cni/net.d`
- 1.1.20 + 1.1.21: Fixed using `find` like in permissive
- 1.2.32: Not applicable [docs](https://docs.rke2.io/security/cis_self_assessment16/#1235)
- 4.2.8: Not applicable [docs](https://docs.rke2.io/security/cis_self_assessment16/#428)

This fixes https://github.com/rancher/cis-operator/issues/125