### PR TITLE
Fix rke2-cis-1.7 controlplane.yaml 3.2.1 --audit-policy-file

### DIFF
--- a/package/cfg/rke2-cis-1.7-hardened/controlplane.yaml
+++ b/package/cfg/rke2-cis-1.7-hardened/controlplane.yaml
@@ -35,13 +35,10 @@ groups:
     checks:
       - id: 3.2.1
         text: "Ensure that a minimal audit policy is created (Automated)"
-        audit: "/bin/ps -ef | grep kube-apiserver | grep -v grep | grep -o audit-policy-file"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
             - flag: "--audit-policy-file"
-              compare:
-                op: eq
-                value: "--audit-policy-file"
               set: true
         remediation: |
           Create an audit policy file for your cluster.

--- a/package/cfg/rke2-cis-1.7-permissive/controlplane.yaml
+++ b/package/cfg/rke2-cis-1.7-permissive/controlplane.yaml
@@ -36,13 +36,10 @@ groups:
       - id: 3.2.1
         text: "Ensure that a minimal audit policy is created (Automated)"
         type: "skip"
-        audit: "/bin/ps -ef | grep kube-apiserver | grep -v grep | grep -o audit-policy-file"
+        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
             - flag: "--audit-policy-file"
-              compare:
-                op: eq
-                value: "--audit-policy-file"
               set: true
         remediation: |
           Create an audit policy file for your cluster.


### PR DESCRIPTION
This fix is to resolve the following issue:

- https://github.com/rancher/rancher/issues/42171

Details:

The fix changes both `audit` and `test_items` to match [kube-bench 3.2.1](https://github.com/aquasecurity/kube-bench/blob/20ad80577ce99677607e668f32ef6aa723e50021/cfg/cis-1.7/controlplane.yaml#L36) defaults which is more generic and leverages the variable `$apiserverbin` instead of absolute path (previously used).

Confirmation tests done a `rke2 hardened cluster`: The test is expected to `PASS` in hardened.

![image](https://github.com/rancher/security-scan/assets/12878731/0ca43e36-77a5-4e75-87d4-94456f8e9b0d)



