### PR TITLE
Improve RKE1 configmap for 1.24/1.7 

### DIFF
--- a/package/cfg/rke-cis-1.24-hardened/config.yaml
+++ b/package/cfg/rke-cis-1.24-hardened/config.yaml
@@ -1,10 +1,25 @@
 ---
 ## Version-specific settings that override the values in cfg/config.yaml
 
+master:
+  components:
+    - apiserver
+    - kubelet
+    - scheduler
+    - controllermanager
+    - etcd
+    - policies
+
+  kubelet:
+    bins:
+      - kubelet
+
 node:
   kubelet:
-    defaultkubeconfig: "/etc/kubernetes/ssl/kubecfg-kube-node.yaml"
-    defaultcafile: "/etc/kubernetes/ssl/kube-ca.pem"
+    defaultkubeconfig: "/node/etc/kubernetes/ssl/kubecfg-kube-node.yaml"
+    defaultcafile: "/node/etc/kubernetes/ssl/kube-ca.pem"
+    bins:
+      - kubelet
 
   proxy:
-    defaultkubeconfig: "/etc/kubernetes/ssl/kubecfg-kube-proxy.yaml"
+    defaultkubeconfig: "/node/etc/kubernetes/ssl/kubecfg-kube-proxy.yaml"

--- a/package/cfg/rke-cis-1.24-permissive/config.yaml
+++ b/package/cfg/rke-cis-1.24-permissive/config.yaml
@@ -1,10 +1,25 @@
 ---
 ## Version-specific settings that override the values in cfg/config.yaml
 
+master:
+  components:
+    - apiserver
+    - kubelet
+    - scheduler
+    - controllermanager
+    - etcd
+    - policies
+
+  kubelet:
+    bins:
+      - kubelet
+
 node:
   kubelet:
-    defaultkubeconfig: "/etc/kubernetes/ssl/kubecfg-kube-node.yaml"
-    defaultcafile: "/etc/kubernetes/ssl/kube-ca.pem"
+    defaultkubeconfig: "/node/etc/kubernetes/ssl/kubecfg-kube-node.yaml"
+    defaultcafile: "/node/etc/kubernetes/ssl/kube-ca.pem"
+    bins:
+      - kubelet
 
   proxy:
-    defaultkubeconfig: "/etc/kubernetes/ssl/kubecfg-kube-proxy.yaml"
+    defaultkubeconfig: "/node/etc/kubernetes/ssl/kubecfg-kube-proxy.yaml"

--- a/package/cfg/rke-cis-1.7-hardened/config.yaml
+++ b/package/cfg/rke-cis-1.7-hardened/config.yaml
@@ -16,8 +16,8 @@ master:
 
 node:
   kubelet:
-    defaultkubeconfig: "/etc/kubernetes/ssl/kubecfg-kube-node.yaml"
-    defaultcafile: "/etc/kubernetes/ssl/kube-ca.pem"
+    defaultkubeconfig: "/node/etc/kubernetes/ssl/kubecfg-kube-node.yaml"
+    defaultcafile: "/node/etc/kubernetes/ssl/kube-ca.pem"
     bins:
       - kubelet
 

--- a/package/cfg/rke-cis-1.7-permissive/config.yaml
+++ b/package/cfg/rke-cis-1.7-permissive/config.yaml
@@ -16,8 +16,8 @@ master:
 
 node:
   kubelet:
-    defaultkubeconfig: "/etc/kubernetes/ssl/kubecfg-kube-node.yaml"
-    defaultcafile: "/etc/kubernetes/ssl/kube-ca.pem"
+    defaultkubeconfig: "/node/etc/kubernetes/ssl/kubecfg-kube-node.yaml"
+    defaultcafile: "/node/etc/kubernetes/ssl/kube-ca.pem"
     bins:
       - kubelet
 


### PR DESCRIPTION
This PR improves the configmap (config.yaml), to fix the following issue in RKE cis-1.24 (checks `4.1.3/4.1.4` and `1.1.9/1.1.10`):
- https://github.com/rancher/rancher/issues/42655