### PR TITLE
Add GKE 1.2.0

### DIFF
--- a/package/cfg/config.yaml
+++ b/package/cfg/config.yaml
@@ -222,8 +222,8 @@ version_mapping:
     - "rke2-cis-1.5-permissive"
   "eks-1.0.1": 
     - "eks-1.0.1"
-  "gke-1.0": 
-    - "gke-1.0"
+  "gke-1.2.0": 
+    - "gke-1.2.0"
   "aks-1.0": 
     - "aks-1.0"	
   "v1.20.5+rke2r1": 
@@ -328,7 +328,7 @@ target_mapping:
     - "policies"  
   "eks-1.0.1":
     - "node"
-  "gke-1.0":
+  "gke-1.2.0":
     - "node"
     - "managedservices"
     - "policies"


### PR DESCRIPTION
This PR adds GKE 1.2.0 and removes GKE 1.0
Related issue: https://github.com/rancher/cis-operator/issues/192