### PR TITLE
Fix `1.1.10` `1.1.20` `1.1.21` warnings for rke2 permissive and hardened profiles

### DIFF
--- a/package/cfg/rke2-cis-1.23-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.23-hardened/master.yaml
@@ -239,7 +239,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Manual)"
-        audit: "find /var/lib/rancher/rke2/server/tls/ -name '*.crt' | xargs stat -c permissions=%a"
+        audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/tls/*.crt"
         use_multiple_values: true
         tests:
           test_items:
@@ -256,13 +256,13 @@ groups:
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "find /var/lib/rancher/rke2/server/tls/ -name '*.key' | xargs stat -c permissions=%a"
+        audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/tls/*.key"
         use_multiple_values: true
         tests:
           test_items:
             - flag: "permissions"
               compare:
-                op: bitmask
+                op: eq
                 value: "600"
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.

--- a/package/cfg/rke2-cis-1.23-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.23-permissive/master.yaml
@@ -115,7 +115,6 @@ groups:
 
       - id: 1.1.10
         text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
-        type: "manual"
         audit: |
           ps -fC ${kubeletbin:-kubelet} | grep -- --cni-conf-dir || echo "/etc/cni/net.d" | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
           find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
@@ -242,7 +241,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Manual)"
-        audit: "check_files_permissions.sh /var/lib/rancher/rke2/server/tls/*.crt 644"
+        audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/tls/*.crt"
         use_multiple_values: true
         tests:
           test_items:
@@ -259,14 +258,14 @@ groups:
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "find /etc/kubernetes/pki/ -name '*.key' | xargs stat -c permissions=%a"
+        audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/tls/*.key"
         use_multiple_values: true
         tests:
           test_items:
-            - flag: "true"
+            - flag: "permissions"
               compare:
                 op: eq
-                value: "true"
+                value: "600"
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.


### PR DESCRIPTION
Related issue: https://github.com/rancher/cis-operator/issues/125

**RKE2 - permissive profile:**
![Screenshot from 2023-01-12 13-10-30](https://user-images.githubusercontent.com/32811240/212006833-0886780c-e2d2-4461-b654-edcd0b4e546e.png)
![Screenshot from 2023-01-12 13-10-47](https://user-images.githubusercontent.com/32811240/212006861-3e113ab7-b7da-4268-91f9-b117ed14d366.png)

**RKE2 - hardened profile:**
![Screenshot from 2023-01-12 13-12-11](https://user-images.githubusercontent.com/32811240/212007184-24a1840a-38f6-46fa-9934-5726e71f4365.png)
![Screenshot from 2023-01-12 13-12-29](https://user-images.githubusercontent.com/32811240/212007211-610b95a0-b4e1-4ba2-86c4-0568598fb210.png)



