### PR TITLE
Bump BCI version to 15.5

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-base:15.4
+FROM registry.suse.com/bci/bci-base:15.5
 
 ARG kube_bench_version=0.6.12
 ARG sonobuoy_version=0.56.16


### PR DESCRIPTION
Bump BCI version to 15.5 before 15.4 goes EOL by the end of the year.