### PR TITLE
CIS-1.7 (1.25) - Add RKE1 profiles

### DIFF
--- a/package/cfg/cis-1.7/config.yaml
+++ b/package/cfg/cis-1.7/config.yaml
@@ -1,0 +1,2 @@
+---
+## Version-specific settings that override the values in cfg/config.yaml

--- a/package/cfg/cis-1.7/controlplane.yaml
+++ b/package/cfg/cis-1.7/controlplane.yaml
@@ -1,0 +1,60 @@
+---
+controls:
+version: "cis-1.7"
+id: 3
+text: "Control Plane Configuration"
+type: "controlplane"
+groups:
+  - id: 3.1
+    text: "Authentication and Authorization"
+    checks:
+      - id: 3.1.1
+        text: "Client certificate authentication should not be used for users (Manual)"
+        type: "manual"
+        remediation: |
+          Alternative mechanisms provided by Kubernetes such as the use of OIDC should be
+          implemented in place of client certificates.
+        scored: false
+      - id: 3.1.2
+        text: "Service account token authentication should not be used for users (Manual)"
+        type: "manual"
+        remediation: |
+          Alternative mechanisms provided by Kubernetes such as the use of OIDC should be implemented
+          in place of service account tokens.
+        scored: false
+      - id: 3.1.3
+        text: "Bootstrap token authentication should not be used for users (Manual)"
+        type: "manual"
+        remediation: |
+          Alternative mechanisms provided by Kubernetes such as the use of OIDC should be implemented
+          in place of bootstrap tokens.
+        scored: false
+
+  - id: 3.2
+    text: "Logging"
+    checks:
+      - id: 3.2.1
+        text: "Ensure that a minimal audit policy is created (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-policy-file"
+              set: true
+        remediation: |
+          Create an audit policy file for your cluster.
+        scored: false
+
+      - id: 3.2.2
+        text: "Ensure that the audit policy covers key security concerns (Manual)"
+        type: "manual"
+        remediation: |
+          Review the audit policy provided for the cluster and ensure that it covers
+          at least the following areas,
+          - Access to Secrets managed by the cluster. Care should be taken to only
+            log Metadata for requests to Secrets, ConfigMaps, and TokenReviews, in
+            order to avoid risk of logging sensitive data.
+          - Modification of Pod and Deployment objects.
+          - Use of `pods/exec`, `pods/portforward`, `pods/proxy` and `services/proxy`.
+          For most requests, minimally logging at the Metadata level is recommended
+          (the most basic level of logging).
+        scored: false

--- a/package/cfg/cis-1.7/controlplane.yaml
+++ b/package/cfg/cis-1.7/controlplane.yaml
@@ -1,6 +1,6 @@
 ---
 controls:
-version: "cis-1.7"
+version: "1.7"
 id: 3
 text: "Control Plane Configuration"
 type: "controlplane"

