### PR TITLE
Fix rke cis 1.7 -  etcd node master config checks

### DIFF
--- a/package/cfg/rke-cis-1.7-hardened/config.yaml
+++ b/package/cfg/rke-cis-1.7-hardened/config.yaml
@@ -1,6 +1,19 @@
 ---
 ## Version-specific settings that override the values in cfg/config.yaml
 
+master:
+  components:
+    - apiserver
+    - kubelet
+    - scheduler
+    - controllermanager
+    - etcd
+    - policies
+
+  kubelet:
+    bins:
+      - kubelet
+
 node:
   kubelet:
     defaultkubeconfig: "/etc/kubernetes/ssl/kubecfg-kube-node.yaml"

--- a/package/cfg/rke-cis-1.7-hardened/config.yaml
+++ b/package/cfg/rke-cis-1.7-hardened/config.yaml
@@ -22,4 +22,4 @@ node:
       - kubelet
 
   proxy:
-    defaultkubeconfig: "/etc/kubernetes/ssl/kubecfg-kube-proxy.yaml"
+    defaultkubeconfig: "/node/etc/kubernetes/ssl/kubecfg-kube-proxy.yaml"

--- a/package/cfg/rke-cis-1.7-hardened/config.yaml
+++ b/package/cfg/rke-cis-1.7-hardened/config.yaml
@@ -19,9 +19,7 @@ node:
     defaultkubeconfig: "/etc/kubernetes/ssl/kubecfg-kube-node.yaml"
     defaultcafile: "/etc/kubernetes/ssl/kube-ca.pem"
     bins:
-      - "containerd"
-      - "hyperkube kubelet"
-      - "kubelet"
+      - kubelet
 
   proxy:
     defaultkubeconfig: "/etc/kubernetes/ssl/kubecfg-kube-proxy.yaml"

--- a/package/cfg/rke-cis-1.7-hardened/etcd.yaml
+++ b/package/cfg/rke-cis-1.7-hardened/etcd.yaml
@@ -57,7 +57,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"
-        audit: "find /node/etc/kubernetes/ssl/  -name '*.pem' ! -name '*key.pem' | xargs stat -c permissions=%a"
+        audit: "find /node/etc/kubernetes/ssl/ -name '*.pem' ! -name '*key.pem' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -68,12 +68,12 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
-          find /node/etc/kubernetes/ssl/  -name '*.pem' ! -name '*key.pem' -exec chmod -R 600 {} +
+          find /node/etc/kubernetes/ssl/ -name '*.pem' ! -name '*key.pem' -exec chmod -R 600 {} +
         scored: false
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "check_files_permissions.sh '/etc/kubernetes/pki/*.key' 600"
+        audit: "find /node/etc/kubernetes/ssl/ -name '*key.pem' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -84,7 +84,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
-          chmod -R 600 /etc/kubernetes/pki/*.key
+          find /node/etc/kubernetes/ssl/ -name '*key.pem' -exec chmod -R 600 {} +
         scored: false
 
   - id: 2

--- a/package/cfg/rke-cis-1.7-hardened/etcd.yaml
+++ b/package/cfg/rke-cis-1.7-hardened/etcd.yaml
@@ -56,19 +56,19 @@ groups:
         scored: true
 
       - id: 1.1.20
-        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Manual)"
-        audit: "check_files_permissions.sh '/etc/kubernetes/pki/*.crt'"
+        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"
+        audit: "find /node/etc/kubernetes/ssl/  -name '*.pem' ! -name '*key.pem' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
             - flag: "permissions"
               compare:
                 op: bitmask
-                value: "644"
+                value: "600"
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
-          chmod -R 644 /etc/kubernetes/pki/*.crt
+          find /node/etc/kubernetes/ssl/  -name '*.pem' ! -name '*key.pem' -exec chmod -R 600 {} +
         scored: false
 
       - id: 1.1.21

--- a/package/cfg/rke-cis-1.7-permissive/config.yaml
+++ b/package/cfg/rke-cis-1.7-permissive/config.yaml
@@ -1,6 +1,19 @@
 ---
 ## Version-specific settings that override the values in cfg/config.yaml
 
+master:
+  components:
+    - apiserver
+    - kubelet
+    - scheduler
+    - controllermanager
+    - etcd
+    - policies
+
+  kubelet:
+    bins:
+      - kubelet
+
 node:
   kubelet:
     defaultkubeconfig: "/etc/kubernetes/ssl/kubecfg-kube-node.yaml"

--- a/package/cfg/rke-cis-1.7-permissive/config.yaml
+++ b/package/cfg/rke-cis-1.7-permissive/config.yaml
@@ -22,4 +22,4 @@ node:
       - kubelet
 
   proxy:
-    defaultkubeconfig: "/etc/kubernetes/ssl/kubecfg-kube-proxy.yaml"
+    defaultkubeconfig: "/node/etc/kubernetes/ssl/kubecfg-kube-proxy.yaml"

--- a/package/cfg/rke-cis-1.7-permissive/config.yaml
+++ b/package/cfg/rke-cis-1.7-permissive/config.yaml
@@ -19,9 +19,7 @@ node:
     defaultkubeconfig: "/etc/kubernetes/ssl/kubecfg-kube-node.yaml"
     defaultcafile: "/etc/kubernetes/ssl/kube-ca.pem"
     bins:
-      - "containerd"
-      - "hyperkube kubelet"
-      - "kubelet"
+      - kubelet
 
   proxy:
     defaultkubeconfig: "/etc/kubernetes/ssl/kubecfg-kube-proxy.yaml"

--- a/package/cfg/rke-cis-1.7-permissive/etcd.yaml
+++ b/package/cfg/rke-cis-1.7-permissive/etcd.yaml
@@ -76,7 +76,7 @@ groups:
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "check_files_permissions.sh '/etc/kubernetes/pki/*.key' 600"
+        audit: "find /node/etc/kubernetes/ssl/ -name '*key.pem' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -87,7 +87,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
-          chmod -R 600 /etc/kubernetes/pki/*.key
+          find /node/etc/kubernetes/ssl/ -name '*key.pem' -exec chmod -R 600 {} +
         scored: false
 
   - id: 2

--- a/package/cfg/rke-cis-1.7-permissive/etcd.yaml
+++ b/package/cfg/rke-cis-1.7-permissive/etcd.yaml
@@ -59,19 +59,19 @@ groups:
         scored: true
 
       - id: 1.1.20
-        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Manual)"
-        audit: "check_files_permissions.sh '/etc/kubernetes/pki/*.crt'"
+        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"
+        audit: "find /node/etc/kubernetes/ssl/  -name '*.pem' ! -name '*key.pem' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
             - flag: "permissions"
               compare:
                 op: bitmask
-                value: "644"
+                value: "600"
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
-          chmod -R 644 /etc/kubernetes/pki/*.crt
+          find /node/etc/kubernetes/ssl/  -name '*.pem' ! -name '*key.pem' -exec chmod -R 600 {} +
         scored: false
 
       - id: 1.1.21


### PR DESCRIPTION
This PR fixes this remaining for [RKE](https://github.com/rancher/rancher/issues/42386) (for checks master 1.1.9/1.1.10, etcd 1.1.20/1.1.21 4, node 4.2.1-3,12). Covers cis-1.7 rke hardened/permissive profiles.

For checks `1.1.20` and `1.1.21`: I removed the use of `check_files_permissions.sh` to comply with Kube-bench's standards.