### PR TITLE
fix k3s scan profiles

### DIFF
--- a/package/cfg/k3s-cis-1.24-hardened/config.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/config.yaml
@@ -25,22 +25,22 @@ master:
     bins:
       - containerd
 
-  node:
-    components:
-      - kubelet
-      - proxy
+node:
+  components:
+    - kubelet
+    - proxy
 
-    kubelet:
-      bins:
-        - containerd
-      defaultkubeconfig: /var/lib/rancher/k3s/agent/kubelet.kubeconfig
-      defaultcafile: /var/lib/rancher/k3s/agent/client-ca.crt
+  kubelet:
+    bins:
+      - containerd
+    defaultkubeconfig: /var/lib/rancher/k3s/agent/kubelet.kubeconfig
+    defaultcafile: /var/lib/rancher/k3s/agent/client-ca.crt
 
-    proxy:
-      bins:
-        - containerd
-      defaultkubeconfig: /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig
+  proxy:
+    bins:
+      - containerd
+    defaultkubeconfig: /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig
 
-  policies:
-    components:
-      - policies
+policies:
+  components:
+    - policies

--- a/package/cfg/k3s-cis-1.24-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/node.yaml
@@ -114,7 +114,7 @@ groups:
 
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
-        audit: "stat -c %U:%G /var/lib/rancher/k3s/server/tls/client-ca.crt"
+        audit: "stat -c %U:%G $$kubeletcafile"
         tests:
           test_items:
             - flag: root:root
@@ -223,7 +223,7 @@ groups:
 
       - id: 4.2.4
         text: "Verify that the --read-only-port argument is set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'read-only-port' "
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'read-only-port' "
         tests:
           bin_op: or
           test_items:
@@ -248,7 +248,7 @@ groups:
 
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'streaming-connection-idle-timeout'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'streaming-connection-idle-timeout'"
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -274,7 +274,7 @@ groups:
 
       - id: 4.2.6
         text: "Ensure that the --protect-kernel-defaults argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'protect-kernel-defaults'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'protect-kernel-defaults'"
         tests:
           test_items:
             - flag: --protect-kernel-defaults

--- a/package/cfg/k3s-cis-1.24-permissive/config.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/config.yaml
@@ -25,22 +25,22 @@ master:
     bins:
       - containerd
 
-  node:
-    components:
-      - kubelet
-      - proxy
+node:
+  components:
+    - kubelet
+    - proxy
 
-    kubelet:
-      bins:
-        - containerd
-      defaultkubeconfig: /var/lib/rancher/k3s/agent/kubelet.kubeconfig
-      defaultcafile: /var/lib/rancher/k3s/agent/client-ca.crt
+  kubelet:
+    bins:
+      - containerd
+    defaultkubeconfig: /var/lib/rancher/k3s/agent/kubelet.kubeconfig
+    defaultcafile: /var/lib/rancher/k3s/agent/client-ca.crt
 
-    proxy:
-      bins:
-        - containerd
-      defaultkubeconfig: /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig
+  proxy:
+    bins:
+      - containerd
+    defaultkubeconfig: /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig
 
-  policies:
-    components:
-      - policies
+policies:
+  components:
+    - policies

--- a/package/cfg/k3s-cis-1.24-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/node.yaml
@@ -114,7 +114,7 @@ groups:
 
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
-        audit: "stat -c %U:%G /var/lib/rancher/k3s/server/tls/client-ca.crt"
+        audit: "stat -c %U:%G $$kubeletcafile"
         tests:
           test_items:
             - flag: root:root
@@ -223,7 +223,7 @@ groups:
 
       - id: 4.2.4
         text: "Verify that the --read-only-port argument is set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'read-only-port' "
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'read-only-port' "
         tests:
           bin_op: or
           test_items:
@@ -248,7 +248,7 @@ groups:
 
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'streaming-connection-idle-timeout'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'streaming-connection-idle-timeout'"
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -274,7 +274,7 @@ groups:
 
       - id: 4.2.6
         text: "Ensure that the --protect-kernel-defaults argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'protect-kernel-defaults'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'protect-kernel-defaults'"
         type: "skip"
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.7-hardened/config.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/config.yaml
@@ -32,22 +32,22 @@ master:
     bins:
       - containerd
 
-  node:
-    components:
-      - kubelet
-      - proxy
+node:
+  components:
+    - kubelet
+    - proxy
 
-    kubelet:
-      bins:
-        - containerd
-      defaultkubeconfig: /var/lib/rancher/k3s/agent/kubelet.kubeconfig
-      defaultcafile: /var/lib/rancher/k3s/agent/client-ca.crt
+  kubelet:
+    bins:
+      - containerd
+    defaultkubeconfig: /var/lib/rancher/k3s/agent/kubelet.kubeconfig
+    defaultcafile: /var/lib/rancher/k3s/agent/client-ca.crt
 
