### PR TITLE
CIS-1.7 (1.25) - Add rke1/rke2/k3s ConfigMap

### DIFF
--- a/package/cfg/config.yaml
+++ b/package/cfg/config.yaml
@@ -201,39 +201,38 @@ managedservices:
 
 # TODO: Clean up in the next refactor
 version_mapping:
-  "rke-1.13": 
-    - "rke-cis-1.4"
-  "rke-1.14": 
-    - "rke-cis-1.4"
-  "rke-1.15": 
-    - "rke-cis-1.5-permissive"
-  "rke-1.16": 
-    - "rke-cis-1.6-permissive"
-  "rke-1.17": 
-    - "rke-cis-1.6-permissive"
-  "rke-1.18": 
-    - "rke-cis-1.6-permissive"
-  "rke-1.19": 
-    - "rke-cis-1.20-permissive"
-  "rke-1.20": 
-    - "rke-cis-1.20-permissive"
-  "v1.18.10+rke2r1": 
-    - "rke2-cis-1.5-hardened"
-    - "rke2-cis-1.5-permissive"
-  "eks-1.0.1": 
-    - "eks-1.0.1"
-  "gke-1.0": 
-    - "gke-1.0"
-  "aks-1.0": 
-    - "aks-1.0"	
-  "v1.20.5+rke2r1": 
-    - "rke2-cis-1.6-hardened"
-    - "rke2-cis-1.6-permissive"
-  "v1.20.5+k3s1": 
-    - "k3s-cis-1.6-hardened"
-    - "k3s-cis-1.6-permissive"
+  "rke-1.13": "rke-cis-1.4"
+  "rke-1.14": "rke-cis-1.4"
+  "rke-1.15": "rke-cis-1.5-permissive"
+  "rke-1.16": "rke-cis-1.6-permissive"
+  "rke-1.17": "rke-cis-1.6-permissive"
+  "rke-1.18": "rke-cis-1.6-permissive"
+  "rke-1.19": "rke-cis-1.20-permissive"
+  "rke-1.20": "rke-cis-1.20-permissive"
+  "v1.18.10+rke2r1": "rke2-cis-1.5-hardened"
+  "v1.18.10+rke2r1": "rke2-cis-1.5-permissive"
+  "eks-1.0.1": "eks-1.0.1"
+  "gke-1.0": "gke-1.0"
+  "aks-1.0": "aks-1.0"	
+  "v1.20.5+rke2r1": "rke2-cis-1.6-hardened"
+  "v1.20.5+rke2r1": "rke2-cis-1.6-permissive"
+  "v1.20.5+k3s1": "k3s-cis-1.6-hardened"
+  "v1.20.5+k3s1": "k3s-cis-1.6-permissive"
 
 target_mapping:
+# EKS
+  "eks-1.0.1":
+    - "node"
+# GKE
+  "gke-1.0":
+    - "node"
+    - "managedservices"
+    - "policies"
+# AKS
+  "aks-1.0":	
+    - "node"
+
+# CIS - Generic profiles
   "cis-1.4":
     - "master"
     - "node"
@@ -261,54 +260,28 @@ target_mapping:
     - "node"
     - "controlplane"
     - "etcd"
-    - "policies"     
+    - "policies"    
+  "cis-1.24":
+    - "master"
+    - "node"
+    - "controlplane"
+    - "etcd"
+    - "policies"  
+
+# RKE1
+# rke1: Generic
   "rke-cis-1.4":
     - "master"
     - "node"
     - "etcd"
