### PR TITLE
Fix audit commands for rke-1.23-hardened profile.

### DIFF
--- a/package/cfg/rke-cis-1.23-hardened/master.yaml
+++ b/package/cfg/rke-cis-1.23-hardened/master.yaml
@@ -119,10 +119,9 @@ groups:
         scored: true
 
       - id: 1.1.9
-        text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Manual)"
-        type: "manual"
+        text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Automated)"
         audit: |
-          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
+          ps -fC ${kubeletbin:-kubelet} | grep -- --cni-conf-dir || echo "/etc/cni/net.d" | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
           find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
         use_multiple_values: true
         tests:
@@ -137,10 +136,9 @@ groups:
         scored: false
 
       - id: 1.1.10
-        text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
-        type: "manual"
+        text: "Ensure that the Container Network Interface file ownership is set to root:root (Automated)"
         audit: |
-          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
+          ps -fC ${kubeletbin:-kubelet} | grep -- --cni-conf-dir || echo "/etc/cni/net.d" | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
           find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
         use_multiple_values: true
         tests:


### PR DESCRIPTION
The tests `1.1.9` and `1.1.10` automated tests were going in warning state and were being skipped as manual. This PR resolves the issue by updating the audit command.

Linked issue: https://github.com/rancher/rancher/issues/40230

Following is the screenshot of the tests on rke hardened cluster:

![Screenshot from 2023-01-20 15-12-37](https://user-images.githubusercontent.com/34883075/213687096-f0e65c02-4478-4679-b2c0-84a64ba1ce23.png)


