### PR TITLE
updated incorrect CIS controls Ids and version mapping

### DIFF
--- a/package/cfg/k3s-cis-1.20-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.20-hardened/master.yaml
@@ -723,7 +723,7 @@ groups:
           --audit-log-maxsize=100
         scored: true
 
-      - id: 1.2.26
+      - id: 1.2.25
         text: "Ensure that the --request-timeout argument is set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'request-timeout'"
         tests:

--- a/package/cfg/k3s-cis-1.23-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.23-permissive/master.yaml
@@ -687,7 +687,7 @@ groups:
           For example, to set it as 100 MB, --audit-log-maxsize=100
         scored: true
 
-      - id: 1.2.25
+      - id: 1.2.23
         text: "Ensure that the --request-timeout argument is set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         type: "skip"

--- a/package/cfg/k3s-cis-1.24-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/master.yaml
@@ -686,7 +686,7 @@ groups:
           For example, to set it as 100 MB, --audit-log-maxsize=100
         scored: true
 
-      - id: 1.2.25
+      - id: 1.2.23
         text: "Ensure that the --request-timeout argument is set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
         type: "skip"

--- a/package/cfg/rke-cis-1.23-hardened/master.yaml
+++ b/package/cfg/rke-cis-1.23-hardened/master.yaml
@@ -627,7 +627,7 @@ groups:
           For example, to set it as 100 MB, --audit-log-maxsize=100
         scored: true
 
-      - id: 1.2.25
+      - id: 1.2.23
         text: "Ensure that the --request-timeout argument is set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:

--- a/package/cfg/rke-cis-1.23-permissive/etcd.yaml
+++ b/package/cfg/rke-cis-1.23-permissive/etcd.yaml
@@ -1,6 +1,6 @@
 ---
 controls:
-version: "cis-1.23"
+version: 1.23
 id: 2
 text: "Etcd Node Configuration"
 type: "etcd"

--- a/package/cfg/rke-cis-1.24-hardened/master.yaml
+++ b/package/cfg/rke-cis-1.24-hardened/master.yaml
@@ -628,7 +628,7 @@ groups:
           For example, to set it as 100 MB, --audit-log-maxsize=100
         scored: true
 
-      - id: 1.2.25
+      - id: 1.2.23
         text: "Ensure that the --request-timeout argument is set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:

--- a/package/cfg/rke-cis-1.24-permissive/etcd.yaml
+++ b/package/cfg/rke-cis-1.24-permissive/etcd.yaml
@@ -1,6 +1,6 @@
 ---
 controls:
-version: "cis-1.24"
+version: 1.24
 id: 2
 text: "Etcd Node Configuration"
 type: "etcd"

--- a/package/cfg/rke2-cis-1.23-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.23-hardened/master.yaml
@@ -647,7 +647,7 @@ groups:
           For example, to set it as 100 MB, --audit-log-maxsize=100
         scored: true
 
-      - id: 1.2.25
+      - id: 1.2.23
         text: "Ensure that the --request-timeout argument is set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:

--- a/package/cfg/rke2-cis-1.24-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.24-hardened/master.yaml
@@ -647,7 +647,7 @@ groups:
           For example, to set it as 100 MB, --audit-log-maxsize=100
         scored: true
 
-      - id: 1.2.25
+      - id: 1.2.23
         text: "Ensure that the --request-timeout argument is set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:


### PR DESCRIPTION
updated the scripts with correct CIS control Ids for controls Ids and version mapping
1. package/cfg/k3s-cis-1.20-hardened/master.yaml - 1.2.25 id missing, found duplicate id for 1.2.26
2. package/cfg/k3s-cis-1.23-permissive/master.yaml - 1.2.23 id missing, found duplicate id for 1.2.25
3. package/cfg/k3s-cis-1.24-permissive/master.yaml - 1.2.23 id missing, found duplicate id for 1.2.25
4. package/cfg/rke-cis-1.23-hardened/master.yaml - 1.2.23 id missing, found duplicate id for 1.2.25
5. package/cfg/rke-cis-1.23-permissive/etcd.yaml - incorrect version mapping found
6. package/cfg/rke-cis-1.24-hardened/master.yaml - 1.2.23 id missing, found duplicate id for 1.2.25
7. package/cfg/rke-cis-1.24-permissive/etcd.yaml - incorrect version mapping found
8. package/cfg/rke2-cis-1.23-hardened/master.yaml - 1.2.23 id missing, found duplicate id for 1.2.25
9. package/cfg/rke2-cis-1.24-hardened/master.yaml - 1.2.23 id missing, found duplicate id for 1.2.25