-    proxy:
-      bins:
-        - containerd
-      defaultkubeconfig: /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig
+  proxy:
+    bins:
+      - containerd
+    defaultkubeconfig: /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig
 
-  policies:
-    components:
-      - policies
+policies:
+  components:
+    - policies

--- a/package/cfg/k3s-cis-1.7-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/node.yaml
@@ -110,7 +110,7 @@ groups:
 
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
-        audit: "stat -c %U:%G /var/lib/rancher/k3s/server/tls/client-ca.crt"
+        audit: "stat -c %U:%G $$kubeletcafile"
         tests:
           test_items:
             - flag: root:root
@@ -219,7 +219,7 @@ groups:
 
       - id: 4.2.4
         text: "Verify that the --read-only-port argument is set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'read-only-port' "
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'read-only-port' "
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           bin_op: or
@@ -245,7 +245,7 @@ groups:
 
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'streaming-connection-idle-timeout'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'streaming-connection-idle-timeout'"
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -271,7 +271,7 @@ groups:
 
       - id: 4.2.6
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'make-iptables-util-chains'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'make-iptables-util-chains'"
         tests:
           test_items:
             - flag: --make-iptables-util-chains

--- a/package/cfg/k3s-cis-1.7-permissive/config.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/config.yaml
@@ -32,22 +32,22 @@ master:
     bins:
       - containerd
 
-  node:
-    components:
-      - kubelet
-      - proxy
+node:
+  components:
+    - kubelet
+    - proxy
 
-    kubelet:
-      bins:
-        - containerd
-      defaultkubeconfig: /var/lib/rancher/k3s/agent/kubelet.kubeconfig
-      defaultcafile: /var/lib/rancher/k3s/agent/client-ca.crt
+  kubelet:
+    bins:
+      - containerd
+    defaultkubeconfig: /var/lib/rancher/k3s/agent/kubelet.kubeconfig
+    defaultcafile: /var/lib/rancher/k3s/agent/client-ca.crt
 
-    proxy:
-      bins:
-        - containerd
-      defaultkubeconfig: /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig
+  proxy:
+    bins:
+      - containerd
+    defaultkubeconfig: /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig
 
-  policies:
-    components:
-      - policies
+policies:
+  components:
+    - policies

--- a/package/cfg/k3s-cis-1.7-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/node.yaml
@@ -110,7 +110,7 @@ groups:
 
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
-        audit: "stat -c %U:%G /var/lib/rancher/k3s/server/tls/client-ca.crt"
+        audit: "stat -c %U:%G $$kubeletcafile"
         tests:
           test_items:
             - flag: root:root
@@ -219,7 +219,7 @@ groups:
 
       - id: 4.2.4
         text: "Verify that the --read-only-port argument is set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'read-only-port' "
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'read-only-port' "
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           bin_op: or
@@ -245,7 +245,7 @@ groups:
 
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'streaming-connection-idle-timeout'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'streaming-connection-idle-timeout'"
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -272,7 +272,7 @@ groups:
       - id: 4.2.6
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
         type: "skip"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'make-iptables-util-chains'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'make-iptables-util-chains'"
         tests:
           test_items:
             - flag: --make-iptables-util-chains

--- a/package/cfg/k3s-cis-1.8-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/node.yaml
@@ -103,7 +103,7 @@ groups:
         scored: false
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
-        audit: "stat -c %U:%G /var/lib/rancher/k3s/server/tls/client-ca.crt"
+        audit: "stat -c %U:%G $$kubeletcafile"
         tests:
           test_items:
             - flag: root:root
@@ -202,7 +202,7 @@ groups:
         scored: true
       - id: 4.2.4
         text: "Verify that the --read-only-port argument is set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'read-only-port' "
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'read-only-port' "
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           bin_op: or
@@ -227,7 +227,7 @@ groups:
         scored: false
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'streaming-connection-idle-timeout'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'streaming-connection-idle-timeout'"
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -252,7 +252,7 @@ groups:
         scored: false
       - id: 4.2.6
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'make-iptables-util-chains'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'make-iptables-util-chains'"
         tests:
           test_items:
             - flag: --make-iptables-util-chains

--- a/package/cfg/k3s-cis-1.8-permissive/config.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/config.yaml
@@ -26,21 +26,21 @@ master:
   etcd:
     bins:
       - containerd
