### PR TITLE
Use Drone's plugin for GitHub releases

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -17,15 +17,13 @@ steps:
     path: /var/run/docker.sock
 
 - name: github_binary_release
-  image: ibuildthecloud/github-release:v0.0.1
+  image: plugins/github-release
   settings:
     api_key:
       from_secret: github_token
     prerelease: true
     checksum:
     - sha256
-    checksum_file: CHECKSUMsum-amd64.txt
-    checksum_flatten: true
     files:
     - "dist/artifacts/*"
   when:
@@ -80,15 +78,13 @@ steps:
     path: /var/run/docker.sock
 
 - name: github_binary_release
-  image: ibuildthecloud/github-release:v0.0.1
+  image: plugins/github-release
   settings:
     api_key:
       from_secret: github_token
     prerelease: true
     checksum:
     - sha256
-    checksum_file: CHECKSUMsum-arm64.txt
-    checksum_flatten: true
     files:
     - "dist/artifacts/*"
   when:


### PR DESCRIPTION
Use Drone's plugin for GitHub releases instead of a non-official image, which is tied to a user's DockerHub repo.

Note: I can't test if the entire config is right. This is only possible when we cut the next -rc.