-  "rke-cis-1.5-hardened":
-    - "master"
-    - "node"
-    - "controlplane"
-    - "etcd"
-    - "policies"
-  "rke2-cis-1.5-hardened":
-    - "master"
-    - "node"
-    - "controlplane"
-    - "etcd"
-    - "policies"
-  "rke-cis-1.6-hardened":
-    - "master"
-    - "node"
-    - "controlplane"
-    - "etcd"
-    - "policies"
-  "rke-cis-1.20-hardened":
-    - "master"
-    - "node"
-    - "controlplane"
-    - "etcd"
-    - "policies"
-  "rke-cis-1.23-hardened":
-    - "master"
-    - "node"
-    - "controlplane"
-    - "etcd"
-    - "policies"    
+# rke1: Permissive
   "rke-cis-1.5-permissive":
     - "master"
     - "node"
     - "controlplane"
     - "etcd"
     - "policies"
-  "rke2-cis-1.5-permissive":
-    - "master"
-    - "node"
-    - "controlplane"
-    - "etcd"
-    - "policies"
-  "rke-cis-1.6-permissive":
+    "rke-cis-1.6-permissive":
     - "master"
     - "node"
     - "controlplane"
@@ -325,16 +298,49 @@ target_mapping:
     - "node"
     - "controlplane"
     - "etcd"
-    - "policies"  
-  "eks-1.0.1":
-    - "node"
-  "gke-1.0":
-    - "node"
-    - "managedservices"
     - "policies"
-  "aks-1.0":	
+  "rke-cis-1.24-permissive":
+    - "master"
     - "node"
-  "rke2-cis-1.6-hardened":
+    - "controlplane"
+    - "etcd"
+    - "policies"
+# rke1 : Hardened
+    "rke-cis-1.5-hardened":
+    - "master"
+    - "node"
+    - "controlplane"
+    - "etcd"
+    - "policies"
+    "rke-cis-1.6-hardened":
+    - "master"
+    - "node"
+    - "controlplane"
+    - "etcd"
+    - "policies"
+  "rke-cis-1.20-hardened":
+    - "master"
+    - "node"
+    - "controlplane"
+    - "etcd"
+    - "policies"
+  "rke-cis-1.23-hardened":
+    - "master"
+    - "node"
+    - "controlplane"
+    - "etcd"
+    - "policies"
+  "rke-cis-1.24-hardened":
+    - "master"
+    - "node"
+    - "controlplane"
+    - "etcd"
+    - "policies"
+
+# RKE2
+# rke2: Generic
+# rke2: Permissive
+  "rke2-cis-1.5-permissive":
     - "master"
     - "node"
     - "controlplane"
@@ -346,13 +352,38 @@ target_mapping:
     - "controlplane"
     - "etcd"
     - "policies"
-  "rke2-cis-1.20-hardened":
+  "rke2-cis-1.20-permissive":
     - "master"
     - "node"
     - "controlplane"
     - "etcd"
     - "policies"
-  "rke2-cis-1.20-permissive":
+  "rke2-cis-1.23-permissive":
+    - "master"
+    - "node"
+    - "controlplane"
+    - "etcd"
+    - "policies"
+  "rke2-cis-1.24-permissive":
+    - "master"
+    - "node"
+    - "controlplane"
+    - "etcd"
+    - "policies" 
+# rke2: Hardened
+  "rke2-cis-1.5-hardened":
+    - "master"
+    - "node"
+    - "controlplane"
+    - "etcd"
+    - "policies"
+  "rke2-cis-1.6-hardened":
+    - "master"
+    - "node"
+    - "controlplane"
+    - "etcd"
+    - "policies"
+  "rke2-cis-1.20-hardened":
     - "master"
     - "node"
     - "controlplane"
@@ -364,19 +395,42 @@ target_mapping:
     - "controlplane"
     - "etcd"
     - "policies"
-  "rke2-cis-1.23-permissive":
-    - "master"
-    - "node"
-    - "controlplane"
-    - "etcd"
-    - "policies"        
-  "k3s-cis-1.6-hardened":
+  "rke2-cis-1.24-hardened":
     - "master"
     - "node"
     - "controlplane"
     - "etcd"
     - "policies"
+
+# K3S
+# k3s: Generic
+# k3s: Permissive
   "k3s-cis-1.6-permissive":
