### PR TITLE
Fix K3s node.yaml 4.1.7 permissive/hardened

### DIFF
--- a/package/cfg/k3s-cis-1.24-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/node.yaml
@@ -98,7 +98,7 @@ groups:
         scored: true
 
       - id: 4.1.7
-        text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Automated)"
+        text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Manual)"
         audit: "stat -c %a /var/lib/rancher/k3s/server/tls/server-ca.crt"
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.24-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/node.yaml
@@ -98,7 +98,7 @@ groups:
         scored: true
 
       - id: 4.1.7
-        text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Automated)"
+        text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Manual)"
         audit: "stat -c %a /var/lib/rancher/k3s/server/tls/server-ca.crt"
         tests:
           test_items:
@@ -110,7 +110,7 @@ groups:
         remediation: |
           Run the following command to modify the file permissions of the
           --client-ca-file chmod 600 <filename>
-        scored: true
+        scored: false
 
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"


### PR DESCRIPTION
Fixes node check `4.1.7` in CIS-1.24 permissive/hardened, Automated to Manual as per this [comment](https://github.com/k3s-io/k3s/issues/7975#issuecomment-1636484712).
Related issue: https://github.com/rancher/rancher/issues/42655