-  node:
-    components:
-      - kubelet
-      - proxy
-    kubelet:
-      bins:
-        - containerd
-      confs:
-        - /var/lib/rancher/k3s/agent/kubelet.kubeconfig
-      defaultkubeconfig: /var/lib/rancher/k3s/agent/kubelet.kubeconfig
-      defaultcafile: /var/lib/rancher/k3s/agent/client-ca.crt
-    proxy:
-      bins:
-        - containerd
-      defaultkubeconfig: /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig
-  policies:
-    components:
-      - policies
+node:
+  components:
+    - kubelet
+    - proxy
+  kubelet:
+    bins:
+      - containerd
+    confs:
+      - /var/lib/rancher/k3s/agent/kubelet.kubeconfig
+    defaultkubeconfig: /var/lib/rancher/k3s/agent/kubelet.kubeconfig
+    defaultcafile: /var/lib/rancher/k3s/agent/client-ca.crt
+  proxy:
+    bins:
+      - containerd
+    defaultkubeconfig: /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig
+policies:
+  components:
+    - policies

--- a/package/cfg/k3s-cis-1.8-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/node.yaml
@@ -103,7 +103,7 @@ groups:
         scored: false
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
-        audit: "stat -c %U:%G /var/lib/rancher/k3s/server/tls/client-ca.crt"
+        audit: "stat -c %U:%G $$kubeletcafile"
         tests:
           test_items:
             - flag: root:root
@@ -202,7 +202,7 @@ groups:
         scored: true
       - id: 4.2.4
         text: "Verify that the --read-only-port argument is set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'read-only-port' "
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'read-only-port' "
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           bin_op: or
@@ -227,7 +227,7 @@ groups:
         scored: false
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'streaming-connection-idle-timeout'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'streaming-connection-idle-timeout'"
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -253,7 +253,7 @@ groups:
       - id: 4.2.6
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
         type: "skip"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'make-iptables-util-chains'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'make-iptables-util-chains'"
         tests:
           test_items:
             - flag: --make-iptables-util-chains

--- a/package/run_sonobuoy_plugin.sh
+++ b/package/run_sonobuoy_plugin.sh
@@ -131,7 +131,7 @@ fi
 kubeletconf="/node/var/lib/kubelet/config"
 
 if [[ "${OVERRIDE_BENCHMARK_VERSION}" != "" ]]; then
-  if [[ "$(pgrep kubelet | wc -l)" -gt 0 ]] || [[ "$(journalctl -D $JOURNAL_LOG -u k3s | grep -m1 'Running kubelet' | wc -l)" -gt 0 ]]; then
+  if [[ "$(pgrep kubelet | wc -l)" -gt 0 ]] || [[ "$(journalctl -D $JOURNAL_LOG -u k3s -u k3s-agent | grep -m1 'Running kubelet' | wc -l)" -gt 0 ]]; then
     echo "node: Using OVERRIDE_BENCHMARK_VERSION=${OVERRIDE_BENCHMARK_VERSION}"
     kube-bench run \
       --targets node \

--- a/package/run_sonobuoy_plugin.sh
+++ b/package/run_sonobuoy_plugin.sh
@@ -58,7 +58,7 @@ LOG_DIR="${RESULTS_DIR}/logs"
 JOURNAL_LOG="${JOURNAL_LOG:-/var/log/journal}"
 if [[ "$(journalctl -D $JOURNAL_LOG --lines=0 2>&1 | grep -s 'No such file or directory' | wc -l)" -gt 0 ]]; then
   JOURNAL_LOG=/run/log/journal
-  find $CONFIG_DIR -name '*.yaml' | xargs -n1 sed -i 's|/var/log/journal|/run/log/journal|'
+  find $CONFIG_DIR -name '*.yaml' | xargs -n1 sed -i 's|/var/log/journal|/run/log/journal|g'
 fi
 mkdir -p "${RESULTS_DIR}"
 


### PR DESCRIPTION
related issue: https://github.com/rancher/cis-operator/issues/254, https://github.com/rancher/cis-operator/issues/255, https://github.com/rancher/cis-operator/issues/258, https://github.com/rancher/cis-operator/issues/259, https://github.com/rancher/cis-operator/issues/260 and https://github.com/rancher/cis-operator/issues/261
Note: fixed k3s profiles for k8s v1.24 and above onl

1. k3s scans were not running on worker nodes because in the run_sonobuoy_plugin script, to check the worker node k3s-agent service logs were not checked.
to fix this, i added the k3s-agent service in that check.
```
  if [[ "$(pgrep kubelet | wc -l)" -gt 0 ]] || [[ "$(journalctl -D $JOURNAL_LOG -u k3s -u k3s-agent | grep -m1 'Running kubelet' | wc -l)" -gt 0 ]]; then
```

2. due to the above fix some tests were broken so fixed those test cases 4.1.8, 4.2.4, 4.2.5 and 4.2.6.

2. cis 1.8 hardened config.yaml was fixed in commit https://github.com/rancher/security-scan/pull/179/commits/614996f078444ba7ec1a5b34bb16cec18bb14618 but this exist in the same way in all other profile configuration for k3s so fixed that.

3.  current sed command was only removing one occurrence in a line so added `|g` to it to correctly replace all occurrences of /var/log/journal in the script.