### PR TITLE
Fix k3s-cis-1.7 permissive node.yaml 4.2.6 --make-iptables-util-chains

### DIFF
--- a/package/cfg/k3s-cis-1.7-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/node.yaml
@@ -276,6 +276,7 @@ groups:
 
       - id: 4.2.6
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
+        type: "skip"
         audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'make-iptables-util-chains'"
         tests:
           test_items:
@@ -297,6 +298,7 @@ groups:
           Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
+          Permissive.
         scored: true
 
       - id: 4.2.7


### PR DESCRIPTION
Related to this BUG: [[BUG] Test 4.2.6 in CIS scan fails on K3S cluster](https://github.com/rancher/rancher/issues/42138).
The `type: skip` is now implemented in _k3s-cis-1.7-permissive_ for `4.2.6 --make-iptables-util-chains` to match with the previous k3s-cis-permissive profiles (1.5-1.24).