+    - "master"
+    - "node"
+    - "controlplane"
+    - "etcd"
+    - "policies"
+  "k3s-cis-1.20-permissive":
+    - "master"
+    - "node"
+    - "controlplane"
+    - "etcd"
+    - "policies" 
+  "k3s-cis-1.23-permissive":
+    - "master"
+    - "node"
+    - "controlplane"
+    - "etcd"
+    - "policies"
+  "k3s-cis-1.24-permissive":
+    - "master"
+    - "node"
+    - "controlplane"
+    - "etcd"
+    - "policies"
+  # k3s: Hardened
+  "k3s-cis-1.6-hardened":
     - "master"
     - "node"
     - "controlplane"
@@ -394,15 +448,25 @@ target_mapping:
     - "controlplane"
     - "etcd"
     - "policies"
-  "k3s-cis-1.20-permissive":
+  "k3s-cis-1.24-hardened":
     - "master"
     - "node"
     - "controlplane"
     - "etcd"
-    - "policies"   
-  "k3s-cis-1.23-permissive":
-    - "master"
-    - "node"
-    - "controlplane"
-    - "etcd"
-    - "policies"    
+    - "policies"
+
+
+
+
+
+
+
+  
+
+
+
+
+  
+
+
+

--- a/package/cfg/config.yaml
+++ b/package/cfg/config.yaml
@@ -200,52 +200,52 @@ managedservices:
 
 # TODO: Clean up in the next refactor
 version_mapping:
-  "rke-1.13": 
+  "rke-1.13":
     - "rke-cis-1.4"
-  "rke-1.14": 
+  "rke-1.14":
     - "rke-cis-1.4"
-  "rke-1.15": 
+  "rke-1.15":
     - "rke-cis-1.5-permissive"
-  "rke-1.16": 
+  "rke-1.16":
     - "rke-cis-1.6-permissive"
-  "rke-1.17": 
+  "rke-1.17":
     - "rke-cis-1.6-permissive"
-  "rke-1.18": 
+  "rke-1.18":
     - "rke-cis-1.6-permissive"
-  "rke-1.19": 
+  "rke-1.19":
     - "rke-cis-1.20-permissive"
-  "rke-1.20": 
+  "rke-1.20":
     - "rke-cis-1.20-permissive"
-  "v1.18.10+rke2r1": 
+  "v1.18.10+rke2r1":
     - "rke2-cis-1.5-hardened"
     - "rke2-cis-1.5-permissive"
-  "eks-1.0.1": 
+  "eks-1.0.1":
     - "eks-1.0.1"
-  "gke-1.2.0": 
+  "gke-1.2.0":
     - "gke-1.2.0"
-  "aks-1.0": 
-    - "aks-1.0"	
-  "v1.20.5+rke2r1": 
+  "aks-1.0":
+    - "aks-1.0"
+  "v1.20.5+rke2r1":
     - "rke2-cis-1.6-hardened"
     - "rke2-cis-1.6-permissive"
-  "v1.20.5+k3s1": 
+  "v1.20.5+k3s1":
     - "k3s-cis-1.6-hardened"
     - "k3s-cis-1.6-permissive"
 
 target_mapping:
-# EKS
+  # EKS
   "eks-1.0.1":
     - "node"
-# GKE
+  # GKE
   "gke-1.2.0":
     - "node"
     - "managedservices"
     - "policies"
-# AKS
-  "aks-1.0":	
+  # AKS
+  "aks-1.0":
     - "node"
 
-# CIS - Generic profiles
+  # CIS - Generic profiles
   "cis-1.4":
     - "master"
     - "node"
@@ -273,27 +273,27 @@ target_mapping:
     - "node"
     - "controlplane"
     - "etcd"
-    - "policies"    
+    - "policies"
   "cis-1.24":
     - "master"
     - "node"
     - "controlplane"
     - "etcd"
-    - "policies"  
+    - "policies"
   "cis-1.7":
     - "master"
     - "node"
     - "controlplane"
     - "etcd"
