### PR TITLE
removed rke2.yaml filepath from configuration

### DIFF
--- a/package/cfg/config.yaml
+++ b/package/cfg/config.yaml
@@ -134,8 +134,7 @@ node:
       - "/etc/systemd/system/kubelet.service"
       - "/lib/systemd/system/kubelet.service"
       - "/etc/systemd/system/snap.kubelet.daemon.service"
-      - "/etc/rancher/rke2/rke2.yaml"
-      - /var/lib/rancher/rke2/agent/kubelet.kubeconfig
+      - "/var/lib/rancher/rke2/agent/kubelet.kubeconfig"
     defaultconf: "/var/lib/kubelet/config.yaml"
     defaultsvc: "/etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
     defaultkubeconfig: "/etc/kubernetes/kubelet.conf"


### PR DESCRIPTION
to remove client-key-data,certificate-authority-data and client-certificate-data fields from cis scan report.
linked issue: https://github.com/rancherlabs/rancher-security/issues/1159
done changes as per: https://github.com/rancherlabs/rancher-security/issues/1159#issuecomment-1564994139

tested this change with a custom image on
- rancher:2.7-head 
- rke2 cluster v1.24.13-rke2r1
- cis chart version 4.0.0


test results: client-key-data and client-certificate-data fields were no longer present in the report.
![Screenshot from 2023-05-30 00-01-14](https://github.com/rancher/security-scan/assets/115442970/0dca48b1-83ed-4a69-9802-b56796b661dd)
