### PR TITLE
Simplify the release pipeline

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -16,25 +16,6 @@ steps:
   - name: docker
     path: /var/run/docker.sock
 
-- name: github_binary_release
-  image: plugins/github-release
-  settings:
-    api_key:
-      from_secret: github_token
-    prerelease: true
-    checksum:
-    - sha256
-    files:
-    - "dist/artifacts/*"
-  when:
-    instance:
-    - drone-publish.rancher.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
-    event:
-    - tag
-
 - name: docker-publish
   image: plugins/docker
   settings:
@@ -76,25 +57,6 @@ steps:
   volumes:
   - name: docker
     path: /var/run/docker.sock
-
-- name: github_binary_release
-  image: plugins/github-release
-  settings:
-    api_key:
-      from_secret: github_token
-    prerelease: true
-    checksum:
-    - sha256
-    files:
-    - "dist/artifacts/*"
-  when:
-    instance:
-    - drone-publish.rancher.io
-    ref:
-    - refs/head/master
-    - refs/tags/*
-    event:
-    - tag
 
 - name: docker-publish
   image: plugins/docker


### PR DESCRIPTION
Simplify the release pipeline by removing the `github_binary_release` Drone step. This error was made clear after PR https://github.com/rancher/security-scan/pull/142 and the failed `tag` pipeline https://drone-publish.rancher.io/rancher/security-scan/199/1/3.

It was working before, but we never actually published an artifact for `security-scan`. All the released versions contain only the repo source code as assets. See example in https://github.com/rancher/security-scan/releases/tag/v0.2.5.