-    - "policies" 
+    - "policies"
 
-# RKE1
-# rke1: Generic
+  # RKE1
+  # rke1: Generic
   "rke-cis-1.4":
     - "master"
     - "node"
     - "etcd"
-# rke1: Permissive
+  # rke1: Permissive
   "rke-cis-1.5-permissive":
     - "master"
     - "node"
@@ -311,7 +311,7 @@ target_mapping:
     - "node"
     - "controlplane"
     - "etcd"
-    - "policies"  
+    - "policies"
   "rke-cis-1.23-permissive":
     - "master"
     - "node"
@@ -324,14 +324,14 @@ target_mapping:
     - "controlplane"
     - "etcd"
     - "policies"
-    "rke-cis-1.7-permissive":
+  "rke-cis-1.7-permissive":
     - "master"
     - "node"
     - "controlplane"
     - "etcd"
     - "policies"
-# rke1 : Hardened
-    "rke-cis-1.5-hardened":
+  # rke1 : Hardened
+  "rke-cis-1.5-hardened":
     - "master"
     - "node"
     - "controlplane"
@@ -368,9 +368,9 @@ target_mapping:
     - "etcd"
     - "policies"
 
-# RKE2
-# rke2: Generic
-# rke2: Permissive
+  # RKE2
+  # rke2: Generic
+  # rke2: Permissive
   "rke2-cis-1.5-permissive":
     - "master"
     - "node"
@@ -400,14 +400,14 @@ target_mapping:
     - "node"
     - "controlplane"
     - "etcd"
-    - "policies" 
+    - "policies"
   "rke2-cis-1.7-permissive":
     - "master"
     - "node"
     - "controlplane"
     - "etcd"
     - "policies"
-# rke2: Hardened
+  # rke2: Hardened
   "rke2-cis-1.5-hardened":
     - "master"
     - "node"
@@ -445,9 +445,9 @@ target_mapping:
     - "etcd"
     - "policies"
 
-# K3S
-# k3s: Generic
-# k3s: Permissive
+  # K3S
+  # k3s: Generic
+  # k3s: Permissive
   "k3s-cis-1.6-permissive":
     - "master"
     - "node"
@@ -459,7 +459,7 @@ target_mapping:
     - "node"
     - "controlplane"
     - "etcd"
-    - "policies" 
+    - "policies"
   "k3s-cis-1.23-permissive":
     - "master"
     - "node"

--- a/package/cfg/config.yaml
+++ b/package/cfg/config.yaml
@@ -200,25 +200,6 @@ managedservices:
 
 # TODO: Clean up in the next refactor
 version_mapping:
-<<<<<<< HEAD
-  "rke-1.13": "rke-cis-1.4"
-  "rke-1.14": "rke-cis-1.4"
-  "rke-1.15": "rke-cis-1.5-permissive"
-  "rke-1.16": "rke-cis-1.6-permissive"
-  "rke-1.17": "rke-cis-1.6-permissive"
-  "rke-1.18": "rke-cis-1.6-permissive"
-  "rke-1.19": "rke-cis-1.20-permissive"
-  "rke-1.20": "rke-cis-1.20-permissive"
-  "v1.18.10+rke2r1": "rke2-cis-1.5-hardened"
-  "v1.18.10+rke2r1": "rke2-cis-1.5-permissive"
-  "eks-1.0.1": "eks-1.0.1"
-  "gke-1.0": "gke-1.0"
-  "aks-1.0": "aks-1.0"	
-  "v1.20.5+rke2r1": "rke2-cis-1.6-hardened"
-  "v1.20.5+rke2r1": "rke2-cis-1.6-permissive"
-  "v1.20.5+k3s1": "k3s-cis-1.6-hardened"
-  "v1.20.5+k3s1": "k3s-cis-1.6-permissive"
-=======
   "rke-1.13": 
     - "rke-cis-1.4"
   "rke-1.14": 
