### PR TITLE
Add `systemd` to Dockerfile

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -7,6 +7,7 @@ ARG ARCH
 
 RUN zypper --non-interactive update \
     && zypper --non-interactive install \
+    systemd \
     curl \
     jq \
     tar \


### PR DESCRIPTION
This PR fixes the issue (`/usr/bin/run_sonobuoy_plugin.sh: line 67: journalctl: command not found`) when `run_sonobuoy_plugin.sh` is run on K3S, full log:

```
cluster-k3s-standalone-pool1-a2e28c00-2bxg7:/ # run_sonobuoy_plugin.sh
+ DEBUG_TIME_IN_SEC=300
+ test 0 '!=' 0
+ trap handle_error ERR
+ IS_RKE2=false
+ pgrep rke2
+ IS_K3S=false
+ pgrep k3s
2181
+ IS_K3S=true
+ set +x
+ RANCHER_K8S_VERSION=v1.25.12+k3s1
+ echo 'Rancher Kubernetes Version: v1.25.12+k3s1'
Rancher Kubernetes Version: v1.25.12+k3s1
+ TAR_FILE_NAME=kb
+ CONFIG_DIR=/etc/kube-bench/cfg
+ [[ /etc/kube-bench/cfg != \/\e\t\c\/\k\u\b\e\-\b\e\n\c\h\/\c\f\g ]]
+ RESULTS_DIR=/tmp/results
+ ERROR_LOG_FILE=/tmp/results/error.log
+ LOG_DIR=/tmp/results/logs
+ JOURNAL_LOG=/var/log/journal
++ journalctl -D /var/log/journal --lines=0
++ wc -l
++ grep -s 'No such file or directory'
+ [[ 0 -gt 0 ]]
+ mkdir -p /tmp/results
+ [[ k3s-cis-1.7-hardened != '' ]]
++ grep etcd
++ wc -l
++ ps -e
+ [[ 0 -gt 0 ]]
++ journalctl -D /var/log/journal -u k3s -u k3s-agent
/usr/bin/run_sonobuoy_plugin.sh: line 67: journalctl: command not found
++ grep -wv 'No entries'
++ grep -wv 'Logs begin'
++ wc -l
+ [[ 0 -gt 0 ]]
+ [[ k3s-cis-1.7-hardened != '' ]]
++ pgrep kube-apiserver
++ wc -l
+ [[ 0 -gt 0 ]]
++ wc -l
++ grep -v grep
++ grep 'Running kube-apiserver'
++ journalctl -D /var/log/journal -u k3s
/usr/bin/run_sonobuoy_plugin.sh: line 100: journalctl: command not found
+ [[ 0 -gt 0 ]]
+ kubeletconf=/node/var/lib/kubelet/config
+ [[ k3s-cis-1.7-hardened != '' ]]
++ wc -l
++ pgrep kubelet
+ [[ 0 -gt 0 ]]
++ grep 'Running kubelet'
++ journalctl -D /var/log/journal -u k3s
++ grep -v grep
/usr/bin/run_sonobuoy_plugin.sh: line 134: journalctl: command not found
++ wc -l
+ [[ 0 -gt 0 ]]
+ [[ k3s-cis-1.7-hardened != '' ]]
++ pgrep kube-apiserver
++ wc -l
+ [[ 0 -gt 0 ]]
++ journalctl -D /var/log/journal -u k3s
/usr/bin/run_sonobuoy_plugin.sh: line 172: journalctl: command not found
++ wc -l
++ grep -v grep
++ grep 'Running kube-apiserver'
+ [[ 0 -gt 0 ]]
+ cd /tmp/results
+ tar -czf kb.tar.gz '*'
tar: *: Cannot stat: No such file or directory
tar: Exiting with failure status due to previous errors
++ handle_error
++ [[ '' == \t\r\u\e ]]
++ echo -n /tmp/results/error.lo
```

Here is the issue from Rancher (all checks are marked as `Mixed`):

<img width="1433" alt="image" src="https://github.com/rancher/security-scan/assets/12878731/508086ce-ae7b-4695-954e-ea810fc708a9">



**Root cause: https://github.com/rancher/security-scan/pull/160/commits/1ef7ceb9e68830154d4e712c8ea88a93fc257521**