### PR TITLE
Remove flag:proxykubeconfig from test_items in node.yaml for 4.1.3/4.1.4

### DIFF
--- a/package/cfg/cis-1.24/node.yaml
+++ b/package/cfg/cis-1.24/node.yaml
@@ -45,8 +45,6 @@ groups:
               compare:
                 op: bitmask
                 value: "600"
-            - flag: "$proxykubeconfig"
-              set: false
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
@@ -60,8 +58,6 @@ groups:
           bin_op: or
           test_items:
             - flag: root:root
-            - flag: "$proxykubeconfig"
-              set: false
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example, chown root:root $proxykubeconfig

--- a/package/cfg/cis-1.7/node.yaml
+++ b/package/cfg/cis-1.7/node.yaml
@@ -45,8 +45,6 @@ groups:
               compare:
                 op: bitmask
                 value: "600"
-            - flag: "$proxykubeconfig"
-              set: false
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
@@ -60,8 +58,6 @@ groups:
           bin_op: or
           test_items:
             - flag: root:root
-            - flag: "$proxykubeconfig"
-              set: false
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example, chown root:root $proxykubeconfig

--- a/package/cfg/k3s-cis-1.24-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/node.yaml
@@ -47,8 +47,6 @@ groups:
               compare:
                 op: bitmask
                 value: "600"
-            - flag: "$proxykubeconfig"
-              set: false
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
@@ -62,8 +60,6 @@ groups:
           bin_op: or
           test_items:
             - flag: root:root
-            - flag: "$proxykubeconfig"
-              set: false
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example, chown root:root $proxykubeconfig

--- a/package/cfg/k3s-cis-1.24-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/node.yaml
@@ -47,8 +47,6 @@ groups:
               compare:
                 op: bitmask
                 value: "600"
-            - flag: "$proxykubeconfig"
-              set: false
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
@@ -62,8 +60,6 @@ groups:
           bin_op: or
           test_items:
             - flag: root:root
-            - flag: "$proxykubeconfig"
-              set: false
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example, chown root:root $proxykubeconfig

--- a/package/cfg/k3s-cis-1.7-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/node.yaml
@@ -49,8 +49,6 @@ groups:
               compare:
                 op: bitmask
                 value: "600"
-            - flag: "$proxykubeconfig"
-              set: false
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
@@ -64,8 +62,6 @@ groups:
           bin_op: or
           test_items:
             - flag: root:root
-            - flag: "$proxykubeconfig"
-              set: false
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example, chown root:root $proxykubeconfig

--- a/package/cfg/k3s-cis-1.7-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/node.yaml
@@ -49,8 +49,6 @@ groups:
               compare:
                 op: bitmask
                 value: "600"
-            - flag: "$proxykubeconfig"
-              set: false
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
@@ -64,8 +62,6 @@ groups:
           bin_op: or
           test_items:
             - flag: root:root
-            - flag: "$proxykubeconfig"
-              set: false
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example, chown root:root $proxykubeconfig

--- a/package/cfg/rke-cis-1.24-hardened/node.yaml
+++ b/package/cfg/rke-cis-1.24-hardened/node.yaml
@@ -46,8 +46,6 @@ groups:
               compare:
                 op: bitmask
                 value: "644"
-            - flag: "$proxykubeconfig"
-              set: false
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
@@ -61,8 +59,6 @@ groups:
           bin_op: or
           test_items:
             - flag: root:root
-            - flag: "$proxykubeconfig"
-              set: false
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example, chown root:root $proxykubeconfig

--- a/package/cfg/rke-cis-1.24-permissive/node.yaml
+++ b/package/cfg/rke-cis-1.24-permissive/node.yaml
@@ -47,8 +47,6 @@ groups:
               compare:
                 op: bitmask
                 value: "600"
-            - flag: "$proxykubeconfig"
-              set: false
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
@@ -62,8 +60,6 @@ groups:
           bin_op: or
           test_items:
             - flag: root:root
-            - flag: "$proxykubeconfig"
-              set: false
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example, chown root:root $proxykubeconfig

--- a/package/cfg/rke-cis-1.7-hardened/node.yaml
+++ b/package/cfg/rke-cis-1.7-hardened/node.yaml
@@ -51,8 +51,6 @@ groups:
               compare:
                 op: bitmask
                 value: "600"
-            - flag: "$proxykubeconfig"
-              set: false
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
@@ -66,8 +64,6 @@ groups:
           bin_op: or
           test_items:
             - flag: root:root
-            - flag: "$proxykubeconfig"
-              set: false
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example, chown root:root $proxykubeconfig

--- a/package/cfg/rke-cis-1.7-permissive/node.yaml
+++ b/package/cfg/rke-cis-1.7-permissive/node.yaml
@@ -51,8 +51,6 @@ groups:
               compare:
                 op: bitmask
                 value: "600"
-            - flag: "$proxykubeconfig"
-              set: false
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
@@ -66,8 +64,6 @@ groups:
           bin_op: or
           test_items:
             - flag: root:root
-            - flag: "$proxykubeconfig"
-              set: false
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example, chown root:root $proxykubeconfig

--- a/package/cfg/rke2-cis-1.24-hardened/node.yaml
+++ b/package/cfg/rke2-cis-1.24-hardened/node.yaml
@@ -49,8 +49,6 @@ groups:
               compare:
                 op: bitmask
                 value: "600"
-            - flag: "$proxykubeconfig"
-              set: false
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
@@ -64,8 +62,6 @@ groups:
           bin_op: or
           test_items:
             - flag: root:root
-            - flag: "$proxykubeconfig"
-              set: false
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example, chown root:root $proxykubeconfig

--- a/package/cfg/rke2-cis-1.24-permissive/node.yaml
+++ b/package/cfg/rke2-cis-1.24-permissive/node.yaml
@@ -48,8 +48,6 @@ groups:
               compare:
                 op: bitmask
                 value: "600"
-            - flag: "$proxykubeconfig"
-              set: false
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
@@ -63,8 +61,6 @@ groups:
           bin_op: or
           test_items:
             - flag: root:root
-            - flag: "$proxykubeconfig"
-              set: false
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example, chown root:root $proxykubeconfig

--- a/package/cfg/rke2-cis-1.7-hardened/node.yaml
+++ b/package/cfg/rke2-cis-1.7-hardened/node.yaml
@@ -49,8 +49,6 @@ groups:
               compare:
                 op: bitmask
                 value: "600"
-            - flag: "$proxykubeconfig"
-              set: false
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
@@ -64,8 +62,6 @@ groups:
           bin_op: or
           test_items:
             - flag: root:root
-            - flag: "$proxykubeconfig"
-              set: false
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example, chown root:root $proxykubeconfig

--- a/package/cfg/rke2-cis-1.7-permissive/node.yaml
+++ b/package/cfg/rke2-cis-1.7-permissive/node.yaml
@@ -49,8 +49,6 @@ groups:
               compare:
                 op: bitmask
                 value: "600"
-            - flag: "$proxykubeconfig"
-              set: false
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
@@ -64,8 +62,6 @@ groups:
           bin_op: or
           test_items:
             - flag: root:root
-            - flag: "$proxykubeconfig"
-              set: false
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example, chown root:root $proxykubeconfig


### PR DESCRIPTION
This PR fixes this remaining for RKE2 [issue](https://github.com/rancher/rancher/issues/42385#issuecomment-1689006407). Covers all cis-1.24 and cis-1.7 profiles for now.
See details about the root cause and fix details, upstream.