### PR TITLE
Fix RKE1 and RKE2 hardened 5.1.5 test failure.

### DIFF
--- a/package/helper_scripts/check_for_default_sa.sh
+++ b/package/helper_scripts/check_for_default_sa.sh
@@ -16,10 +16,10 @@ fi
 
 for ns in $(kubectl get ns --no-headers -o custom-columns=":metadata.name")
 do
-    for result in $(kubectl get clusterrolebinding,rolebinding -n $ns -o json | jq -r '.items[] | select((.subjects[].kind=="ServiceAccount" and .subjects[].name=="default") or (.subjects[].kind=="Group" and .subjects[].name=="system:serviceaccounts"))' | jq -r '"\(.roleRef.kind),\(.roleRef.name)"')
+    for result in $(kubectl get clusterrolebinding,rolebinding -n $ns -o json | jq -r '.items[] | select((.subjects[]?.kind=="ServiceAccount" and .subjects[]?.name=="default") or (.subjects[]?.kind=="Group" and .subjects[]?.name=="system:serviceaccounts"))' | jq -r '"\(.roleRef.kind),\(.roleRef.name)"')
     do
         read kind name <<<$(IFS=","; echo $result)
-        resource_count=$(kubectl get $kind $name -n $ns -o json | jq -r '.rules[] | select(.resources[] != "podsecuritypolicies")' | wc -l)
+        resource_count=$(kubectl get $kind $name -n $ns -o json | jq -r '.rules[] | select(.resources[]? != "podsecuritypolicies")' | wc -l)
         if [[ ${resource_count} -gt 0 ]]; then
             echo "false"
             exit


### PR DESCRIPTION
Related: https://github.com/rancher/rancher/issues/40817

To protect against the possibility that `.items` is not an array added `[]?` else the script was failing with below error
```
jq: error (at <stdin>:4638): Cannot iterate over null (null)
jq: error (at <stdin>:4638): Cannot iterate over null (null)
jq: error (at <stdin>:4638): Cannot iterate over null (null)
```
Now the test is giving appropriate result.  
![5 1 5](https://user-images.githubusercontent.com/32811240/224310119-352d450a-608f-4b4d-bf81-a0d4a2ce4aee.png)
