### PR TITLE
Fix rke-cis-1.7 permissive/hardened node.yaml 4.2.11

### DIFF
--- a/package/cfg/rke-cis-1.7-hardened/node.yaml
+++ b/package/cfg/rke-cis-1.7-hardened/node.yaml
@@ -403,7 +403,7 @@ groups:
           systemctl restart kubelet.service
         scored: true
 
-      - id: 4.2.12
+      - id: 4.2.11
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
         type: "skip"
         audit: "/bin/ps -fC $kubeletbin"

--- a/package/cfg/rke-cis-1.7-permissive/node.yaml
+++ b/package/cfg/rke-cis-1.7-permissive/node.yaml
@@ -405,7 +405,7 @@ groups:
           systemctl restart kubelet.service
         scored: true
 
-      - id: 4.2.12
+      - id: 4.2.11
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
         type: "skip"
         audit: "/bin/ps -fC $kubeletbin"


### PR DESCRIPTION
Related issue: https://github.com/rancher/rancher/issues/42125

In node.yaml for both `rke-cis-1.7-permissive` and `rke-cis-1.7-hardened`, 4.2.12 was used twice.

Here are the expected/fixed check ids (`4.2.11` was `4.2.12` before this fix):

> - id: 4.2.11
>         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
>         
> - id: 4.2.12
>         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"

Here is the link to kube-bench CIS-1.7 node.yaml [4.2.11](https://github.com/aquasecurity/kube-bench/blob/40cdc1bfbb1bbc84ef4d54bd1226b73d8f327af3/cfg/cis-1.7/node.yaml#L398C3-L398C3) and [4.2.12](https://github.com/aquasecurity/kube-bench/blob/40cdc1bfbb1bbc84ef4d54bd1226b73d8f327af3/cfg/cis-1.7/node.yaml#L422) .

This problem is not present in `K3s` and `rke2` profiles.