### PR TITLE
Fix k3s cis 1.7  - node 1.1.10 1.1.19 & master 4.1.5

### DIFF
--- a/package/cfg/k3s-cis-1.7-hardened/config.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/config.yaml
@@ -4,6 +4,7 @@
 master:
   components:
     - apiserver
+    - kubelet
     - scheduler
     - controllermanager
     - etcd
@@ -12,6 +13,12 @@ master:
   apiserver:
     bins:
       - containerd
+
+  kubelet:
+    bins:
+      - containerd
+    defaultkubeconfig: /var/lib/rancher/k3s/agent/kubelet.kubeconfig
+    defaultcafile: /var/lib/rancher/k3s/agent/client-ca.crt
 
   scheduler:
     bins:
@@ -32,9 +39,7 @@ master:
 
     kubelet:
       bins:
-        - "containerd"
-        - "hyperkube kubelet"
-        - "kubelet"
+        - containerd
       defaultkubeconfig: /var/lib/rancher/k3s/agent/kubelet.kubeconfig
       defaultcafile: /var/lib/rancher/k3s/agent/client-ca.crt
 

--- a/package/cfg/k3s-cis-1.7-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/master.yaml
@@ -150,7 +150,7 @@ groups:
 
       - id: 1.1.10
         text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
-	type: skip
+        type: skip
         audit: |
           ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
           find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G

--- a/package/cfg/k3s-cis-1.7-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/master.yaml
@@ -150,6 +150,7 @@ groups:
 
       - id: 1.1.10
         text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
+	type: skip
         audit: |
           ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
           find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
@@ -161,6 +162,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chown root:root <path/to/cni/files>
+          Not Applicable.
         scored: false
 
       - id: 1.1.11
@@ -285,7 +287,7 @@ groups:
 
       - id: 1.1.19
         text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
-        audit: "check_files_owner_in_dir.sh /etc/kubernetes/pki/"
+        audit: "stat -c %U:%G /var/lib/rancher/k3s/server/tls"
         use_multiple_values: true
         tests:
           test_items:
@@ -293,7 +295,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
-          chown -R root:root /etc/kubernetes/pki/
+          chown -R root:root /var/lib/rancher/k3s/server/tls
         scored: true
 
       - id: 1.1.20

--- a/package/cfg/k3s-cis-1.7-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/node.yaml
@@ -73,7 +73,7 @@ groups:
 
       - id: 4.1.5
         text: "Ensure that the --kubeconfig kubelet.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: 'stat -c %a /var/lib/rancher/k3s/agent/kubelet.kubeconfig '
+        audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c permissions=%a $kubeletkubeconfig; fi'' '
         tests:
           test_items:
             - flag: "permissions"

--- a/package/cfg/k3s-cis-1.7-permissive/config.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/config.yaml
@@ -4,6 +4,7 @@
 master:
   components:
     - apiserver
+    - kubelet
     - scheduler
     - controllermanager
     - etcd
@@ -12,6 +13,12 @@ master:
   apiserver:
     bins:
       - containerd
+
+  kubelet:
+    bins:
+      - containerd
+    defaultkubeconfig: /var/lib/rancher/k3s/agent/kubelet.kubeconfig
+    defaultcafile: /var/lib/rancher/k3s/agent/client-ca.crt
 
   scheduler:
     bins:
@@ -32,9 +39,7 @@ master:
 
     kubelet:
       bins:
-        - "containerd"
-        - "hyperkube kubelet"
-        - "kubelet"
+        - containerd
       defaultkubeconfig: /var/lib/rancher/k3s/agent/kubelet.kubeconfig
       defaultcafile: /var/lib/rancher/k3s/agent/client-ca.crt
 

--- a/package/cfg/k3s-cis-1.7-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/master.yaml
@@ -150,6 +150,7 @@ groups:
 
       - id: 1.1.10
         text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
+        type: skip
         audit: |
           ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
           find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
@@ -161,6 +162,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chown root:root <path/to/cni/files>
+          Not Applicable.
         scored: false
 
       - id: 1.1.11
@@ -285,7 +287,7 @@ groups:
 
       - id: 1.1.19
         text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
-        audit: "check_files_owner_in_dir.sh /etc/kubernetes/pki/"
+        audit: "stat -c %U:%G /var/lib/rancher/k3s/server/tls"
         use_multiple_values: true
         tests:
           test_items:
@@ -293,7 +295,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
-          chown -R root:root /etc/kubernetes/pki/
+          chown -R root:root /var/lib/rancher/k3s/server/tls
         scored: true
 
       - id: 1.1.20

--- a/package/cfg/k3s-cis-1.7-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/node.yaml
@@ -73,7 +73,7 @@ groups:
 
       - id: 4.1.5
         text: "Ensure that the --kubeconfig kubelet.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: 'stat -c %a /var/lib/rancher/k3s/agent/kubelet.kubeconfig '
+        audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c permissions=%a $kubeletkubeconfig; fi'' '
         tests:
           test_items:
             - flag: "permissions"


### PR DESCRIPTION
This PR fixes this remaining for K3 [issue](https://github.com/rancher/rancher/issues/42384#issuecomment-1697608305) (for checks 1.1.10/1.1.19/4.1.5). Covers cis-1.7 profiles for now.