@@ -250,14 +231,13 @@ version_mapping:
   "v1.20.5+k3s1": 
     - "k3s-cis-1.6-hardened"
     - "k3s-cis-1.6-permissive"
->>>>>>> master
 
 target_mapping:
 # EKS
   "eks-1.0.1":
     - "node"
 # GKE
-  "gke-1.0":
+  "gke-1.2.0":
     - "node"
     - "managedservices"
     - "policies"
@@ -299,7 +279,6 @@ target_mapping:
     - "node"
     - "controlplane"
     - "etcd"
-<<<<<<< HEAD
     - "policies"  
   "cis-1.7":
     - "master"
@@ -310,53 +289,11 @@ target_mapping:
 
 # RKE1
 # rke1: Generic
-=======
-    - "policies" 
->>>>>>> master
   "rke-cis-1.4":
     - "master"
     - "node"
     - "etcd"
-<<<<<<< HEAD
 # rke1: Permissive
-=======
-  "rke-cis-1.5-hardened":
-    - "master"
-    - "node"
-    - "controlplane"
-    - "etcd"
-    - "policies"
-  "rke2-cis-1.5-hardened":
-    - "master"
-    - "node"
-    - "controlplane"
-    - "etcd"
-    - "policies"
-  "rke-cis-1.6-hardened":
-    - "master"
-    - "node"
-    - "controlplane"
-    - "etcd"
-    - "policies"
-  "rke-cis-1.20-hardened":
-    - "master"
-    - "node"
-    - "controlplane"
-    - "etcd"
-    - "policies"
-  "rke-cis-1.23-hardened":
-    - "master"
-    - "node"
-    - "controlplane"
-    - "etcd"
-    - "policies"
-  "rke-cis-1.24-hardened":
-    - "master"
-    - "node"
-    - "controlplane"
-    - "etcd"
-    - "policies"
->>>>>>> master
   "rke-cis-1.5-permissive":
     - "master"
     - "node"
@@ -380,21 +317,6 @@ target_mapping:
     - "node"
     - "controlplane"
     - "etcd"
-<<<<<<< HEAD
-=======
-    - "policies"
-  "rke-cis-1.24-permissive":
-    - "master"
-    - "node"
-    - "controlplane"
-    - "etcd"
-    - "policies"
-  "eks-1.0.1":
-    - "node"
-  "gke-1.2.0":
-    - "node"
-    - "managedservices"
->>>>>>> master
     - "policies"
   "rke-cis-1.24-permissive":
     - "master"
@@ -510,29 +432,7 @@ target_mapping:
     - "controlplane"
     - "etcd"
     - "policies"
-<<<<<<< HEAD
   "rke2-cis-1.24-hardened":
-=======
-  "rke2-cis-1.23-permissive":
-    - "master"
-    - "node"
-    - "controlplane"
-    - "etcd"
-    - "policies"
-  "rke2-cis-1.24-hardened":
-    - "master"
-    - "node"
-    - "controlplane"
-    - "etcd"
-    - "policies"
-  "rke2-cis-1.24-permissive":
-    - "master"
-    - "node"
-    - "controlplane"
-    - "etcd"
-    - "policies"   
-  "k3s-cis-1.6-hardened":
->>>>>>> master
     - "master"
     - "node"
     - "controlplane"
@@ -609,34 +509,3 @@ target_mapping:
     - "controlplane"
     - "etcd"
     - "policies"
-<<<<<<< HEAD
-
-
-
-
-
-
-
-  
-
-
-
-
-  
-
-
-
-=======
-  "k3s-cis-1.24-hardened":
-    - "master"
-    - "node"
-    - "controlplane"
-    - "etcd"
-    - "policies"
-  "k3s-cis-1.24-permissive":
-    - "master"
-    - "node"
-    - "controlplane"
-    - "etcd"
-    - "policies"
->>>>>>> master

