### PR TITLE
Update GKE 1.2.0 target_mapping

### DIFF
--- a/package/cfg/config.yaml
+++ b/package/cfg/config.yaml
@@ -239,8 +239,6 @@ target_mapping:
   # GKE
   "gke-1.2.0":
     - "node"
-    - "managedservices"
-    - "policies"
   # AKS
   "aks-1.0":
     - "node"


### PR DESCRIPTION
GKE is managed K8s offering, so we don't need to scan etcd, master, controlplane etc components except node. 
Hence removing `policies` and `managedservices` from target mapping for GKE, as AKS and EKS are also following the same. 