### PR TITLE
Add a E2E smoke test to confirm the scan works

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -1,11 +1,21 @@
 FROM registry.suse.com/bci/golang:1.19
 
+ARG KIND_VERSION=0.17.0
+ARG KUBERNETES_VERSION=1.26.0
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
 
-RUN zypper --non-interactive install git docker vim less curl wget
+RUN zypper --non-interactive install git docker vim less curl wget gettext awk
 RUN go install golang.org/x/lint/golint@latest
 RUN go install golang.org/x/tools/cmd/goimports@latest
+
+RUN curl -Lo ./kind "https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-${ARCH}" && \
+    chmod +x ./kind && \
+    mv ./kind /usr/local/bin/
+
+RUN curl -Lo ./kubectl "https://storage.googleapis.com/kubernetes-release/release/v${KUBERNETES_VERSION}/bin/linux/${ARCH}/kubectl" && \
+    chmod +x ./kubectl && \
+    mv ./kubectl /usr/local/bin/
 
 ENV DAPPER_ENV REPO TAG DRONE_TAG
 ENV DAPPER_SOURCE /go/src/github.com/rancher/security-scan/

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -3,6 +3,7 @@ FROM registry.suse.com/bci/bci-base:15.5
 ARG kube_bench_version=0.6.12
 ARG sonobuoy_version=0.56.16
 ARG kubectl_version=1.26.3
+ARG ARCH
 
 RUN zypper --non-interactive update \
     && zypper --non-interactive install \
@@ -13,11 +14,11 @@ RUN zypper --non-interactive update \
     tar \
     awk \
     gzip
-RUN curl -sLf "https://storage.googleapis.com/kubernetes-release/release/v${kubectl_version}/bin/linux/amd64/kubectl" > "/usr/local/bin/kubectl-${kubectl_version}" \
-    && ln -sv "/usr/local/bin/kubectl-${kubectl_version}" /usr/local/bin/kubectl \
-    && chmod +x /usr/local/bin/kubectl*
-RUN curl -sLf "https://github.com/vmware-tanzu/sonobuoy/releases/download/v${sonobuoy_version}/sonobuoy_${sonobuoy_version}_linux_amd64.tar.gz" | tar -xvzf - -C /usr/bin sonobuoy
-RUN curl -sLf "https://github.com/aquasecurity/kube-bench/releases/download/v${kube_bench_version}/kube-bench_${kube_bench_version}_linux_amd64.tar.gz" | tar -xvzf - -C /usr/bin
+RUN curl -Lo ./kubectl "https://storage.googleapis.com/kubernetes-release/release/v${kubectl_version}/bin/linux/${ARCH}/kubectl" && \
+    chmod +x ./kubectl && \
+    mv ./kubectl /usr/local/bin/
+RUN curl -sLf "https://github.com/vmware-tanzu/sonobuoy/releases/download/v${sonobuoy_version}/sonobuoy_${sonobuoy_version}_linux_${ARCH}.tar.gz" | tar -xvzf - -C /usr/bin sonobuoy
+RUN curl -sLf "https://github.com/aquasecurity/kube-bench/releases/download/v${kube_bench_version}/kube-bench_${kube_bench_version}_linux_${ARCH}.tar.gz" | tar -xvzf - -C /usr/bin
 
 # Copy the files within /cfg straight from the immutable GitHub source to /etc/kube-bench/cfg/.
 RUN curl -sLf "https://github.com/aquasecurity/kube-bench/archive/refs/tags/v${kube_bench_version}.tar.gz" | \

--- a/scripts/ci
+++ b/scripts/ci
@@ -7,3 +7,4 @@ cd $(dirname $0)
 ./test
 ./validate
 ./package
