### PR TITLE
Fix regression: missing upstream tests

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -20,7 +20,7 @@ steps:
   image: plugins/docker
   settings:
     build_args:
-    - ARCH=arm64
+    - ARCH=amd64
     dockerfile: package/Dockerfile
     password:
       from_secret: docker_password

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -21,8 +21,9 @@ RUN curl -sLf "https://github.com/vmware-tanzu/sonobuoy/releases/download/v${son
 RUN curl -sLf "https://github.com/aquasecurity/kube-bench/releases/download/v${kube_bench_version}/kube-bench_${kube_bench_version}_linux_${ARCH}.tar.gz" | tar -xvzf - -C /usr/bin
 
 # Copy the files within /cfg straight from the immutable GitHub source to /etc/kube-bench/cfg/.
-RUN curl -sLf "https://github.com/aquasecurity/kube-bench/archive/refs/tags/v${kube_bench_version}.tar.gz" | \
-    tar xvz -C . --strip-components=1 "kube-bench-${kube_bench_version}/cfg"
+RUN mkdir -p /etc/kube-bench/ && \
+    curl -sLf "https://github.com/aquasecurity/kube-bench/archive/refs/tags/v${kube_bench_version}.tar.gz" | \
+    tar xvz -C /etc/kube-bench/ --strip-components=1 "kube-bench-${kube_bench_version}/cfg"
 
 COPY package/cfg/ /etc/kube-bench/cfg/
 COPY package/run.sh \

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eou pipefail
 
 export ARCH="${ARCH:-amd64}"
 export IMAGE=security-scan:e2e
@@ -11,7 +11,8 @@ KINDCONFIG="$(mktemp)"
 E2E_TIMEOUT_SECONDS=600
 
 function cleanup() {
-    rm -rf "${KINDCONFIG}" | true    
+  kind delete cluster --name "${CLUSTER_NAME}" | true
+  rm -rf "${KINDCONFIG}" | true
 }
 trap cleanup EXIT
 
@@ -67,6 +68,27 @@ echo "> Check binaries:"
 kubectl exec -n cis-operator-system security-scan-runner-scan-test -c rancher-cis-benchmark -- /usr/bin/sonobuoy
 kubectl exec -n cis-operator-system security-scan-runner-scan-test -c rancher-cis-benchmark -- /usr/bin/kube-bench version
 kubectl exec -n cis-operator-system security-scan-runner-scan-test -c rancher-cis-benchmark -- /usr/local/bin/kubectl version
+
+echo "> Check for upstream test files:"
+dirs="ack-1.0 aks-1.0 cis-1.20 cis-1.23 cis-1.24 cis-1.5 cis-1.6 cis-1.6-k3s config.yaml eks-1.0.1 eks-1.1.0 eks-stig-kubernetes-v1r6 gke-1.0 gke-1.2.0 rh-0.7 rh-1.0"
+
+for d in ${dirs}; do
+  if ! kubectl exec -n cis-operator-system security-scan-runner-scan-test -c rancher-cis-benchmark -- stat "/etc/kube-bench/cfg/$d"; then
+    echo "/etc/kube-bench/cfg/$d not found"
+    exit 1
+  fi
+done
+
+echo "> Check for our own test files:"
+dirs="$(ls package/cfg)"
+
+for d in ${dirs}; do
+  if ! kubectl exec -n cis-operator-system security-scan-runner-scan-test -c rancher-cis-benchmark -- stat "/etc/kube-bench/cfg/$d"; then
+    echo "/etc/kube-bench/cfg/$d not found"
+    exit 1
+  fi
+done
+
 kubectl exec -n cis-operator-system security-scan-runner-scan-test -c rancher-cis-benchmark -- run.sh &
 
 sleep 20 # Wait for the new daemonset to be created

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -63,6 +63,10 @@ echo "> Deploying test resources"
 envsubst < ./tests/deploy.yaml | kubectl apply -f -
 kubectl wait --for=condition=ready -n cis-operator-system pod security-scan-runner-scan-test --timeout=30s
 
+echo "> Check binaries:"
+kubectl exec -n cis-operator-system security-scan-runner-scan-test -c rancher-cis-benchmark -- /usr/bin/sonobuoy
+kubectl exec -n cis-operator-system security-scan-runner-scan-test -c rancher-cis-benchmark -- /usr/bin/kube-bench version
+kubectl exec -n cis-operator-system security-scan-runner-scan-test -c rancher-cis-benchmark -- /usr/local/bin/kubectl version
 kubectl exec -n cis-operator-system security-scan-runner-scan-test -c rancher-cis-benchmark -- run.sh &
 
 sleep 20 # Wait for the new daemonset to be created


### PR DESCRIPTION
- Fixes regression introduced by https://github.com/rancher/security-scan/commit/1836d3c10467dccffe9cd6f266d9722c5ce2cbff whereby the kube-bench cfg files were misplaced.
- Adds tests to avoid future regressions.