### PR TITLE
Add kube-bench dry run to script/validate

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -2,6 +2,7 @@ FROM registry.suse.com/bci/golang:1.19
 
 ARG KIND_VERSION=0.17.0
 ARG KUBERNETES_VERSION=1.28.0
+ARG KUBE_BENCH_VERSION=0.6.19
 ARG DAPPER_HOST_ARCH
 ENV ARCH $DAPPER_HOST_ARCH
 
@@ -10,13 +11,18 @@ RUN pip install yamllint
 RUN go install golang.org/x/lint/golint@latest
 RUN go install golang.org/x/tools/cmd/goimports@latest
 
+# Install kind
 RUN curl -Lo ./kind "https://github.com/kubernetes-sigs/kind/releases/download/v${KIND_VERSION}/kind-linux-${ARCH}" && \
     chmod +x ./kind && \
     mv ./kind /usr/local/bin/
 
+# Install kubectl
 RUN curl -Lo ./kubectl "https://dl.k8s.io/release/v${KUBERNETES_VERSION}/bin/linux/${ARCH}/kubectl" && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin/
+
+## Install kube-bench
+RUN curl -sLf "https://github.com/aquasecurity/kube-bench/releases/download/v${KUBE_BENCH_VERSION}/kube-bench_${KUBE_BENCH_VERSION}_linux_${ARCH}.tar.gz" | tar -xvzf - -C /usr/bin
 
 ENV DAPPER_ENV REPO TAG DRONE_TAG
 ENV DAPPER_SOURCE /go/src/github.com/rancher/security-scan/

--- a/scripts/validate
+++ b/scripts/validate
@@ -21,19 +21,37 @@ test -z "$failed"
 echo "Running: go fmt"
 test -z "$(go fmt ${PACKAGES} | tee /dev/stderr)"
 
-## validation: Benchmarks (cfgs) yaml files with yamllint
+## validation: Benchmarks (cfgs) with yamllint and kube-bench (dry-run) 
 echo "Running: yamllint against security-scan cfgs"
 
+# CFGS lists all benchmark directories such as cis-1.7
 CFGS="$(find package/cfg/ -mindepth 1 -type d -printf "%f\n")"
+
 FAILED_CFGS_YML=()
+FAILED_CFGS_KB=()
+
+# Loop through all benchmarks
 for cfg in ${CFGS}; do
 set -x
+# yammlint is configured with ../.yamllint.yaml, to catch any liniting errors for a given benchmark. If result isn't empty, FAILED_CFGS_YML is appended with the failing benchmark.
     if [ -n "$(yamllint -s package/cfg/$cfg)" ]; then
-        FAILED_CFGS_YML+=("$package/cfg/cfg")
+        FAILED_CFGS_YML+=("package/cfg/$cfg")
+    fi
+# kube-bench dry-run to detect any errors for a given benchmark's files - check 1.1 is common to all benchmarks and used to speed up the test. If kube-bench commands fails, FAILED_CFGS_KB is appended with the failing benchmark.
+    if kube-bench --config-dir package/cfg --config package/cfg/config.yaml --benchmark "$cfg" --check 1.1 --noremediations --noresults --nosummary --nototals; then
+	echo "$cfg is OK"
+    else
+        FAILED_CFGS_KB+=("$cfg")
     fi
 set +x
 done
+
+# Test if any profiles have errors, either FAILED_CFGS_YML or FAILED_CFGS_KB is greater than 0, fails. 
 if [ ${#FAILED_CFGS_YML[@]} -gt 0 ]; then
 	echo "Error - yamllint failed for these cfgs: ${FAILED_CFGS_YML[@]}"
+	exit 1
+fi
+if [ ${#FAILED_CFGS_KB[@]} -gt 0 ]; then
+	echo "Error - kube-bench dry-run failed for these cfgs: ${FAILED_CFGS_KB[@]}"
 	exit 1
 fi


### PR DESCRIPTION
Parent issue: https://github.com/rancher/cis-operator/issues/227

This PR adds another layer of verification, to ensure that a given CIS benchmark is not faulty.

Let's say we introduce a typo in cis-1.7/master.yaml, (`tiype` instead of `type`), but [yamllint](https://github.com/rancher/security-scan/pull/172) didn't return any errors. Kube-bench can be run against the given benchmark (e.g cis-1.7), if any of the cis-1.7's files have a typo it won't run.
kube-bench indicates which component (file) is faulty : `error setting up master controls: non-master controls file specified`

Example of scenario:

```
$ git diff
diff --git a/package/cfg/cis-1.7/master.yaml b/package/cfg/cis-1.7/master.yaml
index aa27cb4..647a813 100644
--- a/package/cfg/cis-1.7/master.yaml
+++ b/package/cfg/cis-1.7/master.yaml
@@ -3,7 +3,7 @@ controls:
 version: "1.7"
 id: 1
 text: "Control Plane Security Configuration"
-type: "master"
+type: "master"
 groups:
   - id: 1.1
     text: "Control Plane Node Configuration Files"
```

YAMLLINT test 🟢 
```
$ yamllint security-scan/package/cfg/cis-1.7/master.yaml | grep -v line
security-scan/package/cfg/cis-1.7/master.yaml
```
KUBE-BENCH dry-run 🔴 
```
$ ./kube-bench --config-dir security-scan/package/cfg --config security-scan/package/cfg/config.yaml --benchmark cis-1.7
Warning: Kubernetes version was not auto-detected because kubectl could not connect to the Kubernetes server. This may be because the kubeconfig information is missing or has credentials that do not match the server. Assuming default version 1.18

error setting up master controls: non-master controls file specified
```
