### PR TITLE
Add multistage and remove unused packages in Dockerfile

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,29 +1,47 @@
-FROM registry.suse.com/bci/bci-base:15.5
+# Temporary build stage
+FROM registry.suse.com/bci/bci-base:15.5 as builder
 
-ARG kube_bench_version=0.6.12
+# Define build arguments
+ARG kube_bench_version=0.6.17
 ARG sonobuoy_version=0.56.16
 ARG kubectl_version=1.28.0
 ARG ARCH
 
-RUN zypper --non-interactive update \
-    && zypper --non-interactive install \
-    systemd \
-    curl \
-    jq \
-    tar \
-    awk \
-    gzip
+# Install build dependencies
+RUN zypper --non-interactive update && zypper --non-interactive install jq awk tar
+
+# Install kubectl
 RUN curl -Lo ./kubectl "https://storage.googleapis.com/kubernetes-release/release/v${kubectl_version}/bin/linux/${ARCH}/kubectl" && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin/
+
+# Install Sonobuoy
 RUN curl -sLf "https://github.com/vmware-tanzu/sonobuoy/releases/download/v${sonobuoy_version}/sonobuoy_${sonobuoy_version}_linux_${ARCH}.tar.gz" | tar -xvzf - -C /usr/bin sonobuoy
+
+# Install kube-bench
 RUN curl -sLf "https://github.com/aquasecurity/kube-bench/releases/download/v${kube_bench_version}/kube-bench_${kube_bench_version}_linux_${ARCH}.tar.gz" | tar -xvzf - -C /usr/bin
 
-# Copy the files within /cfg straight from the immutable GitHub source to /etc/kube-bench/cfg/.
+# Fix ownership to root:root for all three binaries
+RUN chown root:root /usr/bin/sonobuoy /usr/local/bin/kubectl /usr/bin/kube-bench
+
+# Copy the files within /cfg straight from the immutable GitHub source to /etc/kube-bench/cfg/
 RUN mkdir -p /etc/kube-bench/ && \
     curl -sLf "https://github.com/aquasecurity/kube-bench/archive/refs/tags/v${kube_bench_version}.tar.gz" | \
     tar xvz -C /etc/kube-bench/ --strip-components=1 "kube-bench-${kube_bench_version}/cfg"
 
+# Main stage using bci-base as the base image
+FROM registry.suse.com/bci/bci-base:15.5
+
+# Install image dependencies (systemd to provision journald in run.sh)
+RUN zypper --non-interactive update && zypper --non-interactive install systemd jq
+
+# Copy binaries and configuration files from the builder stage
+COPY --from=builder /usr/local/bin/kubectl /usr/local/bin/
+COPY --from=builder /usr/bin/sonobuoy /usr/bin/
+COPY --from=builder /usr/bin/kube-bench /usr/bin/
+COPY --from=builder /etc/kube-bench/ /etc/kube-bench/
+
+# Copy binaries and configuration files from the local repository
 COPY package/cfg/ /etc/kube-bench/cfg/
 COPY package/run.sh \
     package/run_sonobuoy_plugin.sh \


### PR DESCRIPTION
Parent issue: https://github.com/rancher/security-team/issues/387

This PR covers the following:

1. Have a multi-stage approach
2. Use a ~~minimal~~ [base](https://registry.suse.com/bci/bci-base-15sp5/index.html) final image and remove unused packages.

Note: 
- `bci-minimal` image implies to have all the binaries to run all scripts and `kube-bench` audit commands (this means that we will have to maintain this list for any new checks commands requirements). That is something that we can implement later on. 
- Rootless is under test.