--- a/package/cfg/config.yaml
+++ b/package/cfg/config.yaml
@@ -337,7 +337,7 @@ target_mapping:
     - "controlplane"
     - "etcd"
     - "policies"
-    "rke-cis-1.6-hardened":
+  "rke-cis-1.6-hardened":
     - "master"
     - "node"
     - "controlplane"

--- a/package/cfg/config.yaml
+++ b/package/cfg/config.yaml
@@ -300,7 +300,7 @@ target_mapping:
     - "controlplane"
     - "etcd"
     - "policies"
-    "rke-cis-1.6-permissive":
+  "rke-cis-1.6-permissive":
     - "master"
     - "node"
     - "controlplane"

--- a/package/cfg/config.yaml
+++ b/package/cfg/config.yaml
@@ -267,6 +267,12 @@ target_mapping:
     - "controlplane"
     - "etcd"
     - "policies"  
+  "cis-1.7":
+    - "master"
+    - "node"
+    - "controlplane"
+    - "etcd"
+    - "policies" 
 
 # RKE1
 # rke1: Generic
@@ -305,6 +311,12 @@ target_mapping:
     - "controlplane"
     - "etcd"
     - "policies"
+    "rke-cis-1.7-permissive":
+    - "master"
+    - "node"
+    - "controlplane"
+    - "etcd"
+    - "policies"
 # rke1 : Hardened
     "rke-cis-1.5-hardened":
     - "master"
@@ -331,6 +343,12 @@ target_mapping:
     - "etcd"
     - "policies"
   "rke-cis-1.24-hardened":
+    - "master"
+    - "node"
+    - "controlplane"
+    - "etcd"
+    - "policies"
+  "rke-cis-1.7-hardened":
     - "master"
     - "node"
     - "controlplane"
@@ -370,6 +388,12 @@ target_mapping:
     - "controlplane"
     - "etcd"
     - "policies" 
+  "rke2-cis-1.7-permissive":
+    - "master"
+    - "node"
+    - "controlplane"
+    - "etcd"
+    - "policies"
 # rke2: Hardened
   "rke2-cis-1.5-hardened":
     - "master"
@@ -396,6 +420,12 @@ target_mapping:
     - "etcd"
     - "policies"
   "rke2-cis-1.24-hardened":
+    - "master"
+    - "node"
+    - "controlplane"
+    - "etcd"
+    - "policies"
+  "rke2-cis-1.7-hardened":
     - "master"
     - "node"
     - "controlplane"
@@ -429,6 +459,12 @@ target_mapping:
     - "controlplane"
     - "etcd"
     - "policies"
+  "k3s-cis-1.7-permissive":
+    - "master"
+    - "node"
+    - "controlplane"
+    - "etcd"
+    - "policies"
   # k3s: Hardened
   "k3s-cis-1.6-hardened":
     - "master"
@@ -449,6 +485,12 @@ target_mapping:
     - "etcd"
     - "policies"
   "k3s-cis-1.24-hardened":
+    - "master"
+    - "node"
+    - "controlplane"
+    - "etcd"
+    - "policies"
+  "k3s-cis-1.7-hardened":
     - "master"
     - "node"
     - "controlplane"


### PR DESCRIPTION
This PR covers the following: 

1. Reorganization of the `target_mapping` for all cis versions (with generic, permissive and hardened) to add clarity.

Excerpt:
```
# RKE1
# rke1: Generic
  "rke-cis-1.4":
    - "master"
    - "node"
    - "etcd"
# rke1: Permissive
  "rke-cis-1.5-permissive":
    - "master"
    - "node"
    - "controlplane"
    - "etcd"
    - "policies"
    ...
# rke1: Hardened
  "rke-cis-1.5-hardened":
    - "master"
    - "node"
    - "controlplane"
    - "etcd"
    - "policies"
    ...
```

2. Addition of `CIS-1.7` profiles in `target_mapping` for `rke`, `rke2` and `k3s`.