### PR TITLE
Fix 5.2.2 and 5.2.8 test failures on K8s v1.24 RKE2 hardened cluster with `restricted-nonroot` PSP policy

### DIFF
--- a/package/cfg/rke2-cis-1.23-hardened/policies.yaml
+++ b/package/cfg/rke2-cis-1.23-hardened/policies.yaml
@@ -93,7 +93,7 @@ groups:
 
       - id: 5.2.2
         text: "Minimize the admission of privileged containers (Manual)"
-        audit: kubectl get psp global-restricted-psp && kubectl get psp global-restricted-psp -o json | jq -r ".spec.runAsUser.rule" || kubectl get psp restricted-noroot-psp -o json | jq -r ".spec.runAsUser.rule"
+        audit: kubectl get psp global-restricted-psp && kubectl get psp global-restricted-psp -o json | jq -r ".spec.runAsUser.rule" || kubectl get psp restricted-noroot-psp && kubectl get psp restricted-noroot-psp -o json | jq -r ".spec.runAsUser.rule"
         tests:
            test_items:
              - flag: "MustRunAsNonRoot"
@@ -183,7 +183,7 @@ groups:
 
       - id: 5.2.8
         text: "Minimize the admission of containers with the NET_RAW capability (Automated)"
-        audit: "kubectl get psp global-restricted-psp -o json | jq -r .spec.requiredDropCapabilities[]"
+        audit: "kubectl get psp global-restricted-psp && kubectl get psp global-restricted-psp -o json | jq -r .spec.requiredDropCapabilities[] || kubectl get psp restricted-noroot-psp && kubectl get psp restricted-noroot-psp -o json | jq -r .spec.requiredDropCapabilities[]"
         tests:
           test_items:
             - flag: "ALL"

--- a/package/cfg/rke2-cis-1.23-hardened/policies.yaml
+++ b/package/cfg/rke2-cis-1.23-hardened/policies.yaml
@@ -93,7 +93,7 @@ groups:
 
       - id: 5.2.2
         text: "Minimize the admission of privileged containers (Manual)"
-        audit: "kubectl get psp global-restricted-psp -o json | jq -r '.spec.runAsUser.rule'"
+        audit: kubectl get psp global-restricted-psp && kubectl get psp global-restricted-psp -o json | jq -r ".spec.runAsUser.rule" || kubectl get psp restricted-noroot-psp -o json | jq -r ".spec.runAsUser.rule"
         tests:
            test_items:
              - flag: "MustRunAsNonRoot"


### PR DESCRIPTION
Related: https://github.com/rancher/rancher/issues/40718

5.2.2: The changes in this PR first checks if the `global-restricted-psp` PSP object is present by running the command `kubectl get psp global-restricted-psp`. If the object is present, the command runs `kubectl get psp global-restricted-psp -o json | jq -r ".spec.runAsUser.rule"` to get the `runAsUser` rule from the policy.

If the `global-restricted-psp` PSP object is not present, the command runs `kubectl get psp restricted-noroot-psp -o json | jq -r ".spec.runAsUser.rule"` to get the `runAsUser` rule from the `restricted-noroot-psp` policy.

5.2.8: Same as above.

CIS Scans on RKE2 hardened cluster with K8s 1.24 and restricted-noroot PSP policy:
![rke2-h-res-nroot](https://user-images.githubusercontent.com/32811240/223717064-5c822d27-567c-4d79-8c95-835ae76556e6.png)

CIS Scans on RKE2 hardened cluster with K8s 1.24 and `Default - RKE2 Embedded` policy:
![rke2-h-std](https://user-images.githubusercontent.com/32811240/223717123-42a0516e-fb29-4e85-a8f6-06f6e2cfb748.png)