+./e2e

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -1,0 +1,81 @@
+#!/bin/bash
+set -e
+
+export ARCH="${ARCH:-amd64}"
+export IMAGE=security-scan:e2e
+export SONOBUOY_IMAGE=rancher/mirrored-sonobuoy-sonobuoy:v0.56.7
+
+CLUSTER_NAME="kind-${RANDOM}"
+KUBE_VERSION="${KUBE_VERSION:-v1.26.0}"
+KINDCONFIG="$(mktemp)"
+E2E_TIMEOUT_SECONDS=600
+
+function cleanup() {
+    rm -rf "${KINDCONFIG}" | true    
+}
+trap cleanup EXIT
+
+cd $(dirname $0)/..
+
+echo "Running E2E tests"
+sleep "${E2E_TIMEOUT_SECONDS}" && kind delete cluster --name "${CLUSTER_NAME}" | false &
+
+echo "> Spinning up flux kind cluster"
+cat << EOF > "${KINDCONFIG}"
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    image: kindest/node:$KUBE_VERSION
+    kubeadmConfigPatches:
+      - |
+        kind: InitConfiguration
+        nodeRegistration:
+          kubeletExtraArgs:
+            node-labels: "ingress-ready=true"
+EOF
+
+kind create cluster --name "${CLUSTER_NAME}" --config "${KINDCONFIG}"
+
+# Build, pull and load images while kind cluster is starting to save time.
+echo "> Build and load ${IMAGE} into kind cluster"
+docker build --build-arg ARCH -f package/Dockerfile -t "${IMAGE}" .
+kind load docker-image "${IMAGE}" --name "${CLUSTER_NAME}"
+
+echo "> Pull and load ${SONOBUOY_IMAGE} into kind cluster"
+docker pull "${SONOBUOY_IMAGE}"
+kind load docker-image "${SONOBUOY_IMAGE}" --name "${CLUSTER_NAME}"
+
+# Dapper will run on an isolated docker network.
+# To access kind, grab the current container and connect
+# it to Kind's network.
+NETWORK_ID=$(docker network ls -f name=kind -q)
+CURRENT_CONTAINER=$(cat /etc/hostname)
+docker network connect "${NETWORK_ID}" "${CURRENT_CONTAINER}"
+
+kind export kubeconfig --internal --name "${CLUSTER_NAME}"
+
+echo "> Waiting for kind cluster to be ready"
+kubectl wait node "${CLUSTER_NAME}-control-plane" --for=condition=ready --timeout=30s
+kubectl wait --for=condition=ready -n local-path-storage -l app=local-path-provisioner pod
+
+echo "> Deploying test resources"
+envsubst < ./tests/deploy.yaml | kubectl apply -f -
+kubectl wait --for=condition=ready -n cis-operator-system pod security-scan-runner-scan-test --timeout=30s
+
+kubectl exec -n cis-operator-system security-scan-runner-scan-test -c rancher-cis-benchmark -- run.sh &
+
+sleep 20 # Wait for the new daemonset to be created
+
+# The rancher-kube-bench container will fail to pull the image because the imagePullPolicy is set to Always,
+# which is not ideal when running on a kind cluster.
+kubectl patch ds -n cis-operator-system "$(kubectl get ds -n cis-operator-system -l sonobuoy-component=plugin -o name | awk -F/ '{ print $2}')" -p '{"spec": {"template": {"spec":{"containers":[{"name":"rancher-kube-bench","imagePullPolicy":"Never"}]}}}}'
+
+sonobuoyDone=false
+while [ "${sonobuoyDone}" != "true" ]; do
+  sonobuoyDone=$(kubectl get pod -n cis-operator-system security-scan-runner-scan-test -o jsonpath='{.metadata.annotations.field\.cattle\.io/sonobuoyDone}')
+  sleep 2
+done
+
+echo "> CIS Scan Results:"
+kubectl exec -n cis-operator-system security-scan-runner-scan-test -c rancher-cis-benchmark -- cat /tmp/kb-summarizer/output/output.json

--- a/scripts/package
+++ b/scripts/package
@@ -3,15 +3,15 @@ set -e
 
 source $(dirname $0)/version
 
-ARCH=${ARCH:-"amd64"}
+ARCH="${ARCH:-amd64}"
 SUFFIX="-${ARCH}"
 
 cd $(dirname $0)/..
 
-TAG=${TAG:-${VERSION}${SUFFIX}}
-REPO=${REPO:-rancher}
+TAG="${TAG:-${VERSION}${SUFFIX}}"
+REPO="${REPO:-rancher}"
 
-if echo $TAG | grep -q dirty; then
+if echo "${TAG}" | grep -q dirty; then
     TAG=dev
 fi
 
@@ -19,9 +19,9 @@ mkdir -p dist/artifacts
 
 IMAGE=${REPO}/security-scan:${TAG}
 DOCKERFILE=package/Dockerfile
-if [ -e ${DOCKERFILE}.${ARCH} ]; then
-    DOCKERFILE=${DOCKERFILE}.${ARCH}
+if [ -e "${DOCKERFILE}.${ARCH}" ]; then
+    DOCKERFILE="${DOCKERFILE}.${ARCH}"
 fi
 
-docker build -f ${DOCKERFILE} -t ${IMAGE} .
-echo Built ${IMAGE}
+docker build --build-arg ARCH -f "${DOCKERFILE}" -t "${IMAGE}" .
+echo "Built ${IMAGE}"

--- a/tests/deploy.yaml
+++ b/tests/deploy.yaml
@@ -1,0 +1,365 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cis-operator-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cis-serviceaccount
+  namespace: cis-operator-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: rancher-cis-benchmark
+  name: cis-scan-ns
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - podsecuritypolicies
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - nodes
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+# Permissions from here onwards are not part of the original cis-scan-ns
+# and were given to ensure the test can work.
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  - configmaps
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - delete
+  - create
+- apiGroups:
+  - "apps"
+  resources:
+  - daemonsets
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - delete
+  - create
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cis-scan-ns
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cis-scan-ns
+subjects:
+- kind: ServiceAccount
+  name: cis-serviceaccount
+  namespace: cis-operator-system
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cis-s-config-cm-scan-vk6d4
+  namespace: cis-operator-system
+data:
+  config.json: |
+    {
+        "Description": "kube-bench plugin for CIS benchmarks",
+        "Filters": {
+            "LabelSelector": "",
+            "Namespaces": "[^\\w-.]+"
+        },
+        "PluginNamespace": "cis-operator-system",
+        "Plugins": [
+            {
+                "name": "rancher-kube-bench"
+            }
+        ],
+        "PluginSearchPath": [
+          "/plugins.d"
+        ],
+        "Resources": [],
+        "ResultsDir": "/tmp/sonobuoy",
+        "Server": {
+            "advertiseaddress": "service-rancher-cis-benchmark",
+            "bindaddress": "0.0.0.0",
+            "bindport": 443,
+            "timeoutseconds": 5400
+        },
+        "Namespace": "cis-operator-system",
+        "WorkerImage": "${SONOBUOY_IMAGE}",
+        "Version": "v0.56.7"
+    }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-rancher-cis-benchmark
+  namespace: cis-operator-system
+spec:
+  ports:
+  - name: http
+    port: 443
+    protocol: TCP
+    targetPort: 443
+  selector:    
+    run: sonobuoy-master
+  type: ClusterIP
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cis-s-plugins-cm-scan-vk6d4
+  namespace: cis-operator-system
+data:
+  rancher-kube-bench.yaml: |
+    podSpec:
+      containers: []
+      dnsPolicy: ClusterFirstWithHostNet
+      hostIPC: true
+      hostNetwork: true
+      hostPID: true
+      serviceAccountName: cis-serviceaccount
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/controlplane
+        operator: Exists
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/control-plane
+        operator: Exists
+      - effect: NoExecute
+        key: node-role.kubernetes.io/etcd
+        operator: Exists
+      - effect: NoExecute
+        key: CriticalAddonsOnly
+        operator: Exists
+      volumes:
+      - hostPath:
+          path: /
+        name: root
+      - hostPath:
+          path: /etc/passwd
+        name: etc-passwd
+      - hostPath:
+          path: /etc/group
+        name: etc-group
+      - hostPath:
+          path: /var/lib/rancher
+        name: rke2-root
+      - hostPath:
+          path: /etc/rancher
+        name: rke2-root-config
+      - hostPath:
+          path: /etc/cni/net.d
+        name: rke2-cni
+      - hostPath:
+          path: /var/log
+        name: var-log
+      - hostPath:
+          path: /run/log
+        name: run-log
+    sonobuoy-config:
+      driver: DaemonSet
+      plugin-name: rancher-kube-bench
+      result-type: rancher-kube-bench
+      result-format: raw
+    spec:
+      name: rancher-kube-bench
+      image: $IMAGE
+      command: ["/bin/bash", "-c", "run_sonobuoy_plugin.sh && sleep 3600"]
+      env:
+      - name: SONOBUOY_NS
+        value: cis-operator-system
+      - name: NODE_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: spec.nodeName
+      - name: RESULTS_DIR
+        value: /tmp/results
+      - name: CHROOT_DIR
+        value: /node
+      - name: OVERRIDE_BENCHMARK_VERSION
+        value: cis-1.23
+      imagePullPolicy: Always
+      securityContext:
+        privileged: true
+      volumeMounts:
+      - mountPath: /tmp/results
+        name: results
+        readOnly: false
+      - mountPath: /node
+        name: root
+        readOnly: true
+      - mountPath: /etc/passwd
+        name: etc-passwd
+        readOnly: true
+      - mountPath: /etc/group
+        name: etc-group
+        readOnly: true
+      - mountPath: /var/lib/rancher
+        name: rke2-root
+        readOnly: true
+      - mountPath: /etc/rancher
+        name: rke2-root-config
+        readOnly: true
+      - mountPath: /etc/cni/net.d
+        name: rke2-cni
+        readOnly: true
+      - mountPath: /var/log/
+        name: var-log
+        readOnly: true
+      - mountPath: /run/log/
+        name: run-log
+        readOnly: true
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app.kubernetes.io/instance: security-scan-runner-scan-6fjs5
+    app.kubernetes.io/name: rancher-cis-benchmark
+    cis.cattle.io/clusterscanprofile: cis-1.23-profile
+    cis.cattle.io/controller: cis-operator
+    cis.cattle.io/scan: scan-6fjs5
+    controller-uid: d1c0f186-f321-481f-8cdb-8c052e5cd738
+    job-name: security-scan-runner-scan-6fjs5
+    run: sonobuoy-master
+  annotations:
+    sonobuoy.hept.io/status: "{}"
+  name: security-scan-runner-scan-test
+  namespace: cis-operator-system
+spec:
+  containers:
+    - env:
+        - name: OVERRIDE_BENCHMARK_VERSION
+          value: rke2-cis-1.23-hardened
+        - name: SONOBUOY_NS
+          value: cis-operator-system
+        - name: SONOBUOY_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: SONOBUOY_ADVERTISE_IP
+          value: cisscan-rancher-cis-benchmark
+        - name: OUTPUT_CONFIGMAPNAME
+          value: cisscan-output-for-scan-vk6d4
+      image: $IMAGE
+      imagePullPolicy: Never
+      command: ["bash"]
+      args: ["-c", "while true; do echo hello; sleep 10;done"]
+      name: rancher-cis-benchmark
+      ports:
+        - containerPort: 8080
+          protocol: TCP
+      securityContext:
+        privileged: true
+      terminationMessagePath: /dev/termination-log
+      terminationMessagePolicy: File
+      volumeMounts:
+        - mountPath: /etc/sonobuoy
+          name: s-config-volume
+        - mountPath: /plugins.d
+          name: s-plugins-volume
+        - mountPath: /tmp/sonobuoy
+          name: output-volume
+        - mountPath: /var/lib/rancher
+          name: rke2-root
+        - mountPath: /etc/rancher
+          name: rke2-root-config
+        - mountPath: /etc/cni/net.d
+          name: rke2-cni
+        - mountPath: /etc/passwd
+          name: etc-passwd
+        - mountPath: /etc/group
+          name: etc-group
+        - mountPath: /var/log/
+          name: var-log
+        - mountPath: /run/log/
+          name: run-log
+        - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          name: kube-api-access-6k6bd
+          readOnly: true
+  dnsPolicy: ClusterFirst
+  hostIPC: true
+  hostPID: true
+  nodeSelector:
+    kubernetes.io/os: linux
+  serviceAccount: cis-serviceaccount
+  serviceAccountName: cis-serviceaccount
+  volumes:
+    - configMap:
+        defaultMode: 420
+        name: cis-s-config-cm-scan-vk6d4
+      name: s-config-volume
+    - configMap:
+        defaultMode: 420
+        name: cis-s-plugins-cm-scan-vk6d4
+      name: s-plugins-volume
+    - emptyDir: {}
+      name: output-volume
+    - hostPath:
+        path: /var/lib/rancher
+        type: ''
+      name: rke2-root
+    - hostPath:
+        path: /etc/rancher
+        type: ''
+      name: rke2-root-config
+    - hostPath:
+        path: /etc/cni/net.d
+        type: ''
+      name: rke2-cni
+    - hostPath:
+        path: /etc/passwd
+        type: ''
+      name: etc-passwd
+    - hostPath:
+        path: /etc/group
+        type: ''
+      name: etc-group
+    - hostPath:
+        path: /var/log
+        type: ''
+      name: var-log
+    - hostPath:
+        path: /run/log
+        type: ''
+      name: run-log
+    - name: kube-api-access-6k6bd
+      projected:
+        defaultMode: 420
+        sources:
+          - serviceAccountToken:
+              expirationSeconds: 3607
+              path: token
+          - configMap:
+              items:
+                - key: ca.crt
+                  path: ca.crt
+              name: kube-root-ca.crt
+          - downwardAPI:
+              items:
+                - fieldRef:
+                    apiVersion: v1
+                    fieldPath: metadata.namespace
+                  path: namespace
+---


### PR DESCRIPTION
This PR creates a E2E smoke test which will:

- Create a kind cluster.
- Deploy the security-scan.
- Wait for the `Daemonset` to be created.
- Output the CIS Benchmark results (or errors during the process).
- Remove arch-specific commands, referring to the `ARCH` env var instead.

A timeout of 10 minutes has been set, in case the process gets stuck for some reason. 