### PR TITLE
Bump versions for external tools

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,17 +1,8 @@
-FROM registry.suse.com/bci/bci-base:15.4 as intermediate
-
-#Label the image for cleaning after build process
-LABEL stage=intermediate
-
-RUN zypper --non-interactive update \
-    && zypper --non-interactive install \
-    git
-
-RUN git clone -b v0.6.8 --depth 1 https://github.com/aquasecurity/kube-bench.git
-
 FROM registry.suse.com/bci/bci-base:15.4
-ARG kube_bench_tag=0.6.8
-ARG sonobuoy_version=0.56.7
+
+ARG kube_bench_version=0.6.11
+ARG sonobuoy_version=0.56.15
+ARG kubectl_version=1.26.1
 
 RUN zypper --non-interactive update \
     && zypper --non-interactive install \
@@ -22,14 +13,15 @@ RUN zypper --non-interactive update \
     tar \
     awk \
     gzip
-RUN curl -sLf https://storage.googleapis.com/kubernetes-release/release/v1.13.5/bin/linux/amd64/kubectl > /usr/local/bin/kubectl-1.13 \
-    && ln -sv /usr/local/bin/kubectl-1.13 /usr/local/bin/kubectl \
+RUN curl -sLf "https://storage.googleapis.com/kubernetes-release/release/v${kubectl_version}/bin/linux/amd64/kubectl" > "/usr/local/bin/kubectl-${kubectl_version}" \
+    && ln -sv "/usr/local/bin/kubectl-${kubectl_version}" /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl*
-RUN curl -sLf https://github.com/vmware-tanzu/sonobuoy/releases/download/v${sonobuoy_version}/sonobuoy_${sonobuoy_version}_linux_amd64.tar.gz | tar -xvzf - -C /usr/bin sonobuoy
-RUN curl -sLf https://github.com/aquasecurity/kube-bench/releases/download/v${kube_bench_tag}/kube-bench_${kube_bench_tag}_linux_amd64.tar.gz | tar -xvzf - -C /usr/bin
-#RUN curl -sLf https://github.com/leodotcloud/kube-bench/releases/download/v${kube_bench_tag}/kube-bench.tar.gz | tar -xvzf - -C /usr/bin
+RUN curl -sLf "https://github.com/vmware-tanzu/sonobuoy/releases/download/v${sonobuoy_version}/sonobuoy_${sonobuoy_version}_linux_amd64.tar.gz" | tar -xvzf - -C /usr/bin sonobuoy
+RUN curl -sLf "https://github.com/aquasecurity/kube-bench/releases/download/v${kube_bench_version}/kube-bench_${kube_bench_version}_linux_amd64.tar.gz" | tar -xvzf - -C /usr/bin
 
-COPY --from=intermediate /kube-bench/cfg /etc/kube-bench/cfg/
+# Copy the files within /cfg straight from the immutable GitHub source to /etc/kube-bench/cfg/.
+RUN curl -sLf "https://github.com/aquasecurity/kube-bench/archive/refs/tags/v${kube_bench_version}.tar.gz" | \
+    tar xvz -C . --strip-components=1 "kube-bench-${kube_bench_version}/cfg"
 
 COPY package/cfg/ /etc/kube-bench/cfg/
 COPY package/run.sh \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,8 +1,8 @@
 FROM registry.suse.com/bci/bci-base:15.4
 
-ARG kube_bench_version=0.6.11
-ARG sonobuoy_version=0.56.15
-ARG kubectl_version=1.26.1
+ARG kube_bench_version=0.6.12
+ARG sonobuoy_version=0.56.16
+ARG kubectl_version=1.26.3
 
 RUN zypper --non-interactive update \
     && zypper --non-interactive install \

--- a/package/cfg/config.yaml
+++ b/package/cfg/config.yaml
@@ -201,23 +201,37 @@ managedservices:
 
 # TODO: Clean up in the next refactor
 version_mapping:
-  "rke-1.13": "rke-cis-1.4"
-  "rke-1.14": "rke-cis-1.4"
-  "rke-1.15": "rke-cis-1.5-permissive"
-  "rke-1.16": "rke-cis-1.6-permissive"
-  "rke-1.17": "rke-cis-1.6-permissive"
-  "rke-1.18": "rke-cis-1.6-permissive"
-  "rke-1.19": "rke-cis-1.20-permissive"
-  "rke-1.20": "rke-cis-1.20-permissive"
-  "v1.18.10+rke2r1": "rke2-cis-1.5-hardened"
-  "v1.18.10+rke2r1": "rke2-cis-1.5-permissive"
-  "eks-1.0.1": "eks-1.0.1"
-  "gke-1.0": "gke-1.0"
-  "aks-1.0": "aks-1.0"	
-  "v1.20.5+rke2r1": "rke2-cis-1.6-hardened"
-  "v1.20.5+rke2r1": "rke2-cis-1.6-permissive"
-  "v1.20.5+k3s1": "k3s-cis-1.6-hardened"
-  "v1.20.5+k3s1": "k3s-cis-1.6-permissive"
+  "rke-1.13": 
+    - "rke-cis-1.4"
+  "rke-1.14": 
+    - "rke-cis-1.4"
+  "rke-1.15": 
+    - "rke-cis-1.5-permissive"
+  "rke-1.16": 
+    - "rke-cis-1.6-permissive"
+  "rke-1.17": 
+    - "rke-cis-1.6-permissive"
+  "rke-1.18": 
+    - "rke-cis-1.6-permissive"
+  "rke-1.19": 
+    - "rke-cis-1.20-permissive"
+  "rke-1.20": 
+    - "rke-cis-1.20-permissive"
+  "v1.18.10+rke2r1": 
+    - "rke2-cis-1.5-hardened"
+    - "rke2-cis-1.5-permissive"
+  "eks-1.0.1": 
+    - "eks-1.0.1"
+  "gke-1.0": 
+    - "gke-1.0"
+  "aks-1.0": 
+    - "aks-1.0"	
+  "v1.20.5+rke2r1": 
+    - "rke2-cis-1.6-hardened"
+    - "rke2-cis-1.6-permissive"
+  "v1.20.5+k3s1": 
+    - "k3s-cis-1.6-hardened"
+    - "k3s-cis-1.6-permissive"
 
 target_mapping:
   "cis-1.4":

--- a/pkg/kb-summarizer/summarizer/summarizer.go
+++ b/pkg/kb-summarizer/summarizer/summarizer.go
@@ -377,7 +377,7 @@ func (s *Summarizer) loadVersionMapping() error {
 	}
 
 	kubeToBenchmarkMap := v.GetStringMapString(VersionMappingKey)
-	if kubeToBenchmarkMap == nil || (len(kubeToBenchmarkMap) == 0) {
+	if len(kubeToBenchmarkMap) == 0 {
 		return fmt.Errorf("config file is missing '%v' section", VersionMappingKey)
 	}
 	logrus.Debugf("%v: %v", VersionMappingKey, kubeToBenchmarkMap)


### PR DESCRIPTION
Whilst bumping the versions, it also removes the logic that clones the `kube-bench` repository in order to obtain the files within `cfg`. Instead, it pulls it directly from the GitHub immutable source tar file.

### Updated dependencies:
- aquasecurity/kube-bench v0.6.11
- sonobuoy_version v0.56.15
- kubectl v1.26

Fixes https://jira.suse.com/browse/SURE-5916.