### PR TITLE
When checking default service accounts avoid an error with clusterrolebindings

### DIFF
--- a/package/helper_scripts/check_for_default_sa.sh
+++ b/package/helper_scripts/check_for_default_sa.sh
@@ -13,13 +13,22 @@ if [[ ${count_sa} -gt 0 ]]; then
     echo "false"
     exit
 fi
+for result in $(kubectl get clusterrolebinding -o json | jq -r 'try .items[] | select((.subjects[].kind=="ServiceAccount" and .subjects[].name=="default") or (.subjects[].kind=="Group" and .subjects[].name=="system:serviceaccounts"))' | jq -r '"\(.roleRef.kind),\(.roleRef.name)"')
+do
+    read kind name <<<$(IFS=","; echo $result)
+    resource_count=$(kubectl get "$kind" "$name" -o json | jq -r '.rules[] | select(.resources[] != "podsecuritypolicies")' | wc -l)
+    if [[ ${resource_count} -gt 0 ]]; then
+        echo "false"
+        exit
+    fi
+done
 
 for ns in $(kubectl get ns --no-headers -o custom-columns=":metadata.name")
 do
-    for result in $(kubectl get clusterrolebinding,rolebinding -n $ns -o json | jq -r '.items[] | select((.subjects[].kind=="ServiceAccount" and .subjects[].name=="default") or (.subjects[].kind=="Group" and .subjects[].name=="system:serviceaccounts"))' | jq -r '"\(.roleRef.kind),\(.roleRef.name)"')
+    for result in $(kubectl get rolebinding -n "$ns" -o json | jq -r 'try .items[] | select((.subjects[].kind=="ServiceAccount" and .subjects[].name=="default") or (.subjects[].kind=="Group" and .subjects[].name=="system:serviceaccounts"))' | jq -r '"\(.roleRef.kind),\(.roleRef.name)"')
     do
         read kind name <<<$(IFS=","; echo $result)
-        resource_count=$(kubectl get $kind $name -n $ns -o json | jq -r '.rules[] | select(.resources[] != "podsecuritypolicies")' | wc -l)
+        resource_count=$(kubectl get "$kind" "$name" -n "$ns" -o json | jq -r '.rules[] | select(.resources[] != "podsecuritypolicies")' | wc -l)
         if [[ ${resource_count} -gt 0 ]]; then
             echo "false"
             exit


### PR DESCRIPTION
Error was `jq: error (at <stdin>:1715): Cannot iterate over null (null)`

Additionally, clusterrolebindings don't have a namespace, so we check them only once.