### PR TITLE
Add EKS 1.2.0 Benchmark and Bump kube-bench, sonobuoy

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.suse.com/bci/bci-base:15.5
 
-ARG kube_bench_version=0.6.12
-ARG sonobuoy_version=0.56.16
+ARG kube_bench_version=0.6.19
+ARG sonobuoy_version=0.57.0
 ARG kubectl_version=1.28.0
 ARG ARCH
 

--- a/package/cfg/config.yaml
+++ b/package/cfg/config.yaml
@@ -219,8 +219,8 @@ version_mapping:
   "v1.18.10+rke2r1":
     - "rke2-cis-1.5-hardened"
     - "rke2-cis-1.5-permissive"
-  "eks-1.0.1":
-    - "eks-1.0.1"
+  "eks-1.2.0":
+    - "eks-1.2.0"
   "gke-1.2.0":
     - "gke-1.2.0"
   "aks-1.0":
@@ -234,7 +234,7 @@ version_mapping:
 
 target_mapping:
   # EKS
-  "eks-1.0.1":
+  "eks-1.2.0":
     - "node"
   # GKE
   "gke-1.2.0":

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -70,7 +70,7 @@ kubectl exec -n cis-operator-system security-scan-runner-scan-test -c rancher-ci
 kubectl exec -n cis-operator-system security-scan-runner-scan-test -c rancher-cis-benchmark -- /usr/local/bin/kubectl version
 
 echo "> Check for upstream test files:"
-dirs="ack-1.0 aks-1.0 cis-1.20 cis-1.23 cis-1.24 cis-1.5 cis-1.6 cis-1.6-k3s config.yaml eks-1.0.1 eks-1.1.0 eks-stig-kubernetes-v1r6 gke-1.0 gke-1.2.0 rh-0.7 rh-1.0"
+dirs="ack-1.0 aks-1.0 cis-1.20 cis-1.23 cis-1.24 cis-1.5 cis-1.6 cis-1.6-k3s config.yaml eks-1.0.1 eks-1.1.0 eks-1.2.0 eks-stig-kubernetes-v1r6 gke-1.0 gke-1.2.0 rh-0.7 rh-1.0"
 
 for d in ${dirs}; do
   if ! kubectl exec -n cis-operator-system security-scan-runner-scan-test -c rancher-cis-benchmark -- stat "/etc/kube-bench/cfg/$d"; then


### PR DESCRIPTION
This PR adds EKS 1.2.0 and removes the 1.0.1 benchmark (which is very old).
This PR also update kube-bench and sonobuoy versions to latest. 
Related: https://github.com/rancher/cis-operator/issues/233