--- a/package/cfg/cis-1.7/etcd.yaml
+++ b/package/cfg/cis-1.7/etcd.yaml
@@ -1,0 +1,135 @@
+---
+controls:
+version: "cis-1.7"
+id: 2
+text: "Etcd Node Configuration"
+type: "etcd"
+groups:
+  - id: 2
+    text: "Etcd Node Configuration"
+    checks:
+      - id: 2.1
+        text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--cert-file"
+              env: "ETCD_CERT_FILE"
+            - flag: "--key-file"
+              env: "ETCD_KEY_FILE"
+        remediation: |
+          Follow the etcd service documentation and configure TLS encryption.
+          Then, edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml
+          on the master node and set the below parameters.
+          --cert-file=</path/to/ca-file>
+          --key-file=</path/to/key-file>
+        scored: true
+
+      - id: 2.2
+        text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          test_items:
+            - flag: "--client-cert-auth"
+              env: "ETCD_CLIENT_CERT_AUTH"
+              compare:
+                op: eq
+                value: true
+        remediation: |
+          Edit the etcd pod specification file $etcdconf on the master
+          node and set the below parameter.
+          --client-cert-auth="true"
+        scored: true
+
+      - id: 2.3
+        text: "Ensure that the --auto-tls argument is not set to true (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--auto-tls"
+              env: "ETCD_AUTO_TLS"
+              set: false
+            - flag: "--auto-tls"
+              env: "ETCD_AUTO_TLS"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the etcd pod specification file $etcdconf on the master
+          node and either remove the --auto-tls parameter or set it to false.
+            --auto-tls=false
+        scored: true
+
+      - id: 2.4
+        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are
+        set as appropriate (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--peer-cert-file"
+              env: "ETCD_PEER_CERT_FILE"
+            - flag: "--peer-key-file"
+              env: "ETCD_PEER_KEY_FILE"
+        remediation: |
+          Follow the etcd service documentation and configure peer TLS encryption as appropriate
+          for your etcd cluster.
+          Then, edit the etcd pod specification file $etcdconf on the
+          master node and set the below parameters.
+          --peer-client-file=</path/to/peer-cert-file>
+          --peer-key-file=</path/to/peer-key-file>
+        scored: true
+
+      - id: 2.5
+        text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          test_items:
+            - flag: "--peer-client-cert-auth"
+              env: "ETCD_PEER_CLIENT_CERT_AUTH"
+              compare:
+                op: eq
+                value: true
+        remediation: |
+          Edit the etcd pod specification file $etcdconf on the master
+          node and set the below parameter.
+          --peer-client-cert-auth=true
+        scored: true
+
+      - id: 2.6
+        text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--peer-auto-tls"
+              env: "ETCD_PEER_AUTO_TLS"
+              set: false
+            - flag: "--peer-auto-tls"
+              env: "ETCD_PEER_AUTO_TLS"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the etcd pod specification file $etcdconf on the master
+          node and either remove the --peer-auto-tls parameter or set it to false.
+          --peer-auto-tls=false
+        scored: true
+
+      - id: 2.7
+        text: "Ensure that a unique Certificate Authority is used for etcd (Manual)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          test_items:
+            - flag: "--trusted-ca-file"
+              env: "ETCD_TRUSTED_CA_FILE"
+        remediation: |
+          [Manual test]
+          Follow the etcd documentation and create a dedicated certificate authority setup for the
+          etcd service.
+          Then, edit the etcd pod specification file $etcdconf on the
+          master node and set the below parameter.
+          --trusted-ca-file=</path/to/ca-file>
+        scored: false

--- a/package/cfg/cis-1.7/etcd.yaml
+++ b/package/cfg/cis-1.7/etcd.yaml
@@ -1,6 +1,6 @@
 ---
 controls:
-version: "cis-1.7"
+version: "1.7"
 id: 2
 text: "Etcd Node Configuration"
 type: "etcd"

--- a/package/cfg/cis-1.7/master.yaml
+++ b/package/cfg/cis-1.7/master.yaml
@@ -1,0 +1,947 @@
+---
+controls:
+version: "cis-1.7"
+id: 1
+text: "Control Plane Security Configuration"
+type: "master"
+groups:
+  - id: 1.1
+    text: "Control Plane Node Configuration Files"
+    checks:
+      - id: 1.1.1
+        text: "Ensure that the API server pod specification file permissions are set to 600 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $apiserverconf; then stat -c permissions=%a $apiserverconf; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the
+          control plane node.
+          For example, chmod 600 $apiserverconf
+        scored: true
+
+      - id: 1.1.2
+        text: "Ensure that the API server pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $apiserverconf; then stat -c %U:%G $apiserverconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example, chown root:root $apiserverconf
+        scored: true
+
+      - id: 1.1.3
+        text: "Ensure that the controller manager pod specification file permissions are set to 600 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $controllermanagerconf; then stat -c permissions=%a $controllermanagerconf; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example, chmod 600 $controllermanagerconf
+        scored: true
+
+      - id: 1.1.4
+        text: "Ensure that the controller manager pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $controllermanagerconf; then stat -c %U:%G $controllermanagerconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example, chown root:root $controllermanagerconf
+        scored: true
+
+      - id: 1.1.5
+        text: "Ensure that the scheduler pod specification file permissions are set to 600 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c permissions=%a $schedulerconf; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example, chmod 600 $schedulerconf
+        scored: true
+
+      - id: 1.1.6
+        text: "Ensure that the scheduler pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c %U:%G $schedulerconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example, chown root:root $schedulerconf
+        scored: true
+
+      - id: 1.1.7
+        text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod 600 $etcdconf
+        scored: true
+
+      - id: 1.1.8
+        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c %U:%G; fi'"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root $etcdconf
+        scored: true
+
+      - id: 1.1.9
+        text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Manual)"
+        audit: |
+          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
+          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example, chmod 600 <path/to/cni/files>
+        scored: false
+
+      - id: 1.1.10
+        text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
+        audit: |
+          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
+          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root <path/to/cni/files>
+        scored: false
+
+      - id: 1.1.11
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
+        audit: |
+          DATA_DIR=''
+          for d in $(ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%'); do
+            if test -d "$d"; then DATA_DIR="$d"; fi
+          done
+          if ! test -d "$DATA_DIR"; then DATA_DIR=$etcddatadir; fi
+          stat -c permissions=%a "$DATA_DIR"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "700"
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above). For example,
+          chmod 700 /var/lib/etcd
+        scored: true
+
+      - id: 1.1.12
+        text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
+        audit: |
+          DATA_DIR=''
+          for d in $(ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%'); do
+            if test -d "$d"; then DATA_DIR="$d"; fi
+          done
+          if ! test -d "$DATA_DIR"; then DATA_DIR=$etcddatadir; fi
+          stat -c %U:%G "$DATA_DIR"
+        tests:
+          test_items:
+            - flag: "etcd:etcd"
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above).
+          For example, chown etcd:etcd /var/lib/etcd
+        scored: true
+
+      - id: 1.1.13
+        text: "Ensure that the admin.conf file permissions are set to 600 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c permissions=%a /etc/kubernetes/admin.conf; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example, chmod 600 /etc/kubernetes/admin.conf
+        scored: true
+
+      - id: 1.1.14
+        text: "Ensure that the admin.conf file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c %U:%G /etc/kubernetes/admin.conf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example, chown root:root /etc/kubernetes/admin.conf
+        scored: true
+
+      - id: 1.1.15
+        text: "Ensure that the scheduler.conf file permissions are set to 600 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c permissions=%a $schedulerkubeconfig; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod 600 $schedulerkubeconfig
+        scored: true
+
+      - id: 1.1.16
+        text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c %U:%G $schedulerkubeconfig; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root $schedulerkubeconfig
+        scored: true
+
+      - id: 1.1.17
+        text: "Ensure that the controller-manager.conf file permissions are set to 600 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c permissions=%a $controllermanagerkubeconfig; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod 600 $controllermanagerkubeconfig
+        scored: true
+
+      - id: 1.1.18
+        text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c %U:%G $controllermanagerkubeconfig; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root $controllermanagerkubeconfig
+        scored: true
+
+      - id: 1.1.19
+        text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
+        audit: "find /etc/kubernetes/pki/ | xargs stat -c %U:%G"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown -R root:root /etc/kubernetes/pki/
+        scored: true
+
+      - id: 1.1.20
+        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"
+        audit: "find /etc/kubernetes/pki/ -name '*.crt' | xargs stat -c permissions=%a"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod -R 600 /etc/kubernetes/pki/*.crt
+        scored: false
+
+      - id: 1.1.21
+        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
+        audit: "find /etc/kubernetes/pki/ -name '*.key' | xargs stat -c permissions=%a"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod -R 600 /etc/kubernetes/pki/*.key
+        scored: false
+
+  - id: 1.2
+    text: "API Server"
+    checks:
+      - id: 1.2.1
+        text: "Ensure that the --anonymous-auth argument is set to false (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--anonymous-auth"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the below parameter.
+          --anonymous-auth=false
+        scored: false
+
+      - id: 1.2.2
+        text: "Ensure that the --token-auth-file parameter is not set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--token-auth-file"
+              set: false
+        remediation: |
+          Follow the documentation and configure alternate mechanisms for authentication. Then,
+          edit the API server pod specification file $apiserverconf
+          on the control plane node and remove the --token-auth-file=<filename> parameter.
+        scored: true
+
+      - id: 1.2.3
+        text: "Ensure that the --DenyServiceExternalIPs is set (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: have
+                value: "DenyServiceExternalIPs"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and remove the `DenyServiceExternalIPs`
+          from enabled admission plugins.
+        scored: false
+
+      - id: 1.2.4
+        text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--kubelet-client-certificate"
+            - flag: "--kubelet-client-key"
+        remediation: |
+          Follow the Kubernetes documentation and set up the TLS connection between the
+          apiserver and kubelets. Then, edit API server pod specification file
+          $apiserverconf on the control plane node and set the
+          kubelet client certificate and key parameters as below.
+          --kubelet-client-certificate=<path/to/client-certificate-file>
+          --kubelet-client-key=<path/to/client-key-file>
+        scored: true
+
+      - id: 1.2.5
+        text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--kubelet-certificate-authority"
+        remediation: |
+          Follow the Kubernetes documentation and setup the TLS connection between
+          the apiserver and kubelets. Then, edit the API server pod specification file
+          $apiserverconf on the control plane node and set the
+          --kubelet-certificate-authority parameter to the path to the cert file for the certificate authority.
+          --kubelet-certificate-authority=<ca-string>
+        scored: true
+
+      - id: 1.2.6
+        text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--authorization-mode"
+              compare:
+                op: nothave
+                value: "AlwaysAllow"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --authorization-mode parameter to values other than AlwaysAllow.
+          One such example could be as below.
+          --authorization-mode=RBAC
+        scored: true
+
+      - id: 1.2.7
+        text: "Ensure that the --authorization-mode argument includes Node (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--authorization-mode"
+              compare:
+                op: has
+                value: "Node"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --authorization-mode parameter to a value that includes Node.
+          --authorization-mode=Node,RBAC
+        scored: true
+
+      - id: 1.2.8
+        text: "Ensure that the --authorization-mode argument includes RBAC (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--authorization-mode"
+              compare:
+                op: has
+                value: "RBAC"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --authorization-mode parameter to a value that includes RBAC,
+          for example `--authorization-mode=Node,RBAC`.
+        scored: true
+
+      - id: 1.2.9
+        text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "EventRateLimit"
+        remediation: |
+          Follow the Kubernetes documentation and set the desired limits in a configuration file.
+          Then, edit the API server pod specification file $apiserverconf
+          and set the below parameters.
+          --enable-admission-plugins=...,EventRateLimit,...
+          --admission-control-config-file=<path/to/configuration/file>
+        scored: false
+
+      - id: 1.2.10
+        text: "Ensure that the admission control plugin AlwaysAdmit is not set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: nothave
+                value: AlwaysAdmit
+            - flag: "--enable-admission-plugins"
+              set: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and either remove the --enable-admission-plugins parameter, or set it to a
+          value that does not include AlwaysAdmit.
+        scored: true
+
+      - id: 1.2.11
+        text: "Ensure that the admission control plugin AlwaysPullImages is set (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "AlwaysPullImages"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --enable-admission-plugins parameter to include
+          AlwaysPullImages.
+          --enable-admission-plugins=...,AlwaysPullImages,...
+        scored: false
+
+      - id: 1.2.12
+        text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "SecurityContextDeny"
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "PodSecurityPolicy"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --enable-admission-plugins parameter to include
+          SecurityContextDeny, unless PodSecurityPolicy is already in place.
+          --enable-admission-plugins=...,SecurityContextDeny,...
+        scored: false
+
+      - id: 1.2.13
+        text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--disable-admission-plugins"
+              compare:
+                op: nothave
+                value: "ServiceAccount"
+            - flag: "--disable-admission-plugins"
+              set: false
+        remediation: |
+          Follow the documentation and create ServiceAccount objects as per your environment.
+          Then, edit the API server pod specification file $apiserverconf
+          on the control plane node and ensure that the --disable-admission-plugins parameter is set to a
+          value that does not include ServiceAccount.
+        scored: true
+
+      - id: 1.2.14
+        text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--disable-admission-plugins"
+              compare:
+                op: nothave
+                value: "NamespaceLifecycle"
+            - flag: "--disable-admission-plugins"
+              set: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --disable-admission-plugins parameter to
+          ensure it does not include NamespaceLifecycle.
+        scored: true
+
+      - id: 1.2.15
+        text: "Ensure that the admission control plugin NodeRestriction is set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "NodeRestriction"
+        remediation: |
+          Follow the Kubernetes documentation and configure NodeRestriction plug-in on kubelets.
+          Then, edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --enable-admission-plugins parameter to a
+          value that includes NodeRestriction.
+          --enable-admission-plugins=...,NodeRestriction,...
+        scored: true
+
+      - id: 1.2.16
+        text: "Ensure that the --secure-port argument is not set to 0 - NoteThis recommendation is obsolete and will be deleted per the consensus process (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--secure-port"
+              compare:
+                op: gt
+                value: 0
+            - flag: "--secure-port"
+              set: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and either remove the --secure-port parameter or
+          set it to a different (non-zero) desired port.
+        scored: false
+
+      - id: 1.2.17
+        text: "Ensure that the --profiling argument is set to false (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--profiling"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the below parameter.
+          --profiling=false
+        scored: true
+
+      - id: 1.2.18
+        text: "Ensure that the --audit-log-path argument is set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-log-path"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --audit-log-path parameter to a suitable path and
+          file where you would like audit logs to be written, for example,
+          --audit-log-path=/var/log/apiserver/audit.log
+        scored: true
+
+      - id: 1.2.19
+        text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-log-maxage"
+              compare:
+                op: gte
+                value: 30
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --audit-log-maxage parameter to 30
+          or as an appropriate number of days, for example,
+          --audit-log-maxage=30
+        scored: true
+
+      - id: 1.2.20
+        text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-log-maxbackup"
+              compare:
+                op: gte
+                value: 10
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --audit-log-maxbackup parameter to 10 or to an appropriate
+          value. For example,
+          --audit-log-maxbackup=10
+        scored: true
+
+      - id: 1.2.21
+        text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-log-maxsize"
+              compare:
+                op: gte
+                value: 100
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --audit-log-maxsize parameter to an appropriate size in MB.
+          For example, to set it as 100 MB, --audit-log-maxsize=100
+        scored: true
+
+      - id: 1.2.22
+        text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        type: manual
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          and set the below parameter as appropriate and if needed.
+          For example, --request-timeout=300s
+        scored: false
+
+      - id: 1.2.23
+        text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--service-account-lookup"
+              set: false
+            - flag: "--service-account-lookup"
+              compare:
+                op: eq
+                value: true
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the below parameter.
+          --service-account-lookup=true
+          Alternatively, you can delete the --service-account-lookup parameter from this file so
+          that the default takes effect.
+        scored: true
+
+      - id: 1.2.24
+        text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--service-account-key-file"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --service-account-key-file parameter
+          to the public key file for service accounts. For example,
+          --service-account-key-file=<filename>
+        scored: true
+
+      - id: 1.2.25
+        text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--etcd-certfile"
+            - flag: "--etcd-keyfile"
+        remediation: |
+          Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
+          Then, edit the API server pod specification file $apiserverconf
+          on the control plane node and set the etcd certificate and key file parameters.
+          --etcd-certfile=<path/to/client-certificate-file>
+          --etcd-keyfile=<path/to/client-key-file>
+        scored: true
+
+      - id: 1.2.26
+        text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--tls-cert-file"
+            - flag: "--tls-private-key-file"
+        remediation: |
+          Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
+          Then, edit the API server pod specification file $apiserverconf
+          on the control plane node and set the TLS certificate and private key file parameters.
+          --tls-cert-file=<path/to/tls-certificate-file>
+          --tls-private-key-file=<path/to/tls-key-file>
+        scored: true
+
+      - id: 1.2.27
+        text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--client-ca-file"
+        remediation: |
+          Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
+          Then, edit the API server pod specification file $apiserverconf
+          on the control plane node and set the client certificate authority file.
+          --client-ca-file=<path/to/client-ca-file>
+        scored: true
+
+      - id: 1.2.28
+        text: "Ensure that the --etcd-cafile argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--etcd-cafile"
+        remediation: |
+          Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
+          Then, edit the API server pod specification file $apiserverconf
+          on the control plane node and set the etcd certificate authority file parameter.
+          --etcd-cafile=<path/to/ca-file>
+        scored: true
+
+      - id: 1.2.29
+        text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--encryption-provider-config"
+        remediation: |
+          Follow the Kubernetes documentation and configure a EncryptionConfig file.
+          Then, edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --encryption-provider-config parameter to the path of that file.
+          For example, --encryption-provider-config=</path/to/EncryptionConfig/File>
+        scored: false
+
+      - id: 1.2.30
+        text: "Ensure that encryption providers are appropriately configured (Manual)"
+        audit: |
+          ENCRYPTION_PROVIDER_CONFIG=$(ps -ef | grep $apiserverbin | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
+          if test -e $ENCRYPTION_PROVIDER_CONFIG; then grep -A1 'providers:' $ENCRYPTION_PROVIDER_CONFIG | tail -n1 | grep -o "[A-Za-z]*" | sed 's/^/provider=/'; fi
+        tests:
+          test_items:
+            - flag: "provider"
+              compare:
+                op: valid_elements
+                value: "aescbc,kms,secretbox"
+        remediation: |
+          Follow the Kubernetes documentation and configure a EncryptionConfig file.
+          In this file, choose aescbc, kms or secretbox as the encryption provider.
+        scored: false
+
+      - id: 1.2.31
+        text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--tls-cipher-suites"
+              compare:
+                op: valid_elements
+                value: "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_RSA_WITH_3DES_EDE_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_256_GCM_SHA384"
+        remediation: |
+          Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
+          on the control plane node and set the below parameter.
+          --tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,
+          TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+          TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+          TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+          TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+          TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+          TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_RSA_WITH_3DES_EDE_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,
+          TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_256_GCM_SHA384
+        scored: false
+
+  - id: 1.3
+    text: "Controller Manager"
+    checks:
+      - id: 1.3.1
+        text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Manual)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--terminated-pod-gc-threshold"
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the control plane node and set the --terminated-pod-gc-threshold to an appropriate threshold,
+          for example, --terminated-pod-gc-threshold=10
+        scored: false
+
+      - id: 1.3.2
+        text: "Ensure that the --profiling argument is set to false (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--profiling"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the control plane node and set the below parameter.
+          --profiling=false
+        scored: true
+
+      - id: 1.3.3
+        text: "Ensure that the --use-service-account-credentials argument is set to true (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--use-service-account-credentials"
+              compare:
+                op: noteq
+                value: false
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the control plane node to set the below parameter.
+          --use-service-account-credentials=true
+        scored: true
+
+      - id: 1.3.4
+        text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--service-account-private-key-file"
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the control plane node and set the --service-account-private-key-file parameter
+          to the private key file for service accounts.
+          --service-account-private-key-file=<filename>
+        scored: true
+
+      - id: 1.3.5
+        text: "Ensure that the --root-ca-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--root-ca-file"
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the control plane node and set the --root-ca-file parameter to the certificate bundle file`.
+          --root-ca-file=<path/to/file>
+        scored: true
+
+      - id: 1.3.6
+        text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--feature-gates"
+              compare:
+                op: nothave
+                value: "RotateKubeletServerCertificate=false"
+              set: true
+            - flag: "--feature-gates"
+              set: false
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the control plane node and set the --feature-gates parameter to include RotateKubeletServerCertificate=true.
+          --feature-gates=RotateKubeletServerCertificate=true
+        scored: true
+
+      - id: 1.3.7
+        text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--bind-address"
+              compare:
+                op: eq
+                value: "127.0.0.1"
+            - flag: "--bind-address"
+              set: false
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the control plane node and ensure the correct value for the --bind-address parameter
+        scored: true
+
+  - id: 1.4
+    text: "Scheduler"
+    checks:
+      - id: 1.4.1
+        text: "Ensure that the --profiling argument is set to false (Automated)"
+        audit: "/bin/ps -ef | grep $schedulerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--profiling"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the Scheduler pod specification file $schedulerconf file
+          on the control plane node and set the below parameter.
+          --profiling=false
+        scored: true
+
+      - id: 1.4.2
+        text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
+        audit: "/bin/ps -ef | grep $schedulerbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--bind-address"
+              compare:
+                op: eq
+                value: "127.0.0.1"
+            - flag: "--bind-address"
+              set: false
+        remediation: |
+          Edit the Scheduler pod specification file $schedulerconf
+          on the control plane node and ensure the correct value for the --bind-address parameter
+        scored: true

--- a/package/cfg/cis-1.7/master.yaml
+++ b/package/cfg/cis-1.7/master.yaml
@@ -1,6 +1,6 @@
 ---
 controls:
-version: "cis-1.7"
+version: "1.7"
 id: 1
 text: "Control Plane Security Configuration"
 type: "master"

--- a/package/cfg/cis-1.7/node.yaml
+++ b/package/cfg/cis-1.7/node.yaml
@@ -1,0 +1,461 @@
+---
+controls:
+version: "cis-1.7"
+id: 4
+text: "Worker Node Security Configuration"
+type: "node"
+groups:
+  - id: 4.1
+    text: "Worker Node Configuration Files"
+    checks:
+      - id: 4.1.1
+        text: "Ensure that the kubelet service file permissions are set to 600 or more restrictive (Automated)"
+        audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c permissions=%a $kubeletsvc; fi'' '
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example, chmod 600 $kubeletsvc
+        scored: true
+
+      - id: 4.1.2
+        text: "Ensure that the kubelet service file ownership is set to root:root (Automated)"
+        audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc; fi'' '
+        tests:
+          test_items:
+            - flag: root:root
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chown root:root $kubeletsvc
+        scored: true
+
+      - id: 4.1.3
+        text: "If proxy kubeconfig file exists ensure permissions are set to 600 or more restrictive (Manual)"
+        audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c permissions=%a $proxykubeconfig; fi'' '
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "permissions"
+              set: true
+              compare:
+                op: bitmask
+                value: "600"
+            - flag: "$proxykubeconfig"
+              set: false
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chmod 600 $proxykubeconfig
+        scored: false
+
+      - id: 4.1.4
+        text: "If proxy kubeconfig file exists ensure ownership is set to root:root (Manual)"
+        audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c %U:%G $proxykubeconfig; fi'' '
+        tests:
+          bin_op: or
+          test_items:
+            - flag: root:root
+            - flag: "$proxykubeconfig"
+              set: false
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example, chown root:root $proxykubeconfig
+        scored: false
+
+      - id: 4.1.5
+        text: "Ensure that the --kubeconfig kubelet.conf file permissions are set to 600 or more restrictive (Automated)"
+        audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c permissions=%a $kubeletkubeconfig; fi'' '
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chmod 600 $kubeletkubeconfig
+        scored: true
+
+      - id: 4.1.6
+        text: "Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root (Automated)"
+        audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c %U:%G $kubeletkubeconfig; fi'' '
+        tests:
+          test_items:
+            - flag: root:root
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chown root:root $kubeletkubeconfig
+        scored: true
+
+      - id: 4.1.7
+        text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Manual)"
+        audit: |
+          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
+          if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
+          if test -e $CAFILE; then stat -c permissions=%a $CAFILE; fi
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the following command to modify the file permissions of the
+          --client-ca-file chmod 600 <filename>
+        scored: false
+
+      - id: 4.1.8
+        text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
+        audit: |
+          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
+          if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
+          if test -e $CAFILE; then stat -c %U:%G $CAFILE; fi
+        tests:
+          test_items:
+            - flag: root:root
+              compare:
+                op: eq
+                value: root:root
+        remediation: |
+          Run the following command to modify the ownership of the --client-ca-file.
+          chown root:root <filename>
+        scored: false
+
+      - id: 4.1.9
+        text: "If the kubelet config.yaml configuration file is being used validate permissions set to 600 or more restrictive (Manual)"
+        audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c permissions=%a $kubeletconf; fi'' '
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the following command (using the config file location identified in the Audit step)
+          chmod 600 $kubeletconf
+        scored: false
+
+      - id: 4.1.10
+        text: "If the kubelet config.yaml configuration file is being used validate file ownership is set to root:root (Manual)"
+        audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c %U:%G $kubeletconf; fi'' '
+        tests:
+          test_items:
+            - flag: root:root
+        remediation: |
+          Run the following command (using the config file location identified in the Audit step)
+          chown root:root $kubeletconf
+        scored: false
+
+  - id: 4.2
+    text: "Kubelet"
+    checks:
+      - id: 4.2.1
+        text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: "--anonymous-auth"
+              path: '{.authentication.anonymous.enabled}'
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          If using a Kubelet config file, edit the file to set `authentication: anonymous: enabled` to
+          `false`.
+          If using executable arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          `--anonymous-auth=false`
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.2
+        text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --authorization-mode
+              path: '{.authorization.mode}'
+              compare:
+                op: nothave
+                value: AlwaysAllow
+        remediation: |
+          If using a Kubelet config file, edit the file to set `authorization.mode` to Webhook. If
+          using executable arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_AUTHZ_ARGS variable.
+          --authorization-mode=Webhook
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.3
+        text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --client-ca-file
+              path: '{.authentication.x509.clientCAFile}'
+        remediation: |
+          If using a Kubelet config file, edit the file to set `authentication.x509.clientCAFile` to
+          the location of the client CA file.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_AUTHZ_ARGS variable.
+          --client-ca-file=<path/to/client-ca-file>
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.4
+        text: "Verify that the --read-only-port argument is set to 0 (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--read-only-port"
+              path: '{.readOnlyPort}'
+              compare:
+                op: eq
+                value: 0
+            - flag: "--read-only-port"
+              path: '{.readOnlyPort}'
+              set: false
+        remediation: |
+          If using a Kubelet config file, edit the file to set `readOnlyPort` to 0.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          --read-only-port=0
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.5
+        text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --streaming-connection-idle-timeout
+              path: '{.streamingConnectionIdleTimeout}'
+              compare:
+                op: noteq
+                value: 0
+            - flag: --streaming-connection-idle-timeout
+              path: '{.streamingConnectionIdleTimeout}'
+              set: false
+          bin_op: or
+        remediation: |
+          If using a Kubelet config file, edit the file to set `streamingConnectionIdleTimeout` to a
+          value other than 0.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          --streaming-connection-idle-timeout=5m
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.6
+        text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --make-iptables-util-chains
+              path: '{.makeIPTablesUtilChains}'
+              compare:
+                op: eq
+                value: true
+            - flag: --make-iptables-util-chains
+              path: '{.makeIPTablesUtilChains}'
+              set: false
+          bin_op: or
+        remediation: |
+          If using a Kubelet config file, edit the file to set `makeIPTablesUtilChains` to `true`.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          remove the --make-iptables-util-chains argument from the
+          KUBELET_SYSTEM_PODS_ARGS variable.
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.7
+        text: "Ensure that the --hostname-override argument is not set (Manual)"
+        # This is one of those properties that can only be set as a command line argument.
+        # To check if the property is set as expected, we need to parse the kubelet command
+        # instead reading the Kubelet Configuration file.
+        audit: "/bin/ps -fC $kubeletbin "
+        tests:
+          test_items:
+            - flag: --hostname-override
+              set: false
+        remediation: |
+          Edit the kubelet service file $kubeletsvc
+          on each worker node and remove the --hostname-override argument from the
+          KUBELET_SYSTEM_PODS_ARGS variable.
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.8
+        text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --event-qps
+              path: '{.eventRecordQPS}'
+              compare:
+                op: gte
+                value: 0
+            - flag: --event-qps
+              path: '{.eventRecordQPS}'
+              set: false
+          bin_op: or
+        remediation: |
+          If using a Kubelet config file, edit the file to set `eventRecordQPS` to an appropriate level.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.9
+        text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --tls-cert-file
+              path: '{.tlsCertFile}'
+            - flag: --tls-private-key-file
+              path: '{.tlsPrivateKeyFile}'
+        remediation: |
+          If using a Kubelet config file, edit the file to set `tlsCertFile` to the location
+          of the certificate file to use to identify this Kubelet, and `tlsPrivateKeyFile`
+          to the location of the corresponding private key file.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameters in KUBELET_CERTIFICATE_ARGS variable.
+          --tls-cert-file=<path/to/tls-certificate-file>
+          --tls-private-key-file=<path/to/tls-key-file>
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.10
+        text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --rotate-certificates
+              path: '{.rotateCertificates}'
+              compare:
+                op: eq
+                value: true
+            - flag: --rotate-certificates
+              path: '{.rotateCertificates}'
+              set: false
+          bin_op: or
+        remediation: |
+          If using a Kubelet config file, edit the file to add the line `rotateCertificates` to `true` or
+          remove it altogether to use the default value.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          remove --rotate-certificates=false argument from the KUBELET_CERTIFICATE_ARGS
+          variable.
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.11
+        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: RotateKubeletServerCertificate
+              path: '{.featureGates.RotateKubeletServerCertificate}'
+              compare:
+                op: nothave
+                value: false
+            - flag: RotateKubeletServerCertificate
+              path: '{.featureGates.RotateKubeletServerCertificate}'
+              set: false
+        remediation: |
+          Edit the kubelet service file $kubeletsvc
+          on each worker node and set the below parameter in KUBELET_CERTIFICATE_ARGS variable.
+          --feature-gates=RotateKubeletServerCertificate=true
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.12
+        text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: RotateKubeletServerCertificate
+              path: '{.featureGates.RotateKubeletServerCertificate}'
+              compare:
+                op: nothave
+                value: false
+            - flag: RotateKubeletServerCertificate
+              path: '{.featureGates.RotateKubeletServerCertificate}'
+              set: false
+        remediation: |
+          If using a Kubelet config file, edit the file to set `TLSCipherSuites` to
+          TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+          or to a subset of these values.
+          If using executable arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the --tls-cipher-suites parameter as follows, or to a subset of these values.
+          --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.13
+        text: "Ensure that a limit is set on pod PIDs (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --pod-max-pids
+              path: '{.podPidsLimit}'
+        remediation: |
+          Decide on an appropriate level for this parameter and set it,
+          either via the --pod-max-pids command line parameter or the PodPidsLimit configuration file setting.
+        scored: false

--- a/package/cfg/cis-1.7/node.yaml
+++ b/package/cfg/cis-1.7/node.yaml
@@ -1,6 +1,6 @@
 ---
 controls:
-version: "cis-1.7"
+version: "1.7"
 id: 4
 text: "Worker Node Security Configuration"
 type: "node"
@@ -96,10 +96,7 @@ groups:
 
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Manual)"
-        audit: |
-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
-          if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
-          if test -e $CAFILE; then stat -c permissions=%a $CAFILE; fi
+        audit: "check_cafile_permissions.sh"
         tests:
           test_items:
             - flag: "permissions"
@@ -113,10 +110,7 @@ groups:
 
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
-        audit: |
-          CAFILE=$(ps -ef | grep kubelet | grep -v apiserver | grep -- --client-ca-file= | awk -F '--client-ca-file=' '{print $2}' | awk '{print $1}')
-          if test -z $CAFILE; then CAFILE=$kubeletcafile; fi
-          if test -e $CAFILE; then stat -c %U:%G $CAFILE; fi
+        audit: "check_cafile_ownership.sh"
         tests:
           test_items:
             - flag: root:root

--- a/package/cfg/cis-1.7/policies.yaml
+++ b/package/cfg/cis-1.7/policies.yaml
@@ -1,0 +1,304 @@
+---
+controls:
+version: "cis-1.7"
+id: 5
+text: "Kubernetes Policies"
+type: "policies"
+groups:
+  - id: 5.1
+    text: "RBAC and Service Accounts"
+    checks:
+      - id: 5.1.1
+        text: "Ensure that the cluster-admin role is only used where required (Manual)"
+        type: "manual"
+        remediation: |
+          Identify all clusterrolebindings to the cluster-admin role. Check if they are used and
+          if they need this role or if they could use a role with fewer privileges.
+          Where possible, first bind users to a lower privileged role and then remove the
+          clusterrolebinding to the cluster-admin role :
+          kubectl delete clusterrolebinding [name]
+        scored: false
+
+      - id: 5.1.2
+        text: "Minimize access to secrets (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove get, list and watch access to Secret objects in the cluster.
+        scored: false
+
+      - id: 5.1.3
+        text: "Minimize wildcard use in Roles and ClusterRoles (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible replace any use of wildcards in clusterroles and roles with specific
+          objects or actions.
+        scored: false
+
+      - id: 5.1.4
+        text: "Minimize access to create pods (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove create access to pod objects in the cluster.
+        scored: false
+
+      - id: 5.1.5
+        text: "Ensure that default service accounts are not actively used. (Manual)"
+        type: "manual"
+        remediation: |
+          Create explicit service accounts wherever a Kubernetes workload requires specific access
+          to the Kubernetes API server.
+          Modify the configuration of each default service account to include this value
+          automountServiceAccountToken: false
+        scored: false
+
+      - id: 5.1.6
+        text: "Ensure that Service Account Tokens are only mounted where necessary (Manual)"
+        type: "manual"
+        remediation: |
+          Modify the definition of pods and service accounts which do not need to mount service
+          account tokens to disable it.
+        scored: false
+
+      - id: 5.1.7
+        text: "Avoid use of system:masters group (Manual)"
+        type: "manual"
+        remediation: |
+          Remove the system:masters group from all users in the cluster.
+        scored: false
+
+      - id: 5.1.8
+        text: "Limit use of the Bind, Impersonate and Escalate permissions in the Kubernetes cluster (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove the impersonate, bind and escalate rights from subjects.
+        scored: false
+
+      - id: 5.1.9
+        text: "Minimize access to create persistent volumes (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove create access to PersistentVolume objects in the cluster.
+        scored: false
+
+      - id: 5.1.10
+        text: "Minimize access to the proxy sub-resource of nodes (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove access to the proxy sub-resource of node objects.
+        scored: false
+
+      - id: 5.1.11
+        text: "Minimize access to the approval sub-resource of certificatesigningrequests objects (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove access to the approval sub-resource of certificatesigningrequest objects.
+        scored: false
+
+      - id: 5.1.12
+        text: "Minimize access to webhook configuration objects (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove access to the validatingwebhookconfigurations or mutatingwebhookconfigurations objects
+        scored: false
+
+      - id: 5.1.13
+        text: "Minimize access to the service account token creation (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove access to the token sub-resource of serviceaccount objects.
+        scored: false
+
+  - id: 5.2
+    text: "Pod Security Standards"
+    checks:
+      - id: 5.2.1
+        text: "Ensure that the cluster has at least one active policy control mechanism in place (Manual)"
+        type: "manual"
+        remediation: |
+          Ensure that either Pod Security Admission or an external policy control system is in place
+          for every namespace which contains user workloads.
+        scored: false
+
+      - id: 5.2.2
+        text: "Minimize the admission of privileged containers (Manual)"
+        type: "manual"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of privileged containers.
+        scored: false
+
+      - id: 5.2.3
+        text: "Minimize the admission of containers wishing to share the host process ID namespace (Automated)"
+        type: "manual"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of `hostPID` containers.
+        scored: false
+
+      - id: 5.2.4
+        text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
+        type: "manual"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of `hostIPC` containers.
+        scored: false
+
+      - id: 5.2.5
+        text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
+        type: "manual"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of `hostNetwork` containers.
+        scored: false
+
+      - id: 5.2.6
+        text: "Minimize the admission of containers with allowPrivilegeEscalation (Automated)"
+        type: "manual"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of containers with `.spec.allowPrivilegeEscalation` set to `true`.
+        scored: false
+
+      - id: 5.2.7
+        text: "Minimize the admission of root containers (Automated)"
+        type: "manual"
+        remediation: |
+          Create a policy for each namespace in the cluster, ensuring that either `MustRunAsNonRoot`
+          or `MustRunAs` with the range of UIDs not including 0, is set.
+        scored: false
+
+      - id: 5.2.8
+        text: "Minimize the admission of containers with the NET_RAW capability (Automated)"
+        type: "manual"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of containers with the `NET_RAW` capability.
+        scored: false
+
+      - id: 5.2.9
+        text: "Minimize the admission of containers with added capabilities (Automated)"
+        type: "manual"
+        remediation: |
+          Ensure that `allowedCapabilities` is not present in policies for the cluster unless
+          it is set to an empty array.
+        scored: false
+
+      - id: 5.2.10
+        text: "Minimize the admission of containers with capabilities assigned (Manual)"
+        type: "manual"
+        remediation: |
+          Review the use of capabilites in applications running on your cluster. Where a namespace
+          contains applicaions which do not require any Linux capabities to operate consider adding
+          a PSP which forbids the admission of containers which do not drop all capabilities.
+        scored: false
+
+      - id: 5.2.11
+        text: "Minimize the admission of Windows HostProcess containers (Manual)"
+        type: "manual"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of containers that have `.securityContext.windowsOptions.hostProcess` set to `true`.
+        scored: false
+
+      - id: 5.2.12
+        text: "Minimize the admission of HostPath volumes (Manual)"
+        type: "manual"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of containers with `hostPath` volumes.
+        scored: false
+
+      - id: 5.2.13
+        text: "Minimize the admission of containers which use HostPorts (Manual)"
+        type: "manual"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of containers which use `hostPort` sections.
+        scored: false
+
+  - id: 5.3
+    text: "Network Policies and CNI"
+    checks:
+      - id: 5.3.1
+        text: "Ensure that the CNI in use supports NetworkPolicies (Manual)"
+        type: "manual"
+        remediation: |
+          If the CNI plugin in use does not support network policies, consideration should be given to
+          making use of a different plugin, or finding an alternate mechanism for restricting traffic
+          in the Kubernetes cluster.
+        scored: false
+
+      - id: 5.3.2
+        text: "Ensure that all Namespaces have NetworkPolicies defined (Manual)"
+        type: "manual"
+        remediation: |
+          Follow the documentation and create NetworkPolicy objects as you need them.
+        scored: false
+
+  - id: 5.4
+    text: "Secrets Management"
+    checks:
+      - id: 5.4.1
+        text: "Prefer using Secrets as files over Secrets as environment variables (Manual)"
+        type: "manual"
+        remediation: |
+          If possible, rewrite application code to read Secrets from mounted secret files, rather than
+          from environment variables.
+        scored: false
+
+      - id: 5.4.2
+        text: "Consider external secret storage (Manual)"
+        type: "manual"
+        remediation: |
+          Refer to the Secrets management options offered by your cloud provider or a third-party
+          secrets management solution.
+        scored: false
+
+  - id: 5.5
+    text: "Extensible Admission Control"
+    checks:
+      - id: 5.5.1
+        text: "Configure Image Provenance using ImagePolicyWebhook admission controller (Manual)"
+        type: "manual"
+        remediation: |
+          Follow the Kubernetes documentation and setup image provenance.
+        scored: false
+
+  - id: 5.7
+    text: "General Policies"
+    checks:
+      - id: 5.7.1
+        text: "Create administrative boundaries between resources using namespaces (Manual)"
+        type: "manual"
+        remediation: |
+          Follow the documentation and create namespaces for objects in your deployment as you need
+          them.
+        scored: false
+
+      - id: 5.7.2
+        text: "Ensure that the seccomp profile is set to docker/default in your Pod definitions (Manual)"
+        type: "manual"
+        remediation: |
+          Use `securityContext` to enable the docker/default seccomp profile in your pod definitions.
+          An example is as below:
+            securityContext:
+              seccompProfile:
+                type: RuntimeDefault
+        scored: false
+
+      - id: 5.7.3
+        text: "Apply SecurityContext to your Pods and Containers (Manual)"
+        type: "manual"
+        remediation: |
+          Follow the Kubernetes documentation and apply SecurityContexts to your Pods. For a
+          suggested list of SecurityContexts, you may refer to the CIS Security Benchmark for Docker
+          Containers.
+        scored: false
+
+      - id: 5.7.4
+        text: "The default namespace should not be used (Manual)"
+        type: "manual"
+        remediation: |
+          Ensure that namespaces are created to allow for appropriate segregation of Kubernetes
+          resources and that all new resources are created in a specific namespace.
+        scored: false

--- a/package/cfg/cis-1.7/policies.yaml
+++ b/package/cfg/cis-1.7/policies.yaml
@@ -1,6 +1,6 @@
 ---
 controls:
-version: "cis-1.7"
+version: "1.7"
 id: 5
 text: "Kubernetes Policies"
 type: "policies"

--- a/package/cfg/rke-cis-1.7-hardened/config.yaml
+++ b/package/cfg/rke-cis-1.7-hardened/config.yaml
@@ -1,0 +1,10 @@
+---
+## Version-specific settings that override the values in cfg/config.yaml
+
+node:
+  kubelet:
+    defaultkubeconfig: "/etc/kubernetes/ssl/kubecfg-kube-node.yaml"
+    defaultcafile: "/etc/kubernetes/ssl/kube-ca.pem"
+
+  proxy:
+    defaultkubeconfig: "/etc/kubernetes/ssl/kubecfg-kube-proxy.yaml"

--- a/package/cfg/rke-cis-1.7-hardened/controlplane.yaml
+++ b/package/cfg/rke-cis-1.7-hardened/controlplane.yaml
@@ -1,0 +1,60 @@
+---
+controls:
+version: "1.7"
+id: 3
+text: "Control Plane Configuration"
+type: "controlplane"
+groups:
+  - id: 3.1
+    text: "Authentication and Authorization"
+    checks:
+      - id: 3.1.1
+        text: "Client certificate authentication should not be used for users (Manual)"
+        type: "manual"
+        remediation: |
+          Alternative mechanisms provided by Kubernetes such as the use of OIDC should be
+          implemented in place of client certificates.
+        scored: false
+      - id: 3.1.2
+        text: "Service account token authentication should not be used for users (Manual)"
+        type: "manual"
+        remediation: |
+          Alternative mechanisms provided by Kubernetes such as the use of OIDC should be implemented
+          in place of service account tokens.
+        scored: false
+      - id: 3.1.3
+        text: "Bootstrap token authentication should not be used for users (Manual)"
+        type: "manual"
+        remediation: |
+          Alternative mechanisms provided by Kubernetes such as the use of OIDC should be implemented
+          in place of bootstrap tokens.
+        scored: false
+
+  - id: 3.2
+    text: "Logging"
+    checks:
+      - id: 3.2.1
+        text: "Ensure that a minimal audit policy is created (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-policy-file"
+              set: true
+        remediation: |
+          Create an audit policy file for your cluster.
+        scored: true
+
+      - id: 3.2.2
+        text: "Ensure that the audit policy covers key security concerns (Manual)"
+        type: "manual"
+        remediation: |
+          Review the audit policy provided for the cluster and ensure that it covers
+          at least the following areas,
+          - Access to Secrets managed by the cluster. Care should be taken to only
+            log Metadata for requests to Secrets, ConfigMaps, and TokenReviews, in
+            order to avoid risk of logging sensitive data.
+          - Modification of Pod and Deployment objects.
+          - Use of `pods/exec`, `pods/portforward`, `pods/proxy` and `services/proxy`.
+          For most requests, minimally logging at the Metadata level is recommended
+          (the most basic level of logging).
+        scored: false

--- a/package/cfg/rke-cis-1.7-hardened/etcd.yaml
+++ b/package/cfg/rke-cis-1.7-hardened/etcd.yaml
@@ -1,0 +1,221 @@
+---
+controls:
+version: "1.7"
+id: 2
+text: "Etcd Node Configuration"
+type: "etcd"
+groups:
+  - id: 1.1
+    text: "Control Plane Node Configuration Files"
+    checks:
+      - id: 1.1.11
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
+        audit: stat -c %a /node/var/lib/etcd
+        tests:
+          test_items:
+            - flag: "700"
+              compare:
+                op: eq
+                value: "700"
+              set: true
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above). For example,
+          chmod 700 /var/lib/etcd
+        scored: true
+
+      - id: 1.1.12
+        text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
+        type: "skip"
+        audit: "stat -c %U:%G /node/var/lib/etcd"
+        tests:
+          test_items:
+            - flag: "etcd:etcd"
+              set: true
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above).
+          For example, chown etcd:etcd /var/lib/etcd
+          Permissive - A system service account is required for etcd data directory ownership. 
+          Refer to Rancher's hardening guide for more details on how to configure this ownership.
+        scored: true
+
+      - id: 1.1.19
+        text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
+        audit: "check_files_owner_in_dir.sh /node/etc/kubernetes/ssl"
+        tests:
+          test_items:
+            - flag: "true"
+              compare:
+                op: eq
+                value: "true"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown -R root:root /etc/kubernetes/pki/
+        scored: true
+
+      - id: 1.1.20
+        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Manual)"
+        audit: "find /etc/kubernetes/pki/ -name '*.crt' | xargs stat -c permissions=%a"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod -R 644 /etc/kubernetes/pki/*.crt
+        scored: false
+
+      - id: 1.1.21
+        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
+        audit: "find /etc/kubernetes/pki/ -name '*.key' | xargs stat -c permissions=%a"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod -R 600 /etc/kubernetes/pki/*.key
+        scored: false
+
+  - id: 2
+    text: "Etcd Node Configuration"
+    checks:
+      - id: 2.1
+        text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--cert-file"
+              env: "ETCD_CERT_FILE"
+            - flag: "--key-file"
+              env: "ETCD_KEY_FILE"
+        remediation: |
+          Follow the etcd service documentation and configure TLS encryption.
+          Then, edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml
+          on the master node and set the below parameters.
+          --cert-file=</path/to/ca-file>
+          --key-file=</path/to/key-file>
+        scored: true
+
+      - id: 2.2
+        text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          test_items:
+            - flag: "--client-cert-auth"
+              env: "ETCD_CLIENT_CERT_AUTH"
+              compare:
+                op: eq
+                value: true
+        remediation: |
+          Edit the etcd pod specification file $etcdconf on the master
+          node and set the below parameter.
+          --client-cert-auth="true"
+        scored: true
+
+      - id: 2.3
+        text: "Ensure that the --auto-tls argument is not set to true (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--auto-tls"
+              env: "ETCD_AUTO_TLS"
+              set: false
+            - flag: "--auto-tls"
+              env: "ETCD_AUTO_TLS"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the etcd pod specification file $etcdconf on the master
+          node and either remove the --auto-tls parameter or set it to false.
+            --auto-tls=false
+        scored: true
+
+      - id: 2.4
+        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are
+        set as appropriate (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--peer-cert-file"
+              env: "ETCD_PEER_CERT_FILE"
+            - flag: "--peer-key-file"
+              env: "ETCD_PEER_KEY_FILE"
+        remediation: |
+          Follow the etcd service documentation and configure peer TLS encryption as appropriate
+          for your etcd cluster.
+          Then, edit the etcd pod specification file $etcdconf on the
+          master node and set the below parameters.
+          --peer-client-file=</path/to/peer-cert-file>
+          --peer-key-file=</path/to/peer-key-file>
+        scored: true
+
+      - id: 2.5
+        text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          test_items:
+            - flag: "--peer-client-cert-auth"
+              env: "ETCD_PEER_CLIENT_CERT_AUTH"
+              compare:
+                op: eq
+                value: true
+        remediation: |
+          Edit the etcd pod specification file $etcdconf on the master
+          node and set the below parameter.
+          --peer-client-cert-auth=true
+        scored: true
+
+      - id: 2.6
+        text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--peer-auto-tls"
+              env: "ETCD_PEER_AUTO_TLS"
+              set: false
+            - flag: "--peer-auto-tls"
+              env: "ETCD_PEER_AUTO_TLS"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the etcd pod specification file $etcdconf on the master
+          node and either remove the --peer-auto-tls parameter or set it to false.
+          --peer-auto-tls=false
+        scored: true
+
+      - id: 2.7
+        text: "Ensure that a unique Certificate Authority is used for etcd (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          test_items:
+            - flag: "--trusted-ca-file"
+              env: "ETCD_TRUSTED_CA_FILE"
+              set: true
+        remediation: |
+          [Manual test]
+          Follow the etcd documentation and create a dedicated certificate authority setup for the
+          etcd service.
+          Then, edit the etcd pod specification file $etcdconf on the
+          master node and set the below parameter.
+          --trusted-ca-file=</path/to/ca-file>
+        scored: true

--- a/package/cfg/rke-cis-1.7-hardened/etcd.yaml
+++ b/package/cfg/rke-cis-1.7-hardened/etcd.yaml
@@ -27,7 +27,6 @@ groups:
 
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
-        type: "skip"
         audit: "stat -c %U:%G /node/var/lib/etcd"
         tests:
           test_items:
@@ -38,8 +37,6 @@ groups:
           from the command 'ps -ef | grep etcd'.
           Run the below command (based on the etcd data directory found above).
           For example, chown etcd:etcd /var/lib/etcd
-          Permissive - A system service account is required for etcd data directory ownership. 
-          Refer to Rancher's hardening guide for more details on how to configure this ownership.
         scored: true
 
       - id: 1.1.19

--- a/package/cfg/rke-cis-1.7-hardened/master.yaml
+++ b/package/cfg/rke-cis-1.7-hardened/master.yaml
@@ -22,7 +22,7 @@ groups:
           Run the below command (based on the file location on your system) on the
           control plane node.
           For example, chmod 600 $apiserverconf
-          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
 
@@ -36,7 +36,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chown root:root $apiserverconf
-          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
 
@@ -53,7 +53,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chmod 600 $controllermanagerconf
-          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
 
@@ -67,7 +67,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chown root:root $controllermanagerconf
-          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
 
@@ -84,7 +84,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chmod 600 $schedulerconf
-          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
 
@@ -98,7 +98,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chown root:root $schedulerconf
-          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
 
@@ -117,7 +117,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chmod 600 $etcdconf
-          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
 
@@ -133,7 +133,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chown root:root $etcdconf
-          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
 
@@ -182,7 +182,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chmod 600 /etc/kubernetes/admin.conf
-          Not Applicable: Cluster provisioned by RKE does not store the kubernetes default kubeconfig credentials file on the nodes.
+          Not Applicable -  Cluster provisioned by RKE does not store the kubernetes default kubeconfig credentials file on the nodes.
         scored: true
 
       - id: 1.1.14
@@ -195,7 +195,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chown root:root /etc/kubernetes/admin.conf
-          Not Applicable: Cluster provisioned by RKE does not store the kubernetes default kubeconfig credentials file on the nodes.
+          Not Applicable -  Cluster provisioned by RKE does not store the kubernetes default kubeconfig credentials file on the nodes.
         scored: true
 
       - id: 1.1.15
@@ -212,7 +212,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chmod 600 $schedulerkubeconfig
-          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for scheduler.
+          Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for scheduler.
           All configuration is passed in as arguments at container run time.
         scored: true
 
@@ -227,7 +227,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chown root:root $schedulerkubeconfig
-          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for scheduler.
+          Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for scheduler.
           All configuration is passed in as arguments at container run time.
         scored: true
 
@@ -245,7 +245,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chmod 600 $controllermanagerkubeconfig
-          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for controller-manager.
+          Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for controller-manager.
           All configuration is passed in as arguments at container run time.
         scored: true
 
@@ -260,7 +260,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chown root:root $controllermanagerkubeconfig
-          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for controller-manager.
+          Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for controller-manager.
           All configuration is passed in as arguments at container run time.
         scored: true
 

--- a/package/cfg/rke-cis-1.7-hardened/master.yaml
+++ b/package/cfg/rke-cis-1.7-hardened/master.yaml
@@ -1,0 +1,911 @@
+---
+controls:
+version: 1.7
+id: 1
+text: "Control Plane Security Configuration"
+type: "master"
+groups:
+  - id: 1.1
+    text: "Control Plane Node Configuration Files"
+    checks:
+      - id: 1.1.1
+        text: "Ensure that the API server pod specification file permissions are set to 600 or more restrictive (Automated)"
+        type: "skip"
+        audit: "/bin/sh -c 'if test -e $apiserverconf; then stat -c permissions=%a $apiserverconf; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the
+          control plane node.
+          For example, chmod 600 $apiserverconf
+          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          All configuration is passed in as arguments at container run time.
+        scored: true
+
+      - id: 1.1.2
+        text: "Ensure that the API server pod specification file ownership is set to root:root (Automated)"
+        type: "skip"
+        audit: "/bin/sh -c 'if test -e $apiserverconf; then stat -c %U:%G $apiserverconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example, chown root:root $apiserverconf
+          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          All configuration is passed in as arguments at container run time.
+        scored: true
+
+      - id: 1.1.3
+        text: "Ensure that the controller manager pod specification file permissions are set to 600 or more restrictive (Automated)"
+        type: "skip"
+        audit: "/bin/sh -c 'if test -e $controllermanagerconf; then stat -c permissions=%a $controllermanagerconf; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example, chmod 600 $controllermanagerconf
+          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          All configuration is passed in as arguments at container run time.
+        scored: true
+
+      - id: 1.1.4
+        text: "Ensure that the controller manager pod specification file ownership is set to root:root (Automated)"
+        type: "skip"
+        audit: "/bin/sh -c 'if test -e $controllermanagerconf; then stat -c %U:%G $controllermanagerconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example, chown root:root $controllermanagerconf
+          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          All configuration is passed in as arguments at container run time.
+        scored: true
+
+      - id: 1.1.5
+        text: "Ensure that the scheduler pod specification file permissions are set to 600 or more restrictive (Automated)"
+        type: "skip"
+        audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c permissions=%a $schedulerconf; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example, chmod 600 $schedulerconf
+          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          All configuration is passed in as arguments at container run time.
+        scored: true
+
+      - id: 1.1.6
+        text: "Ensure that the scheduler pod specification file ownership is set to root:root (Automated)"
+        type: "skip"
+        audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c %U:%G $schedulerconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example, chown root:root $schedulerconf
+          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          All configuration is passed in as arguments at container run time.
+        scored: true
+
+      - id: 1.1.7
+        text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
+        type: "skip"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod 600 $etcdconf
+          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          All configuration is passed in as arguments at container run time.
+        scored: true
+
+      - id: 1.1.8
+        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
+        type: "skip"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c %U:%G; fi'"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root $etcdconf
+          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          All configuration is passed in as arguments at container run time.
+        scored: true
+
+      - id: 1.1.9
+        text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Manual)"
+        audit: |
+          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
+          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example, chmod 600 <path/to/cni/files>
+        scored: false
+
+      - id: 1.1.10
+        text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
+        audit: |
+          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
+          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root <path/to/cni/files>
+        scored: false
+
+      - id: 1.1.13
+        text: "Ensure that the admin.conf file permissions are set to 600 or more restrictive (Automated)"
+        type: "skip"
+        audit: "/bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c permissions=%a /etc/kubernetes/admin.conf; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example, chmod 600 /etc/kubernetes/admin.conf
+          Not Applicable: Cluster provisioned by RKE does not store the kubernetes default kubeconfig credentials file on the nodes.
+        scored: true
+
+      - id: 1.1.14
+        text: "Ensure that the admin.conf file ownership is set to root:root (Automated)"
+        type: "skip"
+        audit: "/bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c %U:%G /etc/kubernetes/admin.conf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example, chown root:root /etc/kubernetes/admin.conf
+          Not Applicable: Cluster provisioned by RKE does not store the kubernetes default kubeconfig credentials file on the nodes.
+        scored: true
+
+      - id: 1.1.15
+        text: "Ensure that the scheduler.conf file permissions are set to 600 or more restrictive (Automated)"
+        type: "skip"
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c permissions=%a $schedulerkubeconfig; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod 600 $schedulerkubeconfig
+          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for scheduler.
+          All configuration is passed in as arguments at container run time.
+        scored: true
+
+      - id: 1.1.16
+        text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
+        type: "skip"
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c %U:%G $schedulerkubeconfig; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root $schedulerkubeconfig
+          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for scheduler.
+          All configuration is passed in as arguments at container run time.
+        scored: true
+
+      - id: 1.1.17
+        text: "Ensure that the controller-manager.conf file permissions are set to 600 or more restrictive (Automated)"
+        type: "skip"
+        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c permissions=%a $controllermanagerkubeconfig; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod 600 $controllermanagerkubeconfig
+          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for controller-manager.
+          All configuration is passed in as arguments at container run time.
+        scored: true
+
+      - id: 1.1.18
+        text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
+        type: "skip"
+        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c %U:%G $controllermanagerkubeconfig; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root $controllermanagerkubeconfig
+          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for controller-manager.
+          All configuration is passed in as arguments at container run time.
+        scored: true
+
+
+  - id: 1.2
+    text: "API Server"
+    checks:
+      - id: 1.2.1
+        text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--anonymous-auth"
+              compare:
+                op: eq
+                value: false
+              set: true
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the below parameter.
+          --anonymous-auth=false
+        scored: true
+
+      - id: 1.2.2
+        text: "Ensure that the --token-auth-file parameter is not set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--token-auth-file"
+              set: false
+        remediation: |
+          Follow the documentation and configure alternate mechanisms for authentication. Then,
+          edit the API server pod specification file $apiserverconf
+          on the control plane node and remove the --token-auth-file=<filename> parameter.
+        scored: true
+
+      - id: 1.2.3
+        text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: nothave
+                value: "DenyServiceExternalIPs"
+              set: true
+            - flag: "--enable-admission-plugins"
+              set: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and remove the `DenyServiceExternalIPs`
+          from enabled admission plugins.
+        scored: true
+
+      - id: 1.2.4
+        text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--kubelet-client-certificate"
+            - flag: "--kubelet-client-key"
+        remediation: |
+          Follow the Kubernetes documentation and set up the TLS connection between the
+          apiserver and kubelets. Then, edit API server pod specification file
+          $apiserverconf on the control plane node and set the
+          kubelet client certificate and key parameters as below.
+          --kubelet-client-certificate=<path/to/client-certificate-file>
+          --kubelet-client-key=<path/to/client-key-file>
+        scored: true
+
+      - id: 1.2.5
+        text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
+        type: "skip"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--kubelet-certificate-authority"
+              set: true
+        remediation: |
+          Follow the Kubernetes documentation and setup the TLS connection between
+          the apiserver and kubelets. Then, edit the API server pod specification file
+          $apiserverconf on the control plane node and set the
+          --kubelet-certificate-authority parameter to the path to the cert file for the certificate authority.
+          --kubelet-certificate-authority=<ca-string>
+          When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
+        scored: true
+
+      - id: 1.2.6
+        text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--authorization-mode"
+              compare:
+                op: nothave
+                value: "AlwaysAllow"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --authorization-mode parameter to values other than AlwaysAllow.
+          One such example could be as below.
+          --authorization-mode=RBAC
+        scored: true
+
+      - id: 1.2.7
+        text: "Ensure that the --authorization-mode argument includes Node (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--authorization-mode"
+              compare:
+                op: has
+                value: "Node"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --authorization-mode parameter to a value that includes Node.
+          --authorization-mode=Node,RBAC
+        scored: true
+
+      - id: 1.2.8
+        text: "Ensure that the --authorization-mode argument includes RBAC (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--authorization-mode"
+              compare:
+                op: has
+                value: "RBAC"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --authorization-mode parameter to a value that includes RBAC,
+          for example `--authorization-mode=Node,RBAC`.
+        scored: true
+
+      - id: 1.2.9
+        text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "EventRateLimit"
+        remediation: |
+          Follow the Kubernetes documentation and set the desired limits in a configuration file.
+          Then, edit the API server pod specification file $apiserverconf
+          and set the below parameters.
+          --enable-admission-plugins=...,EventRateLimit,...
+          --admission-control-config-file=<path/to/configuration/file>
+        scored: false
+
+      - id: 1.2.10
+        text: "Ensure that the admission control plugin AlwaysAdmit is not set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: nothave
+                value: AlwaysAdmit
+            - flag: "--enable-admission-plugins"
+              set: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and either remove the --enable-admission-plugins parameter, or set it to a
+          value that does not include AlwaysAdmit.
+        scored: true
+
+      - id: 1.2.11
+        text: "Ensure that the admission control plugin AlwaysPullImages is set (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "AlwaysPullImages"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --enable-admission-plugins parameter to include
+          AlwaysPullImages.
+          --enable-admission-plugins=...,AlwaysPullImages,...
+        scored: false
+
+      - id: 1.2.12
+        text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "SecurityContextDeny"
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "PodSecurityPolicy"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --enable-admission-plugins parameter to include
+          SecurityContextDeny, unless PodSecurityPolicy is already in place.
+          --enable-admission-plugins=...,SecurityContextDeny,...
+        scored: false
+
+      - id: 1.2.13
+        text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--disable-admission-plugins"
+              compare:
+                op: nothave
+                value: "ServiceAccount"
+            - flag: "--disable-admission-plugins"
+              set: false
+        remediation: |
+          Follow the documentation and create ServiceAccount objects as per your environment.
+          Then, edit the API server pod specification file $apiserverconf
+          on the control plane node and ensure that the --disable-admission-plugins parameter is set to a
+          value that does not include ServiceAccount.
+        scored: true
+
+      - id: 1.2.14
+        text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--disable-admission-plugins"
+              compare:
+                op: nothave
+                value: "NamespaceLifecycle"
+            - flag: "--disable-admission-plugins"
+              set: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --disable-admission-plugins parameter to
+          ensure it does not include NamespaceLifecycle.
+        scored: true
+
+      - id: 1.2.15
+        text: "Ensure that the admission control plugin NodeRestriction is set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "NodeRestriction"
+        remediation: |
+          Follow the Kubernetes documentation and configure NodeRestriction plug-in on kubelets.
+          Then, edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --enable-admission-plugins parameter to a
+          value that includes NodeRestriction.
+          --enable-admission-plugins=...,NodeRestriction,...
+        scored: true
+
+      - id: 1.2.16
+        text: "Ensure that the --secure-port argument is not set to 0 - NoteThis recommendation is obsolete and will be deleted per the consensus process (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--secure-port"
+              compare:
+                op: gt
+                value: 0
+            - flag: "--secure-port"
+              set: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and either remove the --secure-port parameter or
+          set it to a different (non-zero) desired port.
+        scored: true
+
+      - id: 1.2.17
+        text: "Ensure that the --profiling argument is set to false (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--profiling"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the below parameter.
+          --profiling=false
+        scored: true
+
+      - id: 1.2.18
+        text: "Ensure that the --audit-log-path argument is set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-log-path"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --audit-log-path parameter to a suitable path and
+          file where you would like audit logs to be written, for example,
+          --audit-log-path=/var/log/apiserver/audit.log
+        scored: true
+
+      - id: 1.2.19
+        text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-log-maxage"
+              compare:
+                op: gte
+                value: 30
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --audit-log-maxage parameter to 30
+          or as an appropriate number of days, for example,
+          --audit-log-maxage=30
+        scored: true
+
+      - id: 1.2.20
+        text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-log-maxbackup"
+              compare:
+                op: gte
+                value: 10
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --audit-log-maxbackup parameter to 10 or to an appropriate
+          value. For example,
+          --audit-log-maxbackup=10
+        scored: true
+
+      - id: 1.2.21
+        text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-log-maxsize"
+              compare:
+                op: gte
+                value: 100
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --audit-log-maxsize parameter to an appropriate size in MB.
+          For example, to set it as 100 MB, --audit-log-maxsize=100
+        scored: true
+
+      - id: 1.2.22
+        text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        type: manual
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          and set the below parameter as appropriate and if needed.
+          For example, --request-timeout=300s
+        scored: false
+
+      - id: 1.2.23
+        text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--service-account-lookup"
+              set: false
+            - flag: "--service-account-lookup"
+              compare:
+                op: eq
+                value: true
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the below parameter.
+          --service-account-lookup=true
+          Alternatively, you can delete the --service-account-lookup parameter from this file so
+          that the default takes effect.
+        scored: true
+
+      - id: 1.2.24
+        text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--service-account-key-file"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --service-account-key-file parameter
+          to the public key file for service accounts. For example,
+          --service-account-key-file=<filename>
+        scored: true
+
+      - id: 1.2.25
+        text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--etcd-certfile"
+            - flag: "--etcd-keyfile"
+        remediation: |
+          Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
+          Then, edit the API server pod specification file $apiserverconf
+          on the control plane node and set the etcd certificate and key file parameters.
+          --etcd-certfile=<path/to/client-certificate-file>
+          --etcd-keyfile=<path/to/client-key-file>
+        scored: true
+
+      - id: 1.2.26
+        text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--tls-cert-file"
+            - flag: "--tls-private-key-file"
+        remediation: |
+          Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
+          Then, edit the API server pod specification file $apiserverconf
+          on the control plane node and set the TLS certificate and private key file parameters.
+          --tls-cert-file=<path/to/tls-certificate-file>
+          --tls-private-key-file=<path/to/tls-key-file>
+        scored: true
+
+      - id: 1.2.27
+        text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--client-ca-file"
+        remediation: |
+          Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
+          Then, edit the API server pod specification file $apiserverconf
+          on the control plane node and set the client certificate authority file.
+          --client-ca-file=<path/to/client-ca-file>
+        scored: true
+
+      - id: 1.2.28
+        text: "Ensure that the --etcd-cafile argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--etcd-cafile"
+        remediation: |
+          Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
+          Then, edit the API server pod specification file $apiserverconf
+          on the control plane node and set the etcd certificate authority file parameter.
+          --etcd-cafile=<path/to/ca-file>
+        scored: true
+
+      - id: 1.2.29
+        text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--encryption-provider-config"
+        remediation: |
+          Follow the Kubernetes documentation and configure a EncryptionConfig file.
+          Then, edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --encryption-provider-config parameter to the path of that file.
+          For example, --encryption-provider-config=</path/to/EncryptionConfig/File>
+        scored: false
+
+      - id: 1.2.30
+        text: "Ensure that encryption providers are appropriately configured (Manual)"
+        audit: |
+          ENCRYPTION_PROVIDER_CONFIG=$(ps -ef | grep $apiserverbin | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
+          if test -e $ENCRYPTION_PROVIDER_CONFIG; then grep -A1 'providers:' $ENCRYPTION_PROVIDER_CONFIG | tail -n1 | grep -o "[A-Za-z]*" | sed 's/^/provider=/'; fi
+        tests:
+          test_items:
+            - flag: "provider"
+              compare:
+                op: valid_elements
+                value: "aescbc,kms,secretbox"
+        remediation: |
+          Follow the Kubernetes documentation and configure a EncryptionConfig file.
+          In this file, choose aescbc, kms or secretbox as the encryption provider.
+        scored: false
+
+      - id: 1.2.31
+        text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--tls-cipher-suites"
+              compare:
+                op: valid_elements
+                value: "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_RSA_WITH_3DES_EDE_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_256_GCM_SHA384"
+        remediation: |
+          Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
+          on the control plane node and set the below parameter.
+          --tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,
+          TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+          TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+          TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+          TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+          TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+          TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_RSA_WITH_3DES_EDE_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,
+          TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_256_GCM_SHA384
+        scored: false
+
+  - id: 1.3
+    text: "Controller Manager"
+    checks:
+      - id: 1.3.1
+        text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--terminated-pod-gc-threshold"
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the control plane node and set the --terminated-pod-gc-threshold to an appropriate threshold,
+          for example, --terminated-pod-gc-threshold=10
+        scored: true
+
+      - id: 1.3.2
+        text: "Ensure that the --profiling argument is set to false (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--profiling"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the control plane node and set the below parameter.
+          --profiling=false
+        scored: true
+
+      - id: 1.3.3
+        text: "Ensure that the --use-service-account-credentials argument is set to true (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--use-service-account-credentials"
+              compare:
+                op: noteq
+                value: false
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the control plane node to set the below parameter.
+          --use-service-account-credentials=true
+        scored: true
+
+      - id: 1.3.4
+        text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--service-account-private-key-file"
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the control plane node and set the --service-account-private-key-file parameter
+          to the private key file for service accounts.
+          --service-account-private-key-file=<filename>
+        scored: true
+
+      - id: 1.3.5
+        text: "Ensure that the --root-ca-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--root-ca-file"
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the control plane node and set the --root-ca-file parameter to the certificate bundle file`.
+          --root-ca-file=<path/to/file>
+        scored: true
+
+      - id: 1.3.6
+        text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
+        type: "skip"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--feature-gates"
+              compare:
+                op: nothave
+                value: "RotateKubeletServerCertificate=false"
+              set: true
+            - flag: "--feature-gates"
+              set: false
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the control plane node and set the --feature-gates parameter to include RotateKubeletServerCertificate=true.
+          --feature-gates=RotateKubeletServerCertificate=true
+          Cluster provisioned by RKE handles certificate rotation directly through RKE.
+        scored: true
+
+      - id: 1.3.7
+        text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--bind-address"
+              compare:
+                op: eq
+                value: "127.0.0.1"
+            - flag: "--bind-address"
+              set: false
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the control plane node and ensure the correct value for the --bind-address parameter
+        scored: true
+
+  - id: 1.4
+    text: "Scheduler"
+    checks:
+      - id: 1.4.1
+        text: "Ensure that the --profiling argument is set to false (Automated)"
+        audit: "/bin/ps -ef | grep $schedulerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--profiling"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the Scheduler pod specification file $schedulerconf file
+          on the control plane node and set the below parameter.
+          --profiling=false
+        scored: true
+
+      - id: 1.4.2
+        text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
+        audit: "/bin/ps -ef | grep $schedulerbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--bind-address"
+              compare:
+                op: eq
+                value: "127.0.0.1"
+            - flag: "--bind-address"
+              set: false
+        remediation: |
+          Edit the Scheduler pod specification file $schedulerconf
+          on the control plane node and ensure the correct value for the --bind-address parameter
+        scored: true

--- a/package/cfg/rke-cis-1.7-hardened/node.yaml
+++ b/package/cfg/rke-cis-1.7-hardened/node.yaml
@@ -1,0 +1,469 @@
+---
+controls:
+version: 1.7
+id: 4
+text: "Worker Node Security Configuration"
+type: "node"
+groups:
+  - id: 4.1
+    text: "Worker Node Configuration Files"
+    checks:
+      - id: 4.1.1
+        text: "Ensure that the kubelet service file permissions are set to 600 or more restrictive (Automated)"
+        type: "skip"
+        audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c permissions=%a $kubeletsvc; fi'' '
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example, chmod 600 $kubeletsvc
+	  Not Applicable - Clusters provisioned by RKE doesn’t require or maintain a configuration file for the kubelet service.
+           All configuration is passed in as arguments at container run time.
+        scored: true
+
+      - id: 4.1.2
+        text: "Ensure that the kubelet service file ownership is set to root:root (Automated)"
+        type: "skip"
+        audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc; fi'' '
+        tests:
+          test_items:
+            - flag: root:root
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chown root:root $kubeletsvc
+          Not Applicable - Clusters provisioned by RKE doesn’t require or maintain a configuration file for the kubelet service.
+           All configuration is passed in as arguments at container run time.
+        scored: true
+
+      - id: 4.1.3
+        text: "If proxy kubeconfig file exists ensure permissions are set to 600 or more restrictive (Automated)"
+        audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c permissions=%a $proxykubeconfig; fi'' '
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "permissions"
+              set: true
+              compare:
+                op: bitmask
+                value: "600"
+            - flag: "$proxykubeconfig"
+              set: false
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chmod 600 $proxykubeconfig
+        scored: true
+
+      - id: 4.1.4
+        text: "If proxy kubeconfig file exists ensure ownership is set to root:root (Automated)"
+        audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c %U:%G $proxykubeconfig; fi'' '
+        tests:
+          bin_op: or
+          test_items:
+            - flag: root:root
+            - flag: "$proxykubeconfig"
+              set: false
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example, chown root:root $proxykubeconfig
+        scored: true
+
+      - id: 4.1.5
+        text: "Ensure that the --kubeconfig kubelet.conf file permissions are set to 600 or more restrictive (Automated)"
+        audit: '/bin/sh -c ''if test -e /node$kubeletkubeconfig; then stat -c permissions=%a /node$kubeletkubeconfig; fi'' '
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chmod 600 $kubeletkubeconfig
+        scored: true
+
+      - id: 4.1.6
+        text: "Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root (Automated)"
+        audit: '/bin/sh -c ''if test -e /node$kubeletkubeconfig; then stat -c %U:%G /node$kubeletkubeconfig; fi'' '
+        tests:
+          test_items:
+            - flag: root:root
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chown root:root $kubeletkubeconfig
+        scored: true
+
+      - id: 4.1.7
+        text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Automated)"
+        audit: "stat -c permissions=%a /node/etc/kubernetes/ssl/kube-ca.pem"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the following command to modify the file permissions of the
+          --client-ca-file chmod 600 <filename>
+        scored: true
+
+      - id: 4.1.8
+        text: "Ensure that the client certificate authorities file ownership is set to root:root (Automated)"
+        audit: "stat -c %U:%G /node/etc/kubernetes/ssl/kube-ca.pem"
+        tests:
+          test_items:
+            - flag: root:root
+              compare:
+                op: eq
+                value: root:root
+        remediation: |
+          Run the following command to modify the ownership of the --client-ca-file.
+          chown root:root <filename>
+        scored: true
+
+      - id: 4.1.9
+        text: "If the kubelet config.yaml configuration file is being used validate permissions set to 600 or more restrictive (Automated)"
+        type: "skip"
+        audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c permissions=%a $kubeletconf; fi'' '
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+	  Run the following command (using the config file location identified in the Audit step)
+          chmod 600 $kubeletconf
+          Not Applicable - Clusters provisioned by RKE do not require or maintain a configuration file for the kubelet.
+          All configuration is passed in as arguments at container run time.
+        scored: true
+
+      - id: 4.1.10
+        text: "If the kubelet config.yaml configuration file is being used validate file ownership is set to root:root (Manual)"
+        type: "skip"
+        audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c %U:%G $kubeletconf; fi'' '
+        tests:
+          test_items:
+            - flag: root:root
+        remediation: |
+	   Run the following command (using the config file location identified in the Audit step)
+          chown root:root $kubeletconf
+          Not Applicable - Clusters provisioned by RKE doesn’t require or maintain a configuration file for the kubelet.
+          All configuration is passed in as arguments at container run time.
+        scored: false
+
+  - id: 4.2
+    text: "Kubelet"
+    checks:
+      - id: 4.2.1
+        text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
+        tests:
+          test_items:
+            - flag: "--anonymous-auth"
+              path: '{.authentication.anonymous.enabled}'
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          If using a Kubelet config file, edit the file to set `authentication: anonymous: enabled` to
+          `false`.
+          If using executable arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          `--anonymous-auth=false`
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.2
+        text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
+        tests:
+          test_items:
+            - flag: --authorization-mode
+              path: '{.authorization.mode}'
+              compare:
+                op: nothave
+                value: AlwaysAllow
+        remediation: |
+          If using a Kubelet config file, edit the file to set `authorization.mode` to Webhook. If
+          using executable arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_AUTHZ_ARGS variable.
+          --authorization-mode=Webhook
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.3
+        text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
+        tests:
+          test_items:
+            - flag: --client-ca-file
+              path: '{.authentication.x509.clientCAFile}'
+        remediation: |
+          If using a Kubelet config file, edit the file to set `authentication.x509.clientCAFile` to
+          the location of the client CA file.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_AUTHZ_ARGS variable.
+          --client-ca-file=<path/to/client-ca-file>
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.4
+        text: "Verify that the --read-only-port argument is set to 0 (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--read-only-port"
+              path: '{.readOnlyPort}'
+              compare:
+                op: eq
+                value: 0
+            - flag: "--read-only-port"
+              path: '{.readOnlyPort}'
+              set: false
+        remediation: |
+          If using a Kubelet config file, edit the file to set `readOnlyPort` to 0.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          --read-only-port=0
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.5
+        text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
+        tests:
+          test_items:
+            - flag: --streaming-connection-idle-timeout
+              path: '{.streamingConnectionIdleTimeout}'
+              compare:
+                op: noteq
+                value: 0
+            - flag: --streaming-connection-idle-timeout
+              path: '{.streamingConnectionIdleTimeout}'
+              set: false
+          bin_op: or
+        remediation: |
+          If using a Kubelet config file, edit the file to set `streamingConnectionIdleTimeout` to a
+          value other than 0.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          --streaming-connection-idle-timeout=5m
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.6
+        text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
+        tests:
+          test_items:
+            - flag: --make-iptables-util-chains
+              path: '{.makeIPTablesUtilChains}'
+              compare:
+                op: eq
+                value: true
+            - flag: --make-iptables-util-chains
+              path: '{.makeIPTablesUtilChains}'
+              set: false
+          bin_op: or
+        remediation: |
+          If using a Kubelet config file, edit the file to set `makeIPTablesUtilChains` to `true`.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          remove the --make-iptables-util-chains argument from the
+          KUBELET_SYSTEM_PODS_ARGS variable.
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.7
+        text: "Ensure that the --hostname-override argument is not set (Manual)"
+        # This is one of those properties that can only be set as a command line argument.
+        # To check if the property is set as expected, we need to parse the kubelet command
+        # instead reading the Kubelet Configuration file.
+        type: "skip"
+        audit: "/bin/ps -fC $kubeletbin "
+        tests:
+          test_items:
+            - flag: --hostname-override
+              set: false
+        remediation: |
+          Edit the kubelet service file $kubeletsvc
+          on each worker node and remove the --hostname-override argument from the
+          KUBELET_SYSTEM_PODS_ARGS variable.
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+          Not applicable: Clusters provisioned by RKE set the --hostname-override to avoid any hostname configuration errors
+        scored: false
+
+      - id: 4.2.8
+        text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
+        tests:
+          test_items:
+            - flag: --event-qps
+              path: '{.eventRecordQPS}'
+              compare:
+                op: gte
+                value: 0
+            - flag: --event-qps
+              path: '{.eventRecordQPS}'
+              set: false
+          bin_op: or
+        remediation: |
+          If using a Kubelet config file, edit the file to set `eventRecordQPS` to an appropriate level.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.9
+        text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
+        type: "skip"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
+        tests:
+          test_items:
+            - flag: --tls-cert-file
+              path: '{.tlsCertFile}'
+            - flag: --tls-private-key-file
+              path: '{.tlsPrivateKeyFile}'
+        remediation: |
+          If using a Kubelet config file, edit the file to set `tlsCertFile` to the location
+          of the certificate file to use to identify this Kubelet, and `tlsPrivateKeyFile`
+          to the location of the corresponding private key file.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameters in KUBELET_CERTIFICATE_ARGS variable.
+          --tls-cert-file=<path/to/tls-certificate-file>
+          --tls-private-key-file=<path/to/tls-key-file>
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+          Permissive - When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
+        scored: false
+
+      - id: 4.2.10
+        text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
+        tests:
+          test_items:
+            - flag: --rotate-certificates
+              path: '{.rotateCertificates}'
+              compare:
+                op: eq
+                value: true
+            - flag: --rotate-certificates
+              path: '{.rotateCertificates}'
+              set: false
+          bin_op: or
+        remediation: |
+          If using a Kubelet config file, edit the file to add the line `rotateCertificates` to `true` or
+          remove it altogether to use the default value.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          remove --rotate-certificates=false argument from the KUBELET_CERTIFICATE_ARGS
+          variable.
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.12
+        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
+        type: "skip"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
+        tests:
+          bin_op: or
+          test_items:
+            - flag: RotateKubeletServerCertificate
+              path: '{.featureGates.RotateKubeletServerCertificate}'
+              compare:
+                op: nothave
+                value: false
+            - flag: RotateKubeletServerCertificate
+              path: '{.featureGates.RotateKubeletServerCertificate}'
+              set: false
+        remediation: |
+          Edit the kubelet service file $kubeletsvc
+          on each worker node and set the below parameter in KUBELET_CERTIFICATE_ARGS variable.
+          --feature-gates=RotateKubeletServerCertificate=true
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+          Not applicable: Clusters provisioned by RKE handles certificate rotation directly through RKE.
+        scored: false
+
+      - id: 4.2.12
+        text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
+        tests:
+          test_items:
+            - flag: --tls-cipher-suites
+              path: '{range .tlsCipherSuites[:]}{}{'',''}{end}'
+              compare:
+                op: valid_elements
+                value: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+        remediation: |
+          If using a Kubelet config file, edit the file to set `TLSCipherSuites` to
+          TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+          or to a subset of these values.
+          If using executable arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the --tls-cipher-suites parameter as follows, or to a subset of these values.
+          --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.13
+        text: "Ensure that a limit is set on pod PIDs (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
+        tests:
+          test_items:
+            - flag: --pod-max-pids
+              path: '{.podPidsLimit}'
+        remediation: |
+          Decide on an appropriate level for this parameter and set it,
+          either via the --pod-max-pids command line parameter or the PodPidsLimit configuration file setting.
+        scored: false

--- a/package/cfg/rke-cis-1.7-hardened/node.yaml
+++ b/package/cfg/rke-cis-1.7-hardened/node.yaml
@@ -21,8 +21,8 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example, chmod 600 $kubeletsvc
-	  Not Applicable - Clusters provisioned by RKE doesn’t require or maintain a configuration file for the kubelet service.
-           All configuration is passed in as arguments at container run time.
+          Not Applicable - Clusters provisioned by RKE doesn’t require or maintain a configuration file for the kubelet service.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 4.1.2
@@ -139,7 +139,7 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-	  Run the following command (using the config file location identified in the Audit step)
+          Run the following command (using the config file location identified in the Audit step)
           chmod 600 $kubeletconf
           Not Applicable - Clusters provisioned by RKE do not require or maintain a configuration file for the kubelet.
           All configuration is passed in as arguments at container run time.
@@ -153,7 +153,7 @@ groups:
           test_items:
             - flag: root:root
         remediation: |
-	   Run the following command (using the config file location identified in the Audit step)
+          Run the following command (using the config file location identified in the Audit step)
           chown root:root $kubeletconf
           Not Applicable - Clusters provisioned by RKE doesn’t require or maintain a configuration file for the kubelet.
           All configuration is passed in as arguments at container run time.

--- a/package/cfg/rke-cis-1.7-hardened/node.yaml
+++ b/package/cfg/rke-cis-1.7-hardened/node.yaml
@@ -324,7 +324,7 @@ groups:
           Based on your system, restart the kubelet service. For example,
           systemctl daemon-reload
           systemctl restart kubelet.service
-          Not applicable: Clusters provisioned by RKE set the --hostname-override to avoid any hostname configuration errors
+          Not Applicable - Clusters provisioned by RKE set the --hostname-override to avoid any hostname configuration errors
         scored: false
 
       - id: 4.2.8
@@ -426,7 +426,7 @@ groups:
           Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
-          Not applicable: Clusters provisioned by RKE handles certificate rotation directly through RKE.
+          Not Applicable - Clusters provisioned by RKE handles certificate rotation directly through RKE.
         scored: false
 
       - id: 4.2.12

--- a/package/cfg/rke-cis-1.7-hardened/node.yaml
+++ b/package/cfg/rke-cis-1.7-hardened/node.yaml
@@ -354,7 +354,6 @@ groups:
 
       - id: 4.2.9
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
-        type: "skip"
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
@@ -375,7 +374,6 @@ groups:
           Based on your system, restart the kubelet service. For example,
           systemctl daemon-reload
           systemctl restart kubelet.service
-          Permissive - When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
         scored: false
 
       - id: 4.2.10

--- a/package/cfg/rke-cis-1.7-hardened/policies.yaml
+++ b/package/cfg/rke-cis-1.7-hardened/policies.yaml
@@ -43,7 +43,6 @@ groups:
 
       - id: 5.1.5
         text: "Ensure that default service accounts are not actively used. (Manual)"
-        type: "skip"
         audit: check_for_default_sa.sh
         tests:
           test_items:
@@ -57,7 +56,6 @@ groups:
           to the Kubernetes API server.
           Modify the configuration of each default service account to include this value
           automountServiceAccountToken: false
-          Permissive: Kubernetes provides default service accounts to be used.
         scored: false
 
       - id: 5.1.6
@@ -138,29 +136,23 @@ groups:
 
       - id: 5.2.3
         text: "Minimize the admission of containers wishing to share the host process ID namespace (Automated)"
-        type: "skip"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostPID` containers.
-          Permissive: Enabling Pod Security Policy can cause applications to unexpectedly fail.
         scored: false
 
       - id: 5.2.4
         text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
-        type: "skip"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostIPC` containers.
-          Permissive: Enabling Pod Security Policy can cause applications to unexpectedly fail.
         scored: false
 
       - id: 5.2.5
         text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
-        type: "skip"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostNetwork` containers.
-	  Permissive: Enabling Pod Security Policy can cause applications to unexpectedly fail.
         scored: false
 
       - id: 5.2.6
@@ -242,10 +234,8 @@ groups:
 
       - id: 5.3.2
         text: "Ensure that all Namespaces have NetworkPolicies defined (Manual)"
-        type: "skip"
         remediation: |
           Follow the documentation and create NetworkPolicy objects as you need them.
-          Permissive: Enabling Network Policies can prevent certain applications from communicating with each other.
         scored: false
 
   - id: 5.4

--- a/package/cfg/rke-cis-1.7-hardened/policies.yaml
+++ b/package/cfg/rke-cis-1.7-hardened/policies.yaml
@@ -1,0 +1,317 @@
+---
+controls:
+version: "cis-1.7"
+id: 5
+text: "Kubernetes Policies"
+type: "policies"
+groups:
+  - id: 5.1
+    text: "RBAC and Service Accounts"
+    checks:
+      - id: 5.1.1
+        text: "Ensure that the cluster-admin role is only used where required (Manual)"
+        type: "manual"
+        remediation: |
+          Identify all clusterrolebindings to the cluster-admin role. Check if they are used and
+          if they need this role or if they could use a role with fewer privileges.
+          Where possible, first bind users to a lower privileged role and then remove the
+          clusterrolebinding to the cluster-admin role :
+          kubectl delete clusterrolebinding [name]
+        scored: false
+
+      - id: 5.1.2
+        text: "Minimize access to secrets (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove get, list and watch access to Secret objects in the cluster.
+        scored: false
+
+      - id: 5.1.3
+        text: "Minimize wildcard use in Roles and ClusterRoles (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible replace any use of wildcards in clusterroles and roles with specific
+          objects or actions.
+        scored: false
+
+      - id: 5.1.4
+        text: "Minimize access to create pods (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove create access to pod objects in the cluster.
+        scored: false
+
+      - id: 5.1.5
+        text: "Ensure that default service accounts are not actively used. (Manual)"
+        type: "skip"
+        audit: check_for_default_sa.sh
+        tests:
+          test_items:
+            - flag: "true"
+              compare:
+                op: eq
+                value: "true"
+              set: true
+        remediation: |
+          Create explicit service accounts wherever a Kubernetes workload requires specific access
+          to the Kubernetes API server.
+          Modify the configuration of each default service account to include this value
+          automountServiceAccountToken: false
+          Permissive: Kubernetes provides default service accounts to be used.
+        scored: false
+
+      - id: 5.1.6
+        text: "Ensure that Service Account Tokens are only mounted where necessary (Manual)"
+        type: "manual"
+        remediation: |
+          Modify the definition of pods and service accounts which do not need to mount service
+          account tokens to disable it.
+        scored: false
+
+      - id: 5.1.7
+        text: "Avoid use of system:masters group (Manual)"
+        type: "manual"
+        remediation: |
+          Remove the system:masters group from all users in the cluster.
+        scored: false
+
+      - id: 5.1.8
+        text: "Limit use of the Bind, Impersonate and Escalate permissions in the Kubernetes cluster (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove the impersonate, bind and escalate rights from subjects.
+        scored: false
+
+      - id: 5.1.9
+        text: "Minimize access to create persistent volumes (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove create access to PersistentVolume objects in the cluster.
+        scored: false
+
+      - id: 5.1.10
+        text: "Minimize access to the proxy sub-resource of nodes (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove access to the proxy sub-resource of node objects.
+        scored: false
+
+      - id: 5.1.11
+        text: "Minimize access to the approval sub-resource of certificatesigningrequests objects (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove access to the approval sub-resource of certificatesigningrequest objects.
+        scored: false
+
+      - id: 5.1.12
+        text: "Minimize access to webhook configuration objects (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove access to the validatingwebhookconfigurations or mutatingwebhookconfigurations objects
+        scored: false
+
+      - id: 5.1.13
+        text: "Minimize access to the service account token creation (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove access to the token sub-resource of serviceaccount objects.
+        scored: false
+
+  - id: 5.2
+    text: "Pod Security Standards"
+    checks:
+      - id: 5.2.1
+        text: "Ensure that the cluster has at least one active policy control mechanism in place (Manual)"
+        type: "manual"
+        remediation: |
+          Ensure that either Pod Security Admission or an external policy control system is in place
+          for every namespace which contains user workloads.
+        scored: false
+
+      - id: 5.2.2
+        text: "Minimize the admission of privileged containers (Manual)"
+        type: "manual"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of privileged containers.
+        scored: false
+
+      - id: 5.2.3
+        text: "Minimize the admission of containers wishing to share the host process ID namespace (Automated)"
+        type: "skip"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of `hostPID` containers.
+          Permissive: Enabling Pod Security Policy can cause applications to unexpectedly fail.
+        scored: false
+
+      - id: 5.2.4
+        text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
+        type: "skip"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of `hostIPC` containers.
+          Permissive: Enabling Pod Security Policy can cause applications to unexpectedly fail.
+        scored: false
+
+      - id: 5.2.5
+        text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
+        type: "skip"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of `hostNetwork` containers.
+	  Permissive: Enabling Pod Security Policy can cause applications to unexpectedly fail.
+        scored: false
+
+      - id: 5.2.6
+        text: "Minimize the admission of containers with allowPrivilegeEscalation (Manual)"
+        type: "manual"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of containers with `.spec.allowPrivilegeEscalation` set to `true`.
+        scored: false
+
+      - id: 5.2.7
+        text: "Minimize the admission of root containers (Manual)"
+        type: "manual"
+        remediation: |
+          Create a policy for each namespace in the cluster, ensuring that either `MustRunAsNonRoot`
+          or `MustRunAs` with the range of UIDs not including 0, is set.
+        scored: false
+
+      - id: 5.2.8
+        text: "Minimize the admission of containers with the NET_RAW capability (Manual)"
+        type: "manual"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of containers with the `NET_RAW` capability.
+        scored: false
+
+      - id: 5.2.9
+        text: "Minimize the admission of containers with added capabilities (Manual)"
+        type: "manual"
+        remediation: |
+          Ensure that `allowedCapabilities` is not present in policies for the cluster unless
+          it is set to an empty array.
+        scored: false
+
+      - id: 5.2.10
+        text: "Minimize the admission of containers with capabilities assigned (Manual)"
+        type: "manual"
+        remediation: |
+          Review the use of capabilites in applications running on your cluster. Where a namespace
+          contains applicaions which do not require any Linux capabities to operate consider adding
+          a PSP which forbids the admission of containers which do not drop all capabilities.
+        scored: false
+
+      - id: 5.2.11
+        text: "Minimize the admission of Windows HostProcess containers (Manual)"
+        type: "manual"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of containers that have `.securityContext.windowsOptions.hostProcess` set to `true`.
+        scored: false
+
+      - id: 5.2.12
+        text: "Minimize the admission of HostPath volumes (Manual)"
+        type: "manual"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of containers with `hostPath` volumes.
+        scored: false
+
+      - id: 5.2.13
+        text: "Minimize the admission of containers which use HostPorts (Manual)"
+        type: "manual"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of containers which use `hostPort` sections.
+        scored: false
+
+  - id: 5.3
+    text: "Network Policies and CNI"
+    checks:
+      - id: 5.3.1
+        text: "Ensure that the CNI in use supports NetworkPolicies (Manual)"
+        type: "manual"
+        remediation: |
+          If the CNI plugin in use does not support network policies, consideration should be given to
+          making use of a different plugin, or finding an alternate mechanism for restricting traffic
+          in the Kubernetes cluster.
+        scored: false
+
+      - id: 5.3.2
+        text: "Ensure that all Namespaces have NetworkPolicies defined (Manual)"
+        type: "skip"
+        remediation: |
+          Follow the documentation and create NetworkPolicy objects as you need them.
+          Permissive: Enabling Network Policies can prevent certain applications from communicating with each other.
+        scored: false
+
+  - id: 5.4
+    text: "Secrets Management"
+    checks:
+      - id: 5.4.1
+        text: "Prefer using Secrets as files over Secrets as environment variables (Manual)"
+        type: "manual"
+        remediation: |
+          If possible, rewrite application code to read Secrets from mounted secret files, rather than
+          from environment variables.
+        scored: false
+
+      - id: 5.4.2
+        text: "Consider external secret storage (Manual)"
+        type: "manual"
+        remediation: |
+          Refer to the Secrets management options offered by your cloud provider or a third-party
+          secrets management solution.
+        scored: false
+
+  - id: 5.5
+    text: "Extensible Admission Control"
+    checks:
+      - id: 5.5.1
+        text: "Configure Image Provenance using ImagePolicyWebhook admission controller (Manual)"
+        type: "manual"
+        remediation: |
+          Follow the Kubernetes documentation and setup image provenance.
+        scored: false
+
+  - id: 5.7
+    text: "General Policies"
+    checks:
+      - id: 5.7.1
+        text: "Create administrative boundaries between resources using namespaces (Manual)"
+        type: "manual"
+        remediation: |
+          Follow the documentation and create namespaces for objects in your deployment as you need
+          them.
+        scored: false
+
+      - id: 5.7.2
+        text: "Ensure that the seccomp profile is set to docker/default in your Pod definitions (Manual)"
+        type: "manual"
+        remediation: |
+          Use `securityContext` to enable the docker/default seccomp profile in your pod definitions.
+          An example is as below:
+            securityContext:
+              seccompProfile:
+                type: RuntimeDefault
+        scored: false
+
+      - id: 5.7.3
+        text: "Apply SecurityContext to your Pods and Containers (Manual)"
+        type: "manual"
+        remediation: |
+          Follow the Kubernetes documentation and apply SecurityContexts to your Pods. For a
+          suggested list of SecurityContexts, you may refer to the CIS Security Benchmark for Docker
+          Containers.
+        scored: false
+
+      - id: 5.7.4
+        text: "The default namespace should not be used (Manual)"
+        type: "skip"
+        remediation: |
+          Ensure that namespaces are created to allow for appropriate segregation of Kubernetes
+          resources and that all new resources are created in a specific namespace.
+        scored: false

--- a/package/cfg/rke-cis-1.7-permissive/config.yaml
+++ b/package/cfg/rke-cis-1.7-permissive/config.yaml
@@ -1,0 +1,2 @@
+---
+## Version-specific settings that override the values in cfg/config.yaml

--- a/package/cfg/rke-cis-1.7-permissive/config.yaml
+++ b/package/cfg/rke-cis-1.7-permissive/config.yaml
@@ -1,2 +1,10 @@
 ---
 ## Version-specific settings that override the values in cfg/config.yaml
+
+node:
+  kubelet:
+    defaultkubeconfig: "/etc/kubernetes/ssl/kubecfg-kube-node.yaml"
+    defaultcafile: "/etc/kubernetes/ssl/kube-ca.pem"
+
+  proxy:
+    defaultkubeconfig: "/etc/kubernetes/ssl/kubecfg-kube-proxy.yaml"

--- a/package/cfg/rke-cis-1.7-permissive/controlplane.yaml
+++ b/package/cfg/rke-cis-1.7-permissive/controlplane.yaml
@@ -1,0 +1,60 @@
+---
+controls:
+version: "1.7"
+id: 3
+text: "Control Plane Configuration"
+type: "controlplane"
+groups:
+  - id: 3.1
+    text: "Authentication and Authorization"
+    checks:
+      - id: 3.1.1
+        text: "Client certificate authentication should not be used for users (Manual)"
+        type: "manual"
+        remediation: |
+          Alternative mechanisms provided by Kubernetes such as the use of OIDC should be
+          implemented in place of client certificates.
+        scored: false
+      - id: 3.1.2
+        text: "Service account token authentication should not be used for users (Manual)"
+        type: "manual"
+        remediation: |
+          Alternative mechanisms provided by Kubernetes such as the use of OIDC should be implemented
+          in place of service account tokens.
+        scored: false
+      - id: 3.1.3
+        text: "Bootstrap token authentication should not be used for users (Manual)"
+        type: "manual"
+        remediation: |
+          Alternative mechanisms provided by Kubernetes such as the use of OIDC should be implemented
+          in place of bootstrap tokens.
+        scored: false
+
+  - id: 3.2
+    text: "Logging"
+    checks:
+      - id: 3.2.1
+        text: "Ensure that a minimal audit policy is created (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-policy-file"
+              set: true
+        remediation: |
+          Create an audit policy file for your cluster.
+        scored: false
+
+      - id: 3.2.2
+        text: "Ensure that the audit policy covers key security concerns (Manual)"
+        type: "manual"
+        remediation: |
+          Review the audit policy provided for the cluster and ensure that it covers
+          at least the following areas,
+          - Access to Secrets managed by the cluster. Care should be taken to only
+            log Metadata for requests to Secrets, ConfigMaps, and TokenReviews, in
+            order to avoid risk of logging sensitive data.
+          - Modification of Pod and Deployment objects.
+          - Use of `pods/exec`, `pods/portforward`, `pods/proxy` and `services/proxy`.
+          For most requests, minimally logging at the Metadata level is recommended
+          (the most basic level of logging).
+        scored: false

--- a/package/cfg/rke-cis-1.7-permissive/controlplane.yaml
+++ b/package/cfg/rke-cis-1.7-permissive/controlplane.yaml
@@ -34,7 +34,7 @@ groups:
     text: "Logging"
     checks:
       - id: 3.2.1
-        text: "Ensure that a minimal audit policy is created (Manual)"
+        text: "Ensure that a minimal audit policy is created (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -42,7 +42,7 @@ groups:
               set: true
         remediation: |
           Create an audit policy file for your cluster.
-        scored: false
+        scored: true
 
       - id: 3.2.2
         text: "Ensure that the audit policy covers key security concerns (Manual)"

--- a/package/cfg/rke-cis-1.7-permissive/etcd.yaml
+++ b/package/cfg/rke-cis-1.7-permissive/etcd.yaml
@@ -1,0 +1,135 @@
+---
+controls:
+version: "1.7"
+id: 2
+text: "Etcd Node Configuration"
+type: "etcd"
+groups:
+  - id: 2
+    text: "Etcd Node Configuration"
+    checks:
+      - id: 2.1
+        text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--cert-file"
+              env: "ETCD_CERT_FILE"
+            - flag: "--key-file"
+              env: "ETCD_KEY_FILE"
+        remediation: |
+          Follow the etcd service documentation and configure TLS encryption.
+          Then, edit the etcd pod specification file /etc/kubernetes/manifests/etcd.yaml
+          on the master node and set the below parameters.
+          --cert-file=</path/to/ca-file>
+          --key-file=</path/to/key-file>
+        scored: true
+
+      - id: 2.2
+        text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          test_items:
+            - flag: "--client-cert-auth"
+              env: "ETCD_CLIENT_CERT_AUTH"
+              compare:
+                op: eq
+                value: true
+        remediation: |
+          Edit the etcd pod specification file $etcdconf on the master
+          node and set the below parameter.
+          --client-cert-auth="true"
+        scored: true
+
+      - id: 2.3
+        text: "Ensure that the --auto-tls argument is not set to true (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--auto-tls"
+              env: "ETCD_AUTO_TLS"
+              set: false
+            - flag: "--auto-tls"
+              env: "ETCD_AUTO_TLS"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the etcd pod specification file $etcdconf on the master
+          node and either remove the --auto-tls parameter or set it to false.
+            --auto-tls=false
+        scored: true
+
+      - id: 2.4
+        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are
+        set as appropriate (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--peer-cert-file"
+              env: "ETCD_PEER_CERT_FILE"
+            - flag: "--peer-key-file"
+              env: "ETCD_PEER_KEY_FILE"
+        remediation: |
+          Follow the etcd service documentation and configure peer TLS encryption as appropriate
+          for your etcd cluster.
+          Then, edit the etcd pod specification file $etcdconf on the
+          master node and set the below parameters.
+          --peer-client-file=</path/to/peer-cert-file>
+          --peer-key-file=</path/to/peer-key-file>
+        scored: true
+
+      - id: 2.5
+        text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          test_items:
+            - flag: "--peer-client-cert-auth"
+              env: "ETCD_PEER_CLIENT_CERT_AUTH"
+              compare:
+                op: eq
+                value: true
+        remediation: |
+          Edit the etcd pod specification file $etcdconf on the master
+          node and set the below parameter.
+          --peer-client-cert-auth=true
+        scored: true
+
+      - id: 2.6
+        text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--peer-auto-tls"
+              env: "ETCD_PEER_AUTO_TLS"
+              set: false
+            - flag: "--peer-auto-tls"
+              env: "ETCD_PEER_AUTO_TLS"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the etcd pod specification file $etcdconf on the master
+          node and either remove the --peer-auto-tls parameter or set it to false.
+          --peer-auto-tls=false
+        scored: true
+
+      - id: 2.7
+        text: "Ensure that a unique Certificate Authority is used for etcd (Manual)"
+        audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
+        tests:
+          test_items:
+            - flag: "--trusted-ca-file"
+              env: "ETCD_TRUSTED_CA_FILE"
+        remediation: |
+          [Manual test]
+          Follow the etcd documentation and create a dedicated certificate authority setup for the
+          etcd service.
+          Then, edit the etcd pod specification file $etcdconf on the
+          master node and set the below parameter.
+          --trusted-ca-file=</path/to/ca-file>
+        scored: false

--- a/package/cfg/rke-cis-1.7-permissive/etcd.yaml
+++ b/package/cfg/rke-cis-1.7-permissive/etcd.yaml
@@ -5,6 +5,91 @@ id: 2
 text: "Etcd Node Configuration"
 type: "etcd"
 groups:
+  - id: 1.1
+    text: "Control Plane Node Configuration Files"
+    checks:
+      - id: 1.1.11
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
+        audit: stat -c %a /node/var/lib/etcd
+        tests:
+          test_items:
+            - flag: "700"
+              compare:
+                op: eq
+                value: "700"
+              set: true
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above). For example,
+          chmod 700 /var/lib/etcd
+        scored: true
+
+      - id: 1.1.12
+        text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
+        type: "skip"
+        audit: "stat -c %U:%G /node/var/lib/etcd"
+        tests:
+          test_items:
+            - flag: "etcd:etcd"
+              set: true
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above).
+          For example, chown etcd:etcd /var/lib/etcd
+          Permissive - A system service account is required for etcd data directory ownership. 
+          Refer to Rancher's hardening guide for more details on how to configure this ownership.
+        scored: true
+
+      - id: 1.1.19
+        text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
+        audit: "check_files_owner_in_dir.sh /node/etc/kubernetes/ssl"
+        tests:
+          test_items:
+            - flag: "true"
+              compare:
+                op: eq
+                value: "true"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown -R root:root /etc/kubernetes/pki/
+        scored: true
+
+      - id: 1.1.20
+        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Manual)"
+        audit: "find /etc/kubernetes/pki/ -name '*.crt' | xargs stat -c permissions=%a"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod -R 644 /etc/kubernetes/pki/*.crt
+        scored: false
+
+      - id: 1.1.21
+        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
+        audit: "find /etc/kubernetes/pki/ -name '*.key' | xargs stat -c permissions=%a"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod -R 600 /etc/kubernetes/pki/*.key
+        scored: false
+
   - id: 2
     text: "Etcd Node Configuration"
     checks:
@@ -119,12 +204,13 @@ groups:
         scored: true
 
       - id: 2.7
-        text: "Ensure that a unique Certificate Authority is used for etcd (Manual)"
+        text: "Ensure that a unique Certificate Authority is used for etcd (Automated)"
         audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
         tests:
           test_items:
             - flag: "--trusted-ca-file"
               env: "ETCD_TRUSTED_CA_FILE"
+              set: true
         remediation: |
           [Manual test]
           Follow the etcd documentation and create a dedicated certificate authority setup for the
@@ -132,4 +218,4 @@ groups:
           Then, edit the etcd pod specification file $etcdconf on the
           master node and set the below parameter.
           --trusted-ca-file=</path/to/ca-file>
-        scored: false
+        scored: true

--- a/package/cfg/rke-cis-1.7-permissive/etcd.yaml
+++ b/package/cfg/rke-cis-1.7-permissive/etcd.yaml
@@ -38,7 +38,7 @@ groups:
           from the command 'ps -ef | grep etcd'.
           Run the below command (based on the etcd data directory found above).
           For example, chown etcd:etcd /var/lib/etcd
-          Permissive - A system service account is required for etcd data directory ownership. 
+          Permissive - A system service account is required for etcd data directory ownership.
           Refer to Rancher's hardening guide for more details on how to configure this ownership.
         scored: true
 

--- a/package/cfg/rke-cis-1.7-permissive/master.yaml
+++ b/package/cfg/rke-cis-1.7-permissive/master.yaml
@@ -1,0 +1,947 @@
+---
+controls:
+version: "1.7"
+id: 1
+text: "Control Plane Security Configuration"
+type: "master"
+groups:
+  - id: 1.1
+    text: "Control Plane Node Configuration Files"
+    checks:
+      - id: 1.1.1
+        text: "Ensure that the API server pod specification file permissions are set to 600 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $apiserverconf; then stat -c permissions=%a $apiserverconf; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the
+          control plane node.
+          For example, chmod 600 $apiserverconf
+        scored: true
+
+      - id: 1.1.2
+        text: "Ensure that the API server pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $apiserverconf; then stat -c %U:%G $apiserverconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example, chown root:root $apiserverconf
+        scored: true
+
+      - id: 1.1.3
+        text: "Ensure that the controller manager pod specification file permissions are set to 600 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $controllermanagerconf; then stat -c permissions=%a $controllermanagerconf; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example, chmod 600 $controllermanagerconf
+        scored: true
+
+      - id: 1.1.4
+        text: "Ensure that the controller manager pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $controllermanagerconf; then stat -c %U:%G $controllermanagerconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example, chown root:root $controllermanagerconf
+        scored: true
+
+      - id: 1.1.5
+        text: "Ensure that the scheduler pod specification file permissions are set to 600 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c permissions=%a $schedulerconf; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example, chmod 600 $schedulerconf
+        scored: true
+
+      - id: 1.1.6
+        text: "Ensure that the scheduler pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c %U:%G $schedulerconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example, chown root:root $schedulerconf
+        scored: true
+
+      - id: 1.1.7
+        text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod 600 $etcdconf
+        scored: true
+
+      - id: 1.1.8
+        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c %U:%G; fi'"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root $etcdconf
+        scored: true
+
+      - id: 1.1.9
+        text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Manual)"
+        audit: |
+          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
+          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example, chmod 600 <path/to/cni/files>
+        scored: false
+
+      - id: 1.1.10
+        text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
+        audit: |
+          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
+          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root <path/to/cni/files>
+        scored: false
+
+      - id: 1.1.11
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
+        audit: |
+          DATA_DIR=''
+          for d in $(ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%'); do
+            if test -d "$d"; then DATA_DIR="$d"; fi
+          done
+          if ! test -d "$DATA_DIR"; then DATA_DIR=$etcddatadir; fi
+          stat -c permissions=%a "$DATA_DIR"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "700"
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above). For example,
+          chmod 700 /var/lib/etcd
+        scored: true
+
+      - id: 1.1.12
+        text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
+        audit: |
+          DATA_DIR=''
+          for d in $(ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%'); do
+            if test -d "$d"; then DATA_DIR="$d"; fi
+          done
+          if ! test -d "$DATA_DIR"; then DATA_DIR=$etcddatadir; fi
+          stat -c %U:%G "$DATA_DIR"
+        tests:
+          test_items:
+            - flag: "etcd:etcd"
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above).
+          For example, chown etcd:etcd /var/lib/etcd
+        scored: true
+
+      - id: 1.1.13
+        text: "Ensure that the admin.conf file permissions are set to 600 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c permissions=%a /etc/kubernetes/admin.conf; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example, chmod 600 /etc/kubernetes/admin.conf
+        scored: true
+
+      - id: 1.1.14
+        text: "Ensure that the admin.conf file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c %U:%G /etc/kubernetes/admin.conf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example, chown root:root /etc/kubernetes/admin.conf
+        scored: true
+
+      - id: 1.1.15
+        text: "Ensure that the scheduler.conf file permissions are set to 600 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c permissions=%a $schedulerkubeconfig; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod 600 $schedulerkubeconfig
+        scored: true
+
+      - id: 1.1.16
+        text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c %U:%G $schedulerkubeconfig; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root $schedulerkubeconfig
+        scored: true
+
+      - id: 1.1.17
+        text: "Ensure that the controller-manager.conf file permissions are set to 600 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c permissions=%a $controllermanagerkubeconfig; fi'"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod 600 $controllermanagerkubeconfig
+        scored: true
+
+      - id: 1.1.18
+        text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c %U:%G $controllermanagerkubeconfig; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root $controllermanagerkubeconfig
+        scored: true
+
+      - id: 1.1.19
+        text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
+        audit: "find /etc/kubernetes/pki/ | xargs stat -c %U:%G"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "root:root"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown -R root:root /etc/kubernetes/pki/
+        scored: true
+
+      - id: 1.1.20
+        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"
+        audit: "find /etc/kubernetes/pki/ -name '*.crt' | xargs stat -c permissions=%a"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod -R 600 /etc/kubernetes/pki/*.crt
+        scored: false
+
+      - id: 1.1.21
+        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
+        audit: "find /etc/kubernetes/pki/ -name '*.key' | xargs stat -c permissions=%a"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod -R 600 /etc/kubernetes/pki/*.key
+        scored: false
+
+  - id: 1.2
+    text: "API Server"
+    checks:
+      - id: 1.2.1
+        text: "Ensure that the --anonymous-auth argument is set to false (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--anonymous-auth"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the below parameter.
+          --anonymous-auth=false
+        scored: false
+
+      - id: 1.2.2
+        text: "Ensure that the --token-auth-file parameter is not set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--token-auth-file"
+              set: false
+        remediation: |
+          Follow the documentation and configure alternate mechanisms for authentication. Then,
+          edit the API server pod specification file $apiserverconf
+          on the control plane node and remove the --token-auth-file=<filename> parameter.
+        scored: true
+
+      - id: 1.2.3
+        text: "Ensure that the --DenyServiceExternalIPs is set (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: have
+                value: "DenyServiceExternalIPs"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and remove the `DenyServiceExternalIPs`
+          from enabled admission plugins.
+        scored: false
+
+      - id: 1.2.4
+        text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--kubelet-client-certificate"
+            - flag: "--kubelet-client-key"
+        remediation: |
+          Follow the Kubernetes documentation and set up the TLS connection between the
+          apiserver and kubelets. Then, edit API server pod specification file
+          $apiserverconf on the control plane node and set the
+          kubelet client certificate and key parameters as below.
+          --kubelet-client-certificate=<path/to/client-certificate-file>
+          --kubelet-client-key=<path/to/client-key-file>
+        scored: true
+
+      - id: 1.2.5
+        text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--kubelet-certificate-authority"
+        remediation: |
+          Follow the Kubernetes documentation and setup the TLS connection between
+          the apiserver and kubelets. Then, edit the API server pod specification file
+          $apiserverconf on the control plane node and set the
+          --kubelet-certificate-authority parameter to the path to the cert file for the certificate authority.
+          --kubelet-certificate-authority=<ca-string>
+        scored: true
+
+      - id: 1.2.6
+        text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--authorization-mode"
+              compare:
+                op: nothave
+                value: "AlwaysAllow"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --authorization-mode parameter to values other than AlwaysAllow.
+          One such example could be as below.
+          --authorization-mode=RBAC
+        scored: true
+
+      - id: 1.2.7
+        text: "Ensure that the --authorization-mode argument includes Node (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--authorization-mode"
+              compare:
+                op: has
+                value: "Node"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --authorization-mode parameter to a value that includes Node.
+          --authorization-mode=Node,RBAC
+        scored: true
+
+      - id: 1.2.8
+        text: "Ensure that the --authorization-mode argument includes RBAC (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--authorization-mode"
+              compare:
+                op: has
+                value: "RBAC"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --authorization-mode parameter to a value that includes RBAC,
+          for example `--authorization-mode=Node,RBAC`.
+        scored: true
+
+      - id: 1.2.9
+        text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "EventRateLimit"
+        remediation: |
+          Follow the Kubernetes documentation and set the desired limits in a configuration file.
+          Then, edit the API server pod specification file $apiserverconf
+          and set the below parameters.
+          --enable-admission-plugins=...,EventRateLimit,...
+          --admission-control-config-file=<path/to/configuration/file>
+        scored: false
+
+      - id: 1.2.10
+        text: "Ensure that the admission control plugin AlwaysAdmit is not set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: nothave
+                value: AlwaysAdmit
+            - flag: "--enable-admission-plugins"
+              set: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and either remove the --enable-admission-plugins parameter, or set it to a
+          value that does not include AlwaysAdmit.
+        scored: true
+
+      - id: 1.2.11
+        text: "Ensure that the admission control plugin AlwaysPullImages is set (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "AlwaysPullImages"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --enable-admission-plugins parameter to include
+          AlwaysPullImages.
+          --enable-admission-plugins=...,AlwaysPullImages,...
+        scored: false
+
+      - id: 1.2.12
+        text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "SecurityContextDeny"
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "PodSecurityPolicy"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --enable-admission-plugins parameter to include
+          SecurityContextDeny, unless PodSecurityPolicy is already in place.
+          --enable-admission-plugins=...,SecurityContextDeny,...
+        scored: false
+
+      - id: 1.2.13
+        text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--disable-admission-plugins"
+              compare:
+                op: nothave
+                value: "ServiceAccount"
+            - flag: "--disable-admission-plugins"
+              set: false
+        remediation: |
+          Follow the documentation and create ServiceAccount objects as per your environment.
+          Then, edit the API server pod specification file $apiserverconf
+          on the control plane node and ensure that the --disable-admission-plugins parameter is set to a
+          value that does not include ServiceAccount.
+        scored: true
+
+      - id: 1.2.14
+        text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--disable-admission-plugins"
+              compare:
+                op: nothave
+                value: "NamespaceLifecycle"
+            - flag: "--disable-admission-plugins"
+              set: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --disable-admission-plugins parameter to
+          ensure it does not include NamespaceLifecycle.
+        scored: true
+
+      - id: 1.2.15
+        text: "Ensure that the admission control plugin NodeRestriction is set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--enable-admission-plugins"
+              compare:
+                op: has
+                value: "NodeRestriction"
+        remediation: |
+          Follow the Kubernetes documentation and configure NodeRestriction plug-in on kubelets.
+          Then, edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --enable-admission-plugins parameter to a
+          value that includes NodeRestriction.
+          --enable-admission-plugins=...,NodeRestriction,...
+        scored: true
+
+      - id: 1.2.16
+        text: "Ensure that the --secure-port argument is not set to 0 - NoteThis recommendation is obsolete and will be deleted per the consensus process (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--secure-port"
+              compare:
+                op: gt
+                value: 0
+            - flag: "--secure-port"
+              set: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and either remove the --secure-port parameter or
+          set it to a different (non-zero) desired port.
+        scored: false
+
+      - id: 1.2.17
+        text: "Ensure that the --profiling argument is set to false (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--profiling"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the below parameter.
+          --profiling=false
+        scored: true
+
+      - id: 1.2.18
+        text: "Ensure that the --audit-log-path argument is set (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-log-path"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --audit-log-path parameter to a suitable path and
+          file where you would like audit logs to be written, for example,
+          --audit-log-path=/var/log/apiserver/audit.log
+        scored: true
+
+      - id: 1.2.19
+        text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-log-maxage"
+              compare:
+                op: gte
+                value: 30
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --audit-log-maxage parameter to 30
+          or as an appropriate number of days, for example,
+          --audit-log-maxage=30
+        scored: true
+
+      - id: 1.2.20
+        text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-log-maxbackup"
+              compare:
+                op: gte
+                value: 10
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --audit-log-maxbackup parameter to 10 or to an appropriate
+          value. For example,
+          --audit-log-maxbackup=10
+        scored: true
+
+      - id: 1.2.21
+        text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--audit-log-maxsize"
+              compare:
+                op: gte
+                value: 100
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --audit-log-maxsize parameter to an appropriate size in MB.
+          For example, to set it as 100 MB, --audit-log-maxsize=100
+        scored: true
+
+      - id: 1.2.22
+        text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        type: manual
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          and set the below parameter as appropriate and if needed.
+          For example, --request-timeout=300s
+        scored: false
+
+      - id: 1.2.23
+        text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--service-account-lookup"
+              set: false
+            - flag: "--service-account-lookup"
+              compare:
+                op: eq
+                value: true
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the below parameter.
+          --service-account-lookup=true
+          Alternatively, you can delete the --service-account-lookup parameter from this file so
+          that the default takes effect.
+        scored: true
+
+      - id: 1.2.24
+        text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--service-account-key-file"
+        remediation: |
+          Edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --service-account-key-file parameter
+          to the public key file for service accounts. For example,
+          --service-account-key-file=<filename>
+        scored: true
+
+      - id: 1.2.25
+        text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--etcd-certfile"
+            - flag: "--etcd-keyfile"
+        remediation: |
+          Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
+          Then, edit the API server pod specification file $apiserverconf
+          on the control plane node and set the etcd certificate and key file parameters.
+          --etcd-certfile=<path/to/client-certificate-file>
+          --etcd-keyfile=<path/to/client-key-file>
+        scored: true
+
+      - id: 1.2.26
+        text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          bin_op: and
+          test_items:
+            - flag: "--tls-cert-file"
+            - flag: "--tls-private-key-file"
+        remediation: |
+          Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
+          Then, edit the API server pod specification file $apiserverconf
+          on the control plane node and set the TLS certificate and private key file parameters.
+          --tls-cert-file=<path/to/tls-certificate-file>
+          --tls-private-key-file=<path/to/tls-key-file>
+        scored: true
+
+      - id: 1.2.27
+        text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--client-ca-file"
+        remediation: |
+          Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
+          Then, edit the API server pod specification file $apiserverconf
+          on the control plane node and set the client certificate authority file.
+          --client-ca-file=<path/to/client-ca-file>
+        scored: true
+
+      - id: 1.2.28
+        text: "Ensure that the --etcd-cafile argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--etcd-cafile"
+        remediation: |
+          Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
+          Then, edit the API server pod specification file $apiserverconf
+          on the control plane node and set the etcd certificate authority file parameter.
+          --etcd-cafile=<path/to/ca-file>
+        scored: true
+
+      - id: 1.2.29
+        text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--encryption-provider-config"
+        remediation: |
+          Follow the Kubernetes documentation and configure a EncryptionConfig file.
+          Then, edit the API server pod specification file $apiserverconf
+          on the control plane node and set the --encryption-provider-config parameter to the path of that file.
+          For example, --encryption-provider-config=</path/to/EncryptionConfig/File>
+        scored: false
+
+      - id: 1.2.30
+        text: "Ensure that encryption providers are appropriately configured (Manual)"
+        audit: |
+          ENCRYPTION_PROVIDER_CONFIG=$(ps -ef | grep $apiserverbin | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
+          if test -e $ENCRYPTION_PROVIDER_CONFIG; then grep -A1 'providers:' $ENCRYPTION_PROVIDER_CONFIG | tail -n1 | grep -o "[A-Za-z]*" | sed 's/^/provider=/'; fi
+        tests:
+          test_items:
+            - flag: "provider"
+              compare:
+                op: valid_elements
+                value: "aescbc,kms,secretbox"
+        remediation: |
+          Follow the Kubernetes documentation and configure a EncryptionConfig file.
+          In this file, choose aescbc, kms or secretbox as the encryption provider.
+        scored: false
+
+      - id: 1.2.31
+        text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Manual)"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--tls-cipher-suites"
+              compare:
+                op: valid_elements
+                value: "TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_RSA_WITH_3DES_EDE_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_256_GCM_SHA384"
+        remediation: |
+          Edit the API server pod specification file /etc/kubernetes/manifests/kube-apiserver.yaml
+          on the control plane node and set the below parameter.
+          --tls-cipher-suites=TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_CHACHA20_POLY1305_SHA256,
+          TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+          TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+          TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,
+          TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+          TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+          TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_RSA_WITH_3DES_EDE_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,
+          TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_256_GCM_SHA384
+        scored: false
+
+  - id: 1.3
+    text: "Controller Manager"
+    checks:
+      - id: 1.3.1
+        text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Manual)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--terminated-pod-gc-threshold"
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the control plane node and set the --terminated-pod-gc-threshold to an appropriate threshold,
+          for example, --terminated-pod-gc-threshold=10
+        scored: false
+
+      - id: 1.3.2
+        text: "Ensure that the --profiling argument is set to false (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--profiling"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the control plane node and set the below parameter.
+          --profiling=false
+        scored: true
+
+      - id: 1.3.3
+        text: "Ensure that the --use-service-account-credentials argument is set to true (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--use-service-account-credentials"
+              compare:
+                op: noteq
+                value: false
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the control plane node to set the below parameter.
+          --use-service-account-credentials=true
+        scored: true
+
+      - id: 1.3.4
+        text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--service-account-private-key-file"
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the control plane node and set the --service-account-private-key-file parameter
+          to the private key file for service accounts.
+          --service-account-private-key-file=<filename>
+        scored: true
+
+      - id: 1.3.5
+        text: "Ensure that the --root-ca-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--root-ca-file"
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the control plane node and set the --root-ca-file parameter to the certificate bundle file`.
+          --root-ca-file=<path/to/file>
+        scored: true
+
+      - id: 1.3.6
+        text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--feature-gates"
+              compare:
+                op: nothave
+                value: "RotateKubeletServerCertificate=false"
+              set: true
+            - flag: "--feature-gates"
+              set: false
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the control plane node and set the --feature-gates parameter to include RotateKubeletServerCertificate=true.
+          --feature-gates=RotateKubeletServerCertificate=true
+        scored: true
+
+      - id: 1.3.7
+        text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
+        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--bind-address"
+              compare:
+                op: eq
+                value: "127.0.0.1"
+            - flag: "--bind-address"
+              set: false
+        remediation: |
+          Edit the Controller Manager pod specification file $controllermanagerconf
+          on the control plane node and ensure the correct value for the --bind-address parameter
+        scored: true
+
+  - id: 1.4
+    text: "Scheduler"
+    checks:
+      - id: 1.4.1
+        text: "Ensure that the --profiling argument is set to false (Automated)"
+        audit: "/bin/ps -ef | grep $schedulerbin | grep -v grep"
+        tests:
+          test_items:
+            - flag: "--profiling"
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          Edit the Scheduler pod specification file $schedulerconf file
+          on the control plane node and set the below parameter.
+          --profiling=false
+        scored: true
+
+      - id: 1.4.2
+        text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
+        audit: "/bin/ps -ef | grep $schedulerbin | grep -v grep"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--bind-address"
+              compare:
+                op: eq
+                value: "127.0.0.1"
+            - flag: "--bind-address"
+              set: false
+        remediation: |
+          Edit the Scheduler pod specification file $schedulerconf
+          on the control plane node and ensure the correct value for the --bind-address parameter
+        scored: true

--- a/package/cfg/rke-cis-1.7-permissive/master.yaml
+++ b/package/cfg/rke-cis-1.7-permissive/master.yaml
@@ -467,7 +467,7 @@ groups:
           on the control plane node and set the --enable-admission-plugins parameter to include
           SecurityContextDeny, unless PodSecurityPolicy is already in place.
           --enable-admission-plugins=...,SecurityContextDeny,...
-	  Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
+          Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
         scored: false
 
       - id: 1.2.13
@@ -720,7 +720,7 @@ groups:
 
       - id: 1.2.29
         text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
-	type: "skip"
+        type: "skip"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -730,7 +730,7 @@ groups:
           Then, edit the API server pod specification file $apiserverconf
           on the control plane node and set the --encryption-provider-config parameter to the path of that file.
           For example, --encryption-provider-config=</path/to/EncryptionConfig/File>
-	  Permissive - Enabling encryption changes how data can be recovered as data is encrypted.
+          Permissive - Enabling encryption changes how data can be recovered as data is encrypted.
         scored: false
 
       - id: 1.2.30
@@ -748,7 +748,7 @@ groups:
         remediation: |
           Follow the Kubernetes documentation and configure a EncryptionConfig file.
           In this file, choose aescbc, kms or secretbox as the encryption provider.
-	  Permissive - Enabling encryption changes how data can be recovered as data is encrypted.
+          Permissive - Enabling encryption changes how data can be recovered as data is encrypted.
         scored: false
 
       - id: 1.2.31

--- a/package/cfg/rke-cis-1.7-permissive/master.yaml
+++ b/package/cfg/rke-cis-1.7-permissive/master.yaml
@@ -22,7 +22,7 @@ groups:
           Run the below command (based on the file location on your system) on the
           control plane node.
           For example, chmod 600 $apiserverconf
-          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
 
@@ -36,7 +36,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chown root:root $apiserverconf
-          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
 
@@ -53,7 +53,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chmod 600 $controllermanagerconf
-          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
 
@@ -67,7 +67,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chown root:root $controllermanagerconf
-          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
 
@@ -84,7 +84,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chmod 600 $schedulerconf
-          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
 
@@ -98,7 +98,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chown root:root $schedulerconf
-          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
 
@@ -117,7 +117,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chmod 600 $etcdconf
-          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
 
@@ -133,7 +133,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chown root:root $etcdconf
-          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
 
@@ -182,7 +182,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chmod 600 /etc/kubernetes/admin.conf
-          Not Applicable: Cluster provisioned by RKE does not store the kubernetes default kubeconfig credentials file on the nodes.
+          Not Applicable -  Cluster provisioned by RKE does not store the kubernetes default kubeconfig credentials file on the nodes.
         scored: true
 
       - id: 1.1.14
@@ -195,7 +195,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chown root:root /etc/kubernetes/admin.conf
-          Not Applicable: Cluster provisioned by RKE does not store the kubernetes default kubeconfig credentials file on the nodes.
+          Not Applicable -  Cluster provisioned by RKE does not store the kubernetes default kubeconfig credentials file on the nodes.
         scored: true
 
       - id: 1.1.15
@@ -212,7 +212,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chmod 600 $schedulerkubeconfig
-          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for scheduler.
+          Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for scheduler.
           All configuration is passed in as arguments at container run time.
         scored: true
 
@@ -227,7 +227,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chown root:root $schedulerkubeconfig
-          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for scheduler.
+          Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for scheduler.
           All configuration is passed in as arguments at container run time.
         scored: true
 
@@ -245,7 +245,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chmod 600 $controllermanagerkubeconfig
-          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for controller-manager.
+          Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for controller-manager.
           All configuration is passed in as arguments at container run time.
         scored: true
 
@@ -260,7 +260,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chown root:root $controllermanagerkubeconfig
-          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for controller-manager.
+          Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for controller-manager.
           All configuration is passed in as arguments at container run time.
         scored: true
 

--- a/package/cfg/rke-cis-1.7-permissive/master.yaml
+++ b/package/cfg/rke-cis-1.7-permissive/master.yaml
@@ -347,7 +347,7 @@ groups:
           $apiserverconf on the control plane node and set the
           --kubelet-certificate-authority parameter to the path to the cert file for the certificate authority.
           --kubelet-certificate-authority=<ca-string>
-          When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
+          Permissive - When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
         scored: true
 
       - id: 1.2.6
@@ -449,6 +449,7 @@ groups:
 
       - id: 1.2.12
         text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)"
+        type: "skip"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           bin_op: or
@@ -466,6 +467,7 @@ groups:
           on the control plane node and set the --enable-admission-plugins parameter to include
           SecurityContextDeny, unless PodSecurityPolicy is already in place.
           --enable-admission-plugins=...,SecurityContextDeny,...
+	  Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
         scored: false
 
       - id: 1.2.13
@@ -718,6 +720,7 @@ groups:
 
       - id: 1.2.29
         text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
+	type: "skip"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -727,10 +730,12 @@ groups:
           Then, edit the API server pod specification file $apiserverconf
           on the control plane node and set the --encryption-provider-config parameter to the path of that file.
           For example, --encryption-provider-config=</path/to/EncryptionConfig/File>
+	  Permissive - Enabling encryption changes how data can be recovered as data is encrypted.
         scored: false
 
       - id: 1.2.30
         text: "Ensure that encryption providers are appropriately configured (Manual)"
+        type: "skip"
         audit: |
           ENCRYPTION_PROVIDER_CONFIG=$(ps -ef | grep $apiserverbin | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
           if test -e $ENCRYPTION_PROVIDER_CONFIG; then grep -A1 'providers:' $ENCRYPTION_PROVIDER_CONFIG | tail -n1 | grep -o "[A-Za-z]*" | sed 's/^/provider=/'; fi
@@ -743,6 +748,7 @@ groups:
         remediation: |
           Follow the Kubernetes documentation and configure a EncryptionConfig file.
           In this file, choose aescbc, kms or secretbox as the encryption provider.
+	  Permissive - Enabling encryption changes how data can be recovered as data is encrypted.
         scored: false
 
       - id: 1.2.31

--- a/package/cfg/rke-cis-1.7-permissive/master.yaml
+++ b/package/cfg/rke-cis-1.7-permissive/master.yaml
@@ -1,6 +1,6 @@
 ---
 controls:
-version: "1.7"
+version: 1.7
 id: 1
 text: "Control Plane Security Configuration"
 type: "master"
@@ -10,6 +10,7 @@ groups:
     checks:
       - id: 1.1.1
         text: "Ensure that the API server pod specification file permissions are set to 600 or more restrictive (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $apiserverconf; then stat -c permissions=%a $apiserverconf; fi'"
         tests:
           test_items:
@@ -21,10 +22,13 @@ groups:
           Run the below command (based on the file location on your system) on the
           control plane node.
           For example, chmod 600 $apiserverconf
+          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.2
         text: "Ensure that the API server pod specification file ownership is set to root:root (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $apiserverconf; then stat -c %U:%G $apiserverconf; fi'"
         tests:
           test_items:
@@ -32,10 +36,13 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chown root:root $apiserverconf
+          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.3
         text: "Ensure that the controller manager pod specification file permissions are set to 600 or more restrictive (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $controllermanagerconf; then stat -c permissions=%a $controllermanagerconf; fi'"
         tests:
           test_items:
@@ -46,10 +53,13 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chmod 600 $controllermanagerconf
+          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.4
         text: "Ensure that the controller manager pod specification file ownership is set to root:root (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $controllermanagerconf; then stat -c %U:%G $controllermanagerconf; fi'"
         tests:
           test_items:
@@ -57,10 +67,13 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chown root:root $controllermanagerconf
+          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.5
         text: "Ensure that the scheduler pod specification file permissions are set to 600 or more restrictive (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c permissions=%a $schedulerconf; fi'"
         tests:
           test_items:
@@ -71,10 +84,13 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chmod 600 $schedulerconf
+          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.6
         text: "Ensure that the scheduler pod specification file ownership is set to root:root (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c %U:%G $schedulerconf; fi'"
         tests:
           test_items:
@@ -82,10 +98,13 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chown root:root $schedulerconf
+          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.7
         text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
         use_multiple_values: true
         tests:
@@ -98,10 +117,13 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chmod 600 $etcdconf
+          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.8
         text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c %U:%G; fi'"
         use_multiple_values: true
         tests:
@@ -111,6 +133,8 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chown root:root $etcdconf
+          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.9
@@ -145,49 +169,9 @@ groups:
           chown root:root <path/to/cni/files>
         scored: false
 
-      - id: 1.1.11
-        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: |
-          DATA_DIR=''
-          for d in $(ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%'); do
-            if test -d "$d"; then DATA_DIR="$d"; fi
-          done
-          if ! test -d "$DATA_DIR"; then DATA_DIR=$etcddatadir; fi
-          stat -c permissions=%a "$DATA_DIR"
-        tests:
-          test_items:
-            - flag: "permissions"
-              compare:
-                op: bitmask
-                value: "700"
-        remediation: |
-          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-          from the command 'ps -ef | grep etcd'.
-          Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
-        scored: true
-
-      - id: 1.1.12
-        text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
-        audit: |
-          DATA_DIR=''
-          for d in $(ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%'); do
-            if test -d "$d"; then DATA_DIR="$d"; fi
-          done
-          if ! test -d "$DATA_DIR"; then DATA_DIR=$etcddatadir; fi
-          stat -c %U:%G "$DATA_DIR"
-        tests:
-          test_items:
-            - flag: "etcd:etcd"
-        remediation: |
-          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-          from the command 'ps -ef | grep etcd'.
-          Run the below command (based on the etcd data directory found above).
-          For example, chown etcd:etcd /var/lib/etcd
-        scored: true
-
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 600 or more restrictive (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c permissions=%a /etc/kubernetes/admin.conf; fi'"
         tests:
           test_items:
@@ -198,10 +182,12 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chmod 600 /etc/kubernetes/admin.conf
+          Not Applicable: Cluster provisioned by RKE does not store the kubernetes default kubeconfig credentials file on the nodes.
         scored: true
 
       - id: 1.1.14
         text: "Ensure that the admin.conf file ownership is set to root:root (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e /etc/kubernetes/admin.conf; then stat -c %U:%G /etc/kubernetes/admin.conf; fi'"
         tests:
           test_items:
@@ -209,10 +195,12 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chown root:root /etc/kubernetes/admin.conf
+          Not Applicable: Cluster provisioned by RKE does not store the kubernetes default kubeconfig credentials file on the nodes.
         scored: true
 
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 600 or more restrictive (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c permissions=%a $schedulerkubeconfig; fi'"
         tests:
           test_items:
@@ -224,10 +212,13 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chmod 600 $schedulerkubeconfig
+          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for scheduler.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c %U:%G $schedulerkubeconfig; fi'"
         tests:
           test_items:
@@ -236,10 +227,13 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chown root:root $schedulerkubeconfig
+          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for scheduler.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 600 or more restrictive (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c permissions=%a $controllermanagerkubeconfig; fi'"
         tests:
           test_items:
@@ -251,10 +245,13 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chmod 600 $controllermanagerkubeconfig
+          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for controller-manager.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 1.1.18
         text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
+        type: "skip"
         audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c %U:%G $controllermanagerkubeconfig; fi'"
         tests:
           test_items:
@@ -263,58 +260,16 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chown root:root $controllermanagerkubeconfig
+          Not Applicable: Cluster provisioned by RKE doesn't require or maintain a configuration file for controller-manager.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
-      - id: 1.1.19
-        text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
-        audit: "find /etc/kubernetes/pki/ | xargs stat -c %U:%G"
-        use_multiple_values: true
-        tests:
-          test_items:
-            - flag: "root:root"
-        remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chown -R root:root /etc/kubernetes/pki/
-        scored: true
-
-      - id: 1.1.20
-        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"
-        audit: "find /etc/kubernetes/pki/ -name '*.crt' | xargs stat -c permissions=%a"
-        use_multiple_values: true
-        tests:
-          test_items:
-            - flag: "permissions"
-              compare:
-                op: bitmask
-                value: "600"
-        remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chmod -R 600 /etc/kubernetes/pki/*.crt
-        scored: false
-
-      - id: 1.1.21
-        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "find /etc/kubernetes/pki/ -name '*.key' | xargs stat -c permissions=%a"
-        use_multiple_values: true
-        tests:
-          test_items:
-            - flag: "permissions"
-              compare:
-                op: bitmask
-                value: "600"
-        remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chmod -R 600 /etc/kubernetes/pki/*.key
-        scored: false
 
   - id: 1.2
     text: "API Server"
     checks:
       - id: 1.2.1
-        text: "Ensure that the --anonymous-auth argument is set to false (Manual)"
+        text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -322,11 +277,12 @@ groups:
               compare:
                 op: eq
                 value: false
+              set: true
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the control plane node and set the below parameter.
           --anonymous-auth=false
-        scored: false
+        scored: true
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
@@ -342,20 +298,23 @@ groups:
         scored: true
 
       - id: 1.2.3
-        text: "Ensure that the --DenyServiceExternalIPs is set (Manual)"
+        text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           bin_op: or
           test_items:
             - flag: "--enable-admission-plugins"
               compare:
-                op: have
+                op: nothave
                 value: "DenyServiceExternalIPs"
+              set: true
+            - flag: "--enable-admission-plugins"
+              set: false
         remediation: |
           Edit the API server pod specification file $apiserverconf
           on the control plane node and remove the `DenyServiceExternalIPs`
           from enabled admission plugins.
-        scored: false
+        scored: true
 
       - id: 1.2.4
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"
@@ -376,16 +335,19 @@ groups:
 
       - id: 1.2.5
         text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
+        type: "skip"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
             - flag: "--kubelet-certificate-authority"
+              set: true
         remediation: |
           Follow the Kubernetes documentation and setup the TLS connection between
           the apiserver and kubelets. Then, edit the API server pod specification file
           $apiserverconf on the control plane node and set the
           --kubelet-certificate-authority parameter to the path to the cert file for the certificate authority.
           --kubelet-certificate-authority=<ca-string>
+          When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
         scored: true
 
       - id: 1.2.6
@@ -561,7 +523,7 @@ groups:
         scored: true
 
       - id: 1.2.16
-        text: "Ensure that the --secure-port argument is not set to 0 - NoteThis recommendation is obsolete and will be deleted per the consensus process (Manual)"
+        text: "Ensure that the --secure-port argument is not set to 0 - NoteThis recommendation is obsolete and will be deleted per the consensus process (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           bin_op: or
@@ -576,7 +538,7 @@ groups:
           Edit the API server pod specification file $apiserverconf
           on the control plane node and either remove the --secure-port parameter or
           set it to a different (non-zero) desired port.
-        scored: false
+        scored: true
 
       - id: 1.2.17
         text: "Ensure that the --profiling argument is set to false (Automated)"
@@ -809,7 +771,7 @@ groups:
     text: "Controller Manager"
     checks:
       - id: 1.3.1
-        text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Manual)"
+        text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
         tests:
           test_items:
@@ -818,7 +780,7 @@ groups:
           Edit the Controller Manager pod specification file $controllermanagerconf
           on the control plane node and set the --terminated-pod-gc-threshold to an appropriate threshold,
           for example, --terminated-pod-gc-threshold=10
-        scored: false
+        scored: true
 
       - id: 1.3.2
         text: "Ensure that the --profiling argument is set to false (Automated)"
@@ -877,6 +839,7 @@ groups:
 
       - id: 1.3.6
         text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
+        type: "skip"
         audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
         tests:
           bin_op: or
@@ -892,6 +855,7 @@ groups:
           Edit the Controller Manager pod specification file $controllermanagerconf
           on the control plane node and set the --feature-gates parameter to include RotateKubeletServerCertificate=true.
           --feature-gates=RotateKubeletServerCertificate=true
+          Cluster provisioned by RKE handles certificate rotation directly through RKE.
         scored: true
 
       - id: 1.3.7

--- a/package/cfg/rke-cis-1.7-permissive/node.yaml
+++ b/package/cfg/rke-cis-1.7-permissive/node.yaml
@@ -21,8 +21,8 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example, chmod 600 $kubeletsvc
-	  Not Applicable - Clusters provisioned by RKE doesn’t require or maintain a configuration file for the kubelet service.
-           All configuration is passed in as arguments at container run time.
+          Not Applicable - Clusters provisioned by RKE doesn’t require or maintain a configuration file for the kubelet service.
+          All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 4.1.2
@@ -139,7 +139,7 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-	  Run the following command (using the config file location identified in the Audit step)
+          Run the following command (using the config file location identified in the Audit step)
           chmod 600 $kubeletconf
           Not Applicable - Clusters provisioned by RKE do not require or maintain a configuration file for the kubelet.
           All configuration is passed in as arguments at container run time.
@@ -153,7 +153,7 @@ groups:
           test_items:
             - flag: root:root
         remediation: |
-	   Run the following command (using the config file location identified in the Audit step)
+          Run the following command (using the config file location identified in the Audit step)
           chown root:root $kubeletconf
           Not Applicable - Clusters provisioned by RKE doesn’t require or maintain a configuration file for the kubelet.
           All configuration is passed in as arguments at container run time.

--- a/package/cfg/rke-cis-1.7-permissive/node.yaml
+++ b/package/cfg/rke-cis-1.7-permissive/node.yaml
@@ -1,6 +1,6 @@
 ---
 controls:
-version: "1.7"
+version: 1.7
 id: 4
 text: "Worker Node Security Configuration"
 type: "node"
@@ -10,6 +10,7 @@ groups:
     checks:
       - id: 4.1.1
         text: "Ensure that the kubelet service file permissions are set to 600 or more restrictive (Automated)"
+        type: "skip"
         audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c permissions=%a $kubeletsvc; fi'' '
         tests:
           test_items:
@@ -20,10 +21,13 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example, chmod 600 $kubeletsvc
+	  Not Applicable - Clusters provisioned by RKE doesn’t require or maintain a configuration file for the kubelet service.
+           All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 4.1.2
         text: "Ensure that the kubelet service file ownership is set to root:root (Automated)"
+        type: "skip"
         audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc; fi'' '
         tests:
           test_items:
@@ -32,10 +36,12 @@ groups:
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
           chown root:root $kubeletsvc
+          Not Applicable - Clusters provisioned by RKE doesn’t require or maintain a configuration file for the kubelet service.
+           All configuration is passed in as arguments at container run time.
         scored: true
 
       - id: 4.1.3
-        text: "If proxy kubeconfig file exists ensure permissions are set to 600 or more restrictive (Manual)"
+        text: "If proxy kubeconfig file exists ensure permissions are set to 600 or more restrictive (Automated)"
         audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c permissions=%a $proxykubeconfig; fi'' '
         tests:
           bin_op: or
@@ -51,10 +57,10 @@ groups:
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
           chmod 600 $proxykubeconfig
-        scored: false
+        scored: true
 
       - id: 4.1.4
-        text: "If proxy kubeconfig file exists ensure ownership is set to root:root (Manual)"
+        text: "If proxy kubeconfig file exists ensure ownership is set to root:root (Automated)"
         audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c %U:%G $proxykubeconfig; fi'' '
         tests:
           bin_op: or
@@ -65,11 +71,11 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example, chown root:root $proxykubeconfig
-        scored: false
+        scored: true
 
       - id: 4.1.5
         text: "Ensure that the --kubeconfig kubelet.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c permissions=%a $kubeletkubeconfig; fi'' '
+        audit: '/bin/sh -c ''if test -e /node$kubeletkubeconfig; then stat -c permissions=%a /node$kubeletkubeconfig; fi'' '
         tests:
           test_items:
             - flag: "permissions"
@@ -84,7 +90,7 @@ groups:
 
       - id: 4.1.6
         text: "Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root (Automated)"
-        audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c %U:%G $kubeletkubeconfig; fi'' '
+        audit: '/bin/sh -c ''if test -e /node$kubeletkubeconfig; then stat -c %U:%G /node$kubeletkubeconfig; fi'' '
         tests:
           test_items:
             - flag: root:root
@@ -95,8 +101,8 @@ groups:
         scored: true
 
       - id: 4.1.7
-        text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Manual)"
-        audit: "check_cafile_permissions.sh"
+        text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Automated)"
+        audit: "stat -c permissions=%a /node/etc/kubernetes/ssl/kube-ca.pem"
         tests:
           test_items:
             - flag: "permissions"
@@ -106,11 +112,11 @@ groups:
         remediation: |
           Run the following command to modify the file permissions of the
           --client-ca-file chmod 600 <filename>
-        scored: false
+        scored: true
 
       - id: 4.1.8
-        text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
-        audit: "check_cafile_ownership.sh"
+        text: "Ensure that the client certificate authorities file ownership is set to root:root (Automated)"
+        audit: "stat -c %U:%G /node/etc/kubernetes/ssl/kube-ca.pem"
         tests:
           test_items:
             - flag: root:root
@@ -120,10 +126,11 @@ groups:
         remediation: |
           Run the following command to modify the ownership of the --client-ca-file.
           chown root:root <filename>
-        scored: false
+        scored: true
 
       - id: 4.1.9
-        text: "If the kubelet config.yaml configuration file is being used validate permissions set to 600 or more restrictive (Manual)"
+        text: "If the kubelet config.yaml configuration file is being used validate permissions set to 600 or more restrictive (Automated)"
+        type: "skip"
         audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c permissions=%a $kubeletconf; fi'' '
         tests:
           test_items:
@@ -132,19 +139,24 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the following command (using the config file location identified in the Audit step)
+	  Run the following command (using the config file location identified in the Audit step)
           chmod 600 $kubeletconf
-        scored: false
+          Not Applicable - Clusters provisioned by RKE do not require or maintain a configuration file for the kubelet.
+          All configuration is passed in as arguments at container run time.
+        scored: true
 
       - id: 4.1.10
         text: "If the kubelet config.yaml configuration file is being used validate file ownership is set to root:root (Manual)"
+        type: "skip"
         audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c %U:%G $kubeletconf; fi'' '
         tests:
           test_items:
             - flag: root:root
         remediation: |
-          Run the following command (using the config file location identified in the Audit step)
+	   Run the following command (using the config file location identified in the Audit step)
           chown root:root $kubeletconf
+          Not Applicable - Clusters provisioned by RKE doesn’t require or maintain a configuration file for the kubelet.
+          All configuration is passed in as arguments at container run time.
         scored: false
 
   - id: 4.2
@@ -153,7 +165,7 @@ groups:
       - id: 4.2.1
         text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: "--anonymous-auth"
@@ -176,7 +188,7 @@ groups:
       - id: 4.2.2
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --authorization-mode
@@ -198,7 +210,7 @@ groups:
       - id: 4.2.3
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --client-ca-file
@@ -216,9 +228,9 @@ groups:
         scored: true
 
       - id: 4.2.4
-        text: "Verify that the --read-only-port argument is set to 0 (Manual)"
+        text: "Verify that the --read-only-port argument is set to 0 (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           bin_op: or
           test_items:
@@ -239,12 +251,12 @@ groups:
           Based on your system, restart the kubelet service. For example,
           systemctl daemon-reload
           systemctl restart kubelet.service
-        scored: false
+        scored: true
 
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -271,7 +283,7 @@ groups:
       - id: 4.2.6
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --make-iptables-util-chains
@@ -299,6 +311,7 @@ groups:
         # This is one of those properties that can only be set as a command line argument.
         # To check if the property is set as expected, we need to parse the kubelet command
         # instead reading the Kubelet Configuration file.
+        type: "skip"
         audit: "/bin/ps -fC $kubeletbin "
         tests:
           test_items:
@@ -311,12 +324,13 @@ groups:
           Based on your system, restart the kubelet service. For example,
           systemctl daemon-reload
           systemctl restart kubelet.service
+          Not applicable: Clusters provisioned by RKE set the --hostname-override to avoid any hostname configuration errors
         scored: false
 
       - id: 4.2.8
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --event-qps
@@ -340,8 +354,9 @@ groups:
 
       - id: 4.2.9
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
+        type: "skip"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --tls-cert-file
@@ -360,12 +375,13 @@ groups:
           Based on your system, restart the kubelet service. For example,
           systemctl daemon-reload
           systemctl restart kubelet.service
+          Permissive - When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
         scored: false
 
       - id: 4.2.10
         text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --rotate-certificates
@@ -389,10 +405,11 @@ groups:
           systemctl restart kubelet.service
         scored: true
 
-      - id: 4.2.11
+      - id: 4.2.12
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
+        type: "skip"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           bin_op: or
           test_items:
@@ -411,23 +428,20 @@ groups:
           Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
+          Not applicable: Clusters provisioned by RKE handles certificate rotation directly through RKE.
         scored: false
 
       - id: 4.2.12
-        text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
+        text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
-          bin_op: or
           test_items:
-            - flag: RotateKubeletServerCertificate
-              path: '{.featureGates.RotateKubeletServerCertificate}'
+            - flag: --tls-cipher-suites
+              path: '{range .tlsCipherSuites[:]}{}{'',''}{end}'
               compare:
-                op: nothave
-                value: false
-            - flag: RotateKubeletServerCertificate
-              path: '{.featureGates.RotateKubeletServerCertificate}'
-              set: false
+                op: valid_elements
+                value: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
         remediation: |
           If using a Kubelet config file, edit the file to set `TLSCipherSuites` to
           TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
@@ -439,12 +453,12 @@ groups:
           Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
-        scored: false
+        scored: true
 
       - id: 4.2.13
         text: "Ensure that a limit is set on pod PIDs (Manual)"
         audit: "/bin/ps -fC $kubeletbin"
-        audit_config: "/bin/cat $kubeletconf"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --pod-max-pids

--- a/package/cfg/rke-cis-1.7-permissive/node.yaml
+++ b/package/cfg/rke-cis-1.7-permissive/node.yaml
@@ -324,7 +324,7 @@ groups:
           Based on your system, restart the kubelet service. For example,
           systemctl daemon-reload
           systemctl restart kubelet.service
-          Not applicable: Clusters provisioned by RKE set the --hostname-override to avoid any hostname configuration errors
+          Not Applicable - Clusters provisioned by RKE set the --hostname-override to avoid any hostname configuration errors
         scored: false
 
       - id: 4.2.8
@@ -428,7 +428,7 @@ groups:
           Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
-          Not applicable: Clusters provisioned by RKE handles certificate rotation directly through RKE.
+          Not Applicable - Clusters provisioned by RKE handles certificate rotation directly through RKE.
         scored: false
 
       - id: 4.2.12

--- a/package/cfg/rke-cis-1.7-permissive/node.yaml
+++ b/package/cfg/rke-cis-1.7-permissive/node.yaml
@@ -1,0 +1,455 @@
+---
+controls:
+version: "1.7"
+id: 4
+text: "Worker Node Security Configuration"
+type: "node"
+groups:
+  - id: 4.1
+    text: "Worker Node Configuration Files"
+    checks:
+      - id: 4.1.1
+        text: "Ensure that the kubelet service file permissions are set to 600 or more restrictive (Automated)"
+        audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c permissions=%a $kubeletsvc; fi'' '
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example, chmod 600 $kubeletsvc
+        scored: true
+
+      - id: 4.1.2
+        text: "Ensure that the kubelet service file ownership is set to root:root (Automated)"
+        audit: '/bin/sh -c ''if test -e $kubeletsvc; then stat -c %U:%G $kubeletsvc; fi'' '
+        tests:
+          test_items:
+            - flag: root:root
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chown root:root $kubeletsvc
+        scored: true
+
+      - id: 4.1.3
+        text: "If proxy kubeconfig file exists ensure permissions are set to 600 or more restrictive (Manual)"
+        audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c permissions=%a $proxykubeconfig; fi'' '
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "permissions"
+              set: true
+              compare:
+                op: bitmask
+                value: "600"
+            - flag: "$proxykubeconfig"
+              set: false
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chmod 600 $proxykubeconfig
+        scored: false
+
+      - id: 4.1.4
+        text: "If proxy kubeconfig file exists ensure ownership is set to root:root (Manual)"
+        audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c %U:%G $proxykubeconfig; fi'' '
+        tests:
+          bin_op: or
+          test_items:
+            - flag: root:root
+            - flag: "$proxykubeconfig"
+              set: false
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example, chown root:root $proxykubeconfig
+        scored: false
+
+      - id: 4.1.5
+        text: "Ensure that the --kubeconfig kubelet.conf file permissions are set to 600 or more restrictive (Automated)"
+        audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c permissions=%a $kubeletkubeconfig; fi'' '
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chmod 600 $kubeletkubeconfig
+        scored: true
+
+      - id: 4.1.6
+        text: "Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root (Automated)"
+        audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c %U:%G $kubeletkubeconfig; fi'' '
+        tests:
+          test_items:
+            - flag: root:root
+        remediation: |
+          Run the below command (based on the file location on your system) on the each worker node.
+          For example,
+          chown root:root $kubeletkubeconfig
+        scored: true
+
+      - id: 4.1.7
+        text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Manual)"
+        audit: "check_cafile_permissions.sh"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the following command to modify the file permissions of the
+          --client-ca-file chmod 600 <filename>
+        scored: false
+
+      - id: 4.1.8
+        text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
+        audit: "check_cafile_ownership.sh"
+        tests:
+          test_items:
+            - flag: root:root
+              compare:
+                op: eq
+                value: root:root
+        remediation: |
+          Run the following command to modify the ownership of the --client-ca-file.
+          chown root:root <filename>
+        scored: false
+
+      - id: 4.1.9
+        text: "If the kubelet config.yaml configuration file is being used validate permissions set to 600 or more restrictive (Manual)"
+        audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c permissions=%a $kubeletconf; fi'' '
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the following command (using the config file location identified in the Audit step)
+          chmod 600 $kubeletconf
+        scored: false
+
+      - id: 4.1.10
+        text: "If the kubelet config.yaml configuration file is being used validate file ownership is set to root:root (Manual)"
+        audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c %U:%G $kubeletconf; fi'' '
+        tests:
+          test_items:
+            - flag: root:root
+        remediation: |
+          Run the following command (using the config file location identified in the Audit step)
+          chown root:root $kubeletconf
+        scored: false
+
+  - id: 4.2
+    text: "Kubelet"
+    checks:
+      - id: 4.2.1
+        text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: "--anonymous-auth"
+              path: '{.authentication.anonymous.enabled}'
+              compare:
+                op: eq
+                value: false
+        remediation: |
+          If using a Kubelet config file, edit the file to set `authentication: anonymous: enabled` to
+          `false`.
+          If using executable arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          `--anonymous-auth=false`
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.2
+        text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --authorization-mode
+              path: '{.authorization.mode}'
+              compare:
+                op: nothave
+                value: AlwaysAllow
+        remediation: |
+          If using a Kubelet config file, edit the file to set `authorization.mode` to Webhook. If
+          using executable arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_AUTHZ_ARGS variable.
+          --authorization-mode=Webhook
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.3
+        text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --client-ca-file
+              path: '{.authentication.x509.clientCAFile}'
+        remediation: |
+          If using a Kubelet config file, edit the file to set `authentication.x509.clientCAFile` to
+          the location of the client CA file.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_AUTHZ_ARGS variable.
+          --client-ca-file=<path/to/client-ca-file>
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.4
+        text: "Verify that the --read-only-port argument is set to 0 (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: "--read-only-port"
+              path: '{.readOnlyPort}'
+              compare:
+                op: eq
+                value: 0
+            - flag: "--read-only-port"
+              path: '{.readOnlyPort}'
+              set: false
+        remediation: |
+          If using a Kubelet config file, edit the file to set `readOnlyPort` to 0.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          --read-only-port=0
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.5
+        text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --streaming-connection-idle-timeout
+              path: '{.streamingConnectionIdleTimeout}'
+              compare:
+                op: noteq
+                value: 0
+            - flag: --streaming-connection-idle-timeout
+              path: '{.streamingConnectionIdleTimeout}'
+              set: false
+          bin_op: or
+        remediation: |
+          If using a Kubelet config file, edit the file to set `streamingConnectionIdleTimeout` to a
+          value other than 0.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          --streaming-connection-idle-timeout=5m
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.6
+        text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --make-iptables-util-chains
+              path: '{.makeIPTablesUtilChains}'
+              compare:
+                op: eq
+                value: true
+            - flag: --make-iptables-util-chains
+              path: '{.makeIPTablesUtilChains}'
+              set: false
+          bin_op: or
+        remediation: |
+          If using a Kubelet config file, edit the file to set `makeIPTablesUtilChains` to `true`.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          remove the --make-iptables-util-chains argument from the
+          KUBELET_SYSTEM_PODS_ARGS variable.
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.7
+        text: "Ensure that the --hostname-override argument is not set (Manual)"
+        # This is one of those properties that can only be set as a command line argument.
+        # To check if the property is set as expected, we need to parse the kubelet command
+        # instead reading the Kubelet Configuration file.
+        audit: "/bin/ps -fC $kubeletbin "
+        tests:
+          test_items:
+            - flag: --hostname-override
+              set: false
+        remediation: |
+          Edit the kubelet service file $kubeletsvc
+          on each worker node and remove the --hostname-override argument from the
+          KUBELET_SYSTEM_PODS_ARGS variable.
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.8
+        text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --event-qps
+              path: '{.eventRecordQPS}'
+              compare:
+                op: gte
+                value: 0
+            - flag: --event-qps
+              path: '{.eventRecordQPS}'
+              set: false
+          bin_op: or
+        remediation: |
+          If using a Kubelet config file, edit the file to set `eventRecordQPS` to an appropriate level.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.9
+        text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --tls-cert-file
+              path: '{.tlsCertFile}'
+            - flag: --tls-private-key-file
+              path: '{.tlsPrivateKeyFile}'
+        remediation: |
+          If using a Kubelet config file, edit the file to set `tlsCertFile` to the location
+          of the certificate file to use to identify this Kubelet, and `tlsPrivateKeyFile`
+          to the location of the corresponding private key file.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the below parameters in KUBELET_CERTIFICATE_ARGS variable.
+          --tls-cert-file=<path/to/tls-certificate-file>
+          --tls-private-key-file=<path/to/tls-key-file>
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.10
+        text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --rotate-certificates
+              path: '{.rotateCertificates}'
+              compare:
+                op: eq
+                value: true
+            - flag: --rotate-certificates
+              path: '{.rotateCertificates}'
+              set: false
+          bin_op: or
+        remediation: |
+          If using a Kubelet config file, edit the file to add the line `rotateCertificates` to `true` or
+          remove it altogether to use the default value.
+          If using command line arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          remove --rotate-certificates=false argument from the KUBELET_CERTIFICATE_ARGS
+          variable.
+          Based on your system, restart the kubelet service. For example,
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: true
+
+      - id: 4.2.11
+        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: RotateKubeletServerCertificate
+              path: '{.featureGates.RotateKubeletServerCertificate}'
+              compare:
+                op: nothave
+                value: false
+            - flag: RotateKubeletServerCertificate
+              path: '{.featureGates.RotateKubeletServerCertificate}'
+              set: false
+        remediation: |
+          Edit the kubelet service file $kubeletsvc
+          on each worker node and set the below parameter in KUBELET_CERTIFICATE_ARGS variable.
+          --feature-gates=RotateKubeletServerCertificate=true
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.12
+        text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          bin_op: or
+          test_items:
+            - flag: RotateKubeletServerCertificate
+              path: '{.featureGates.RotateKubeletServerCertificate}'
+              compare:
+                op: nothave
+                value: false
+            - flag: RotateKubeletServerCertificate
+              path: '{.featureGates.RotateKubeletServerCertificate}'
+              set: false
+        remediation: |
+          If using a Kubelet config file, edit the file to set `TLSCipherSuites` to
+          TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+          or to a subset of these values.
+          If using executable arguments, edit the kubelet service file
+          $kubeletsvc on each worker node and
+          set the --tls-cipher-suites parameter as follows, or to a subset of these values.
+          --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+          Based on your system, restart the kubelet service. For example:
+          systemctl daemon-reload
+          systemctl restart kubelet.service
+        scored: false
+
+      - id: 4.2.13
+        text: "Ensure that a limit is set on pod PIDs (Manual)"
+        audit: "/bin/ps -fC $kubeletbin"
+        audit_config: "/bin/cat $kubeletconf"
+        tests:
+          test_items:
+            - flag: --pod-max-pids
+              path: '{.podPidsLimit}'
+        remediation: |
+          Decide on an appropriate level for this parameter and set it,
+          either via the --pod-max-pids command line parameter or the PodPidsLimit configuration file setting.
+        scored: false

--- a/package/cfg/rke-cis-1.7-permissive/policies.yaml
+++ b/package/cfg/rke-cis-1.7-permissive/policies.yaml
@@ -1,0 +1,304 @@
+---
+controls:
+version: "1.7"
+id: 5
+text: "Kubernetes Policies"
+type: "policies"
+groups:
+  - id: 5.1
+    text: "RBAC and Service Accounts"
+    checks:
+      - id: 5.1.1
+        text: "Ensure that the cluster-admin role is only used where required (Manual)"
+        type: "manual"
+        remediation: |
+          Identify all clusterrolebindings to the cluster-admin role. Check if they are used and
+          if they need this role or if they could use a role with fewer privileges.
+          Where possible, first bind users to a lower privileged role and then remove the
+          clusterrolebinding to the cluster-admin role :
+          kubectl delete clusterrolebinding [name]
+        scored: false
+
+      - id: 5.1.2
+        text: "Minimize access to secrets (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove get, list and watch access to Secret objects in the cluster.
+        scored: false
+
+      - id: 5.1.3
+        text: "Minimize wildcard use in Roles and ClusterRoles (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible replace any use of wildcards in clusterroles and roles with specific
+          objects or actions.
+        scored: false
+
+      - id: 5.1.4
+        text: "Minimize access to create pods (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove create access to pod objects in the cluster.
+        scored: false
+
+      - id: 5.1.5
+        text: "Ensure that default service accounts are not actively used. (Manual)"
+        type: "manual"
+        remediation: |
+          Create explicit service accounts wherever a Kubernetes workload requires specific access
+          to the Kubernetes API server.
+          Modify the configuration of each default service account to include this value
+          automountServiceAccountToken: false
+        scored: false
+
+      - id: 5.1.6
+        text: "Ensure that Service Account Tokens are only mounted where necessary (Manual)"
+        type: "manual"
+        remediation: |
+          Modify the definition of pods and service accounts which do not need to mount service
+          account tokens to disable it.
+        scored: false
+
+      - id: 5.1.7
+        text: "Avoid use of system:masters group (Manual)"
+        type: "manual"
+        remediation: |
+          Remove the system:masters group from all users in the cluster.
+        scored: false
+
+      - id: 5.1.8
+        text: "Limit use of the Bind, Impersonate and Escalate permissions in the Kubernetes cluster (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove the impersonate, bind and escalate rights from subjects.
+        scored: false
+
+      - id: 5.1.9
+        text: "Minimize access to create persistent volumes (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove create access to PersistentVolume objects in the cluster.
+        scored: false
+
+      - id: 5.1.10
+        text: "Minimize access to the proxy sub-resource of nodes (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove access to the proxy sub-resource of node objects.
+        scored: false
+
+      - id: 5.1.11
+        text: "Minimize access to the approval sub-resource of certificatesigningrequests objects (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove access to the approval sub-resource of certificatesigningrequest objects.
+        scored: false
+
+      - id: 5.1.12
+        text: "Minimize access to webhook configuration objects (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove access to the validatingwebhookconfigurations or mutatingwebhookconfigurations objects
+        scored: false
+
+      - id: 5.1.13
+        text: "Minimize access to the service account token creation (Manual)"
+        type: "manual"
+        remediation: |
+          Where possible, remove access to the token sub-resource of serviceaccount objects.
+        scored: false
+
+  - id: 5.2
+    text: "Pod Security Standards"
+    checks:
+      - id: 5.2.1
+        text: "Ensure that the cluster has at least one active policy control mechanism in place (Manual)"
+        type: "manual"
+        remediation: |
+          Ensure that either Pod Security Admission or an external policy control system is in place
+          for every namespace which contains user workloads.
+        scored: false
+
+      - id: 5.2.2
+        text: "Minimize the admission of privileged containers (Manual)"
+        type: "manual"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of privileged containers.
+        scored: false
+
+      - id: 5.2.3
+        text: "Minimize the admission of containers wishing to share the host process ID namespace (Automated)"
+        type: "manual"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of `hostPID` containers.
+        scored: false
+
+      - id: 5.2.4
+        text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
+        type: "manual"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of `hostIPC` containers.
+        scored: false
+
+      - id: 5.2.5
+        text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
+        type: "manual"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of `hostNetwork` containers.
+        scored: false
+
+      - id: 5.2.6
+        text: "Minimize the admission of containers with allowPrivilegeEscalation (Automated)"
+        type: "manual"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of containers with `.spec.allowPrivilegeEscalation` set to `true`.
+        scored: false
+
+      - id: 5.2.7
+        text: "Minimize the admission of root containers (Automated)"
+        type: "manual"
+        remediation: |
+          Create a policy for each namespace in the cluster, ensuring that either `MustRunAsNonRoot`
+          or `MustRunAs` with the range of UIDs not including 0, is set.
+        scored: false
+
+      - id: 5.2.8
+        text: "Minimize the admission of containers with the NET_RAW capability (Automated)"
+        type: "manual"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of containers with the `NET_RAW` capability.
+        scored: false
+
+      - id: 5.2.9
+        text: "Minimize the admission of containers with added capabilities (Automated)"
+        type: "manual"
+        remediation: |
+          Ensure that `allowedCapabilities` is not present in policies for the cluster unless
+          it is set to an empty array.
+        scored: false
+
+      - id: 5.2.10
+        text: "Minimize the admission of containers with capabilities assigned (Manual)"
+        type: "manual"
+        remediation: |
+          Review the use of capabilites in applications running on your cluster. Where a namespace
+          contains applicaions which do not require any Linux capabities to operate consider adding
+          a PSP which forbids the admission of containers which do not drop all capabilities.
+        scored: false
+
+      - id: 5.2.11
+        text: "Minimize the admission of Windows HostProcess containers (Manual)"
+        type: "manual"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of containers that have `.securityContext.windowsOptions.hostProcess` set to `true`.
+        scored: false
+
+      - id: 5.2.12
+        text: "Minimize the admission of HostPath volumes (Manual)"
+        type: "manual"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of containers with `hostPath` volumes.
+        scored: false
+
+      - id: 5.2.13
+        text: "Minimize the admission of containers which use HostPorts (Manual)"
+        type: "manual"
+        remediation: |
+          Add policies to each namespace in the cluster which has user workloads to restrict the
+          admission of containers which use `hostPort` sections.
+        scored: false
+
+  - id: 5.3
+    text: "Network Policies and CNI"
+    checks:
+      - id: 5.3.1
+        text: "Ensure that the CNI in use supports NetworkPolicies (Manual)"
+        type: "manual"
+        remediation: |
+          If the CNI plugin in use does not support network policies, consideration should be given to
+          making use of a different plugin, or finding an alternate mechanism for restricting traffic
+          in the Kubernetes cluster.
+        scored: false
+
+      - id: 5.3.2
+        text: "Ensure that all Namespaces have NetworkPolicies defined (Manual)"
+        type: "manual"
+        remediation: |
+          Follow the documentation and create NetworkPolicy objects as you need them.
+        scored: false
+
+  - id: 5.4
+    text: "Secrets Management"
+    checks:
+      - id: 5.4.1
+        text: "Prefer using Secrets as files over Secrets as environment variables (Manual)"
+        type: "manual"
+        remediation: |
+          If possible, rewrite application code to read Secrets from mounted secret files, rather than
+          from environment variables.
+        scored: false
+
+      - id: 5.4.2
+        text: "Consider external secret storage (Manual)"
+        type: "manual"
+        remediation: |
+          Refer to the Secrets management options offered by your cloud provider or a third-party
+          secrets management solution.
+        scored: false
+
+  - id: 5.5
+    text: "Extensible Admission Control"
+    checks:
+      - id: 5.5.1
+        text: "Configure Image Provenance using ImagePolicyWebhook admission controller (Manual)"
+        type: "manual"
+        remediation: |
+          Follow the Kubernetes documentation and setup image provenance.
+        scored: false
+
+  - id: 5.7
+    text: "General Policies"
+    checks:
+      - id: 5.7.1
+        text: "Create administrative boundaries between resources using namespaces (Manual)"
+        type: "manual"
+        remediation: |
+          Follow the documentation and create namespaces for objects in your deployment as you need
+          them.
+        scored: false
+
+      - id: 5.7.2
+        text: "Ensure that the seccomp profile is set to docker/default in your Pod definitions (Manual)"
+        type: "manual"
+        remediation: |
+          Use `securityContext` to enable the docker/default seccomp profile in your pod definitions.
+          An example is as below:
+            securityContext:
+              seccompProfile:
+                type: RuntimeDefault
+        scored: false
+
+      - id: 5.7.3
+        text: "Apply SecurityContext to your Pods and Containers (Manual)"
+        type: "manual"
+        remediation: |
+          Follow the Kubernetes documentation and apply SecurityContexts to your Pods. For a
+          suggested list of SecurityContexts, you may refer to the CIS Security Benchmark for Docker
+          Containers.
+        scored: false
+
+      - id: 5.7.4
+        text: "The default namespace should not be used (Manual)"
+        type: "manual"
+        remediation: |
+          Ensure that namespaces are created to allow for appropriate segregation of Kubernetes
+          resources and that all new resources are created in a specific namespace.
+        scored: false

--- a/package/cfg/rke-cis-1.7-permissive/policies.yaml
+++ b/package/cfg/rke-cis-1.7-permissive/policies.yaml
@@ -160,7 +160,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostNetwork` containers.
-	  Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
+          Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
         scored: false
 
       - id: 5.2.6

--- a/package/cfg/rke-cis-1.7-permissive/policies.yaml
+++ b/package/cfg/rke-cis-1.7-permissive/policies.yaml
@@ -57,7 +57,7 @@ groups:
           to the Kubernetes API server.
           Modify the configuration of each default service account to include this value
           automountServiceAccountToken: false
-          Permissive: Kubernetes provides default service accounts to be used.
+          Permissive - Kubernetes provides default service accounts to be used.
         scored: false
 
       - id: 5.1.6
@@ -142,7 +142,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostPID` containers.
-          Permissive: Enabling Pod Security Policy can cause applications to unexpectedly fail.
+          Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
         scored: false
 
       - id: 5.2.4
@@ -151,7 +151,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostIPC` containers.
-          Permissive: Enabling Pod Security Policy can cause applications to unexpectedly fail.
+          Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
         scored: false
 
       - id: 5.2.5
@@ -160,7 +160,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostNetwork` containers.
-	  Permissive: Enabling Pod Security Policy can cause applications to unexpectedly fail.
+	  Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
         scored: false
 
       - id: 5.2.6
@@ -245,7 +245,7 @@ groups:
         type: "skip"
         remediation: |
           Follow the documentation and create NetworkPolicy objects as you need them.
-          Permissive: Enabling Network Policies can prevent certain applications from communicating with each other.
+          Permissive - Enabling Network Policies can prevent certain applications from communicating with each other.
         scored: false
 
   - id: 5.4
@@ -314,4 +314,5 @@ groups:
         remediation: |
           Ensure that namespaces are created to allow for appropriate segregation of Kubernetes
           resources and that all new resources are created in a specific namespace.
+          Permissive - Kubernetes provides a default namespace.
         scored: false

--- a/package/cfg/rke-cis-1.7-permissive/policies.yaml
+++ b/package/cfg/rke-cis-1.7-permissive/policies.yaml
@@ -1,6 +1,6 @@
 ---
 controls:
-version: "1.7"
+version: "cis-1.7"
 id: 5
 text: "Kubernetes Policies"
 type: "policies"
@@ -43,12 +43,21 @@ groups:
 
       - id: 5.1.5
         text: "Ensure that default service accounts are not actively used. (Manual)"
-        type: "manual"
+        type: "skip"
+        audit: check_for_default_sa.sh
+        tests:
+          test_items:
+            - flag: "true"
+              compare:
+                op: eq
+                value: "true"
+              set: true
         remediation: |
           Create explicit service accounts wherever a Kubernetes workload requires specific access
           to the Kubernetes API server.
           Modify the configuration of each default service account to include this value
           automountServiceAccountToken: false
+          Permissive: Kubernetes provides default service accounts to be used.
         scored: false
 
       - id: 5.1.6
@@ -129,30 +138,33 @@ groups:
 
       - id: 5.2.3
         text: "Minimize the admission of containers wishing to share the host process ID namespace (Automated)"
-        type: "manual"
+        type: "skip"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostPID` containers.
+          Permissive: Enabling Pod Security Policy can cause applications to unexpectedly fail.
         scored: false
 
       - id: 5.2.4
         text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
-        type: "manual"
+        type: "skip"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostIPC` containers.
+          Permissive: Enabling Pod Security Policy can cause applications to unexpectedly fail.
         scored: false
 
       - id: 5.2.5
         text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
-        type: "manual"
+        type: "skip"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostNetwork` containers.
+	  Permissive: Enabling Pod Security Policy can cause applications to unexpectedly fail.
         scored: false
 
       - id: 5.2.6
-        text: "Minimize the admission of containers with allowPrivilegeEscalation (Automated)"
+        text: "Minimize the admission of containers with allowPrivilegeEscalation (Manual)"
         type: "manual"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
@@ -160,7 +172,7 @@ groups:
         scored: false
 
       - id: 5.2.7
-        text: "Minimize the admission of root containers (Automated)"
+        text: "Minimize the admission of root containers (Manual)"
         type: "manual"
         remediation: |
           Create a policy for each namespace in the cluster, ensuring that either `MustRunAsNonRoot`
@@ -168,7 +180,7 @@ groups:
         scored: false
 
       - id: 5.2.8
-        text: "Minimize the admission of containers with the NET_RAW capability (Automated)"
+        text: "Minimize the admission of containers with the NET_RAW capability (Manual)"
         type: "manual"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
@@ -176,7 +188,7 @@ groups:
         scored: false
 
       - id: 5.2.9
-        text: "Minimize the admission of containers with added capabilities (Automated)"
+        text: "Minimize the admission of containers with added capabilities (Manual)"
         type: "manual"
         remediation: |
           Ensure that `allowedCapabilities` is not present in policies for the cluster unless
@@ -230,9 +242,10 @@ groups:
 
       - id: 5.3.2
         text: "Ensure that all Namespaces have NetworkPolicies defined (Manual)"
-        type: "manual"
+        type: "skip"
         remediation: |
           Follow the documentation and create NetworkPolicy objects as you need them.
+          Permissive: Enabling Network Policies can prevent certain applications from communicating with each other.
         scored: false
 
   - id: 5.4
@@ -297,7 +310,7 @@ groups:
 
       - id: 5.7.4
         text: "The default namespace should not be used (Manual)"
-        type: "manual"
+        type: "skip"
         remediation: |
           Ensure that namespaces are created to allow for appropriate segregation of Kubernetes
           resources and that all new resources are created in a specific namespace.


### PR DESCRIPTION
### Details

Distribution: `RKE`
Kubernetes version: `1.25.x`
CIS version: [1.7](https://workbench.cisecurity.org/benchmarks/11107)
kube-bench profile: [cis-1.7](https://github.com/aquasecurity/kube-bench/tree/main/cfg/cis-1.7)
Profiles created: `rke-cis-1.7-permissive` and `rke-cis-1.7-hardened`

### Main `test`  additions/removals in CIS-1.7

#### config.yaml: 

- None

#### etcd.yaml: 

- None

#### controlplane.yaml:

- Added `3.1.2 - "Service account token authentication should not be used for users (Manual)"`
- Added `3.1.3 - "Bootstrap token authentication should not be used for users (Manual)"`

#### master.yaml:

- Removed `1.2.4 - "Ensure that the --kubelet-https argument is set to true (Automated)"`, replaced by `"Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"`
- All the other check have been kept but their number has been decremented by 1 from `1.2.4`. 
   - `1.2.6 "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"` becomes `1.2.5 "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"`, up to `1.2.31 "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Manual)"`

#### node.yaml:

- Removed `4.2.6 "Ensure that the --protect-kernel-defaults argument is set to true (Automated)" `, replaced by `4.2.6 ""Ensure that the --make-iptables-util-chains argument is set to true (Automated)"`
-  All the other check have been kept but their number has been decremented by 1 from `4.2.6`
   - `4.2.8 "Ensure that the --hostname-override argument is not set (Manual)"` becomes `4.2.7 ""Ensure that the --hostname-override argument is not set (Manual)"`, up to `4.2.12 ""Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Automated)"`
- Added `4.2.13 "Ensure that a limit is set on pod PIDs (Manual)"


#### policies.yaml:

- Added `5.1.9 "Minimize access to create persistent volumes (Manual)"`
- Added `5.1.10 "Minimize access to the proxy sub-resource of nodes (Manual)"`
- Added `5.1.11 "Minimize access to the approval sub-resource of certificatesigningrequests objects (Manual)"`
- Added `5.1.12 "Minimize access to webhook configuration objects (Manual)"`
- Added `5.1.13 "Minimize access to the service account token creation (Manual)"`

### Additional improvements 
Based on [skipped-and-notapplicable-tests ](https://ranchermanager.docs.rancher.com/v2.7/integrations-in-rancher/cis-scans/skipped-and-not-applicable-tests):
- Add missing skips for permissive checks.
- Add `Not Applicable `and/or `Permissive` in the remediation descriptions.

### Permissive tests

```
➜  rke-cis-1.7-permissive git:(rke1-cis-1.7) grep -ri  'id:\|text\|Permissive'  | grep Permissive -B2
./policies.yaml:      - id: 5.1.5
./policies.yaml:        text: "Ensure that default service accounts are not actively used. (Manual)"
./policies.yaml:          Permissive - Kubernetes provides default service accounts to be used.
--
./policies.yaml:      - id: 5.2.3
./policies.yaml:        text: "Minimize the admission of containers wishing to share the host process ID namespace (Automated)"
./policies.yaml:          Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
./policies.yaml:      - id: 5.2.4
./policies.yaml:        text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
./policies.yaml:          Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
./policies.yaml:      - id: 5.2.5
./policies.yaml:        text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
./policies.yaml:	  Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
--
./policies.yaml:      - id: 5.3.2
./policies.yaml:        text: "Ensure that all Namespaces have NetworkPolicies defined (Manual)"
./policies.yaml:          Permissive - Enabling Network Policies can prevent certain applications from communicating with each other.
--
./policies.yaml:      - id: 5.7.4
./policies.yaml:        text: "The default namespace should not be used (Manual)"
./policies.yaml:          Permissive - Kubernetes provides a default namespace.
--
./etcd.yaml:      - id: 1.1.12
./etcd.yaml:        text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
./etcd.yaml:          Permissive - A system service account is required for etcd data directory ownership.
--
./node.yaml:      - id: 4.2.9
./node.yaml:        text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
./node.yaml:          Permissive - When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
--
./master.yaml:      - id: 1.2.5
./master.yaml:        text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
./master.yaml:          Permissive - When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
--
./master.yaml:          SecurityContextDeny, unless PodSecurityPolicy is already in place.
./master.yaml:          --enable-admission-plugins=...,SecurityContextDeny,...
./master.yaml:	  Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
--
./master.yaml:      - id: 1.2.29
./master.yaml:        text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
./master.yaml:	  Permissive - Enabling encryption changes how data can be recovered as data is encrypted.
./master.yaml:      - id: 1.2.30
./master.yaml:        text: "Ensure that encryption providers are appropriately configured (Manual)"
./master.yaml:	  Permissive - Enabling encryption changes how data can be recovered as data is encrypted.
```

