### PR TITLE
Fix CIS test 1.2.14 for K3s Hardened profile

### DIFF
--- a/package/cfg/k3s-cis-1.23-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.23-hardened/master.yaml
@@ -537,7 +537,7 @@ groups:
 
       - id: 1.2.14
         text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'ServiceAccount'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         tests:
           bin_op: or
           test_items:


### PR DESCRIPTION
Related issue: https://github.com/rancher/rancher/issues/41642

Snapshot of the scan on v1.26 K3s hardened cluster:

![Screenshot from 2023-05-23 18-06-32](https://github.com/rancher/security-scan/assets/32811240/850d810d-85a6-4541-b820-0fe6b13ce8f9)

- [ ] TODO: Tag `v0.2.12-rc2` when the PR is merged. 