### PR TITLE
fix k3s tests for k3s-cis-1.23-profile

### DIFF
--- a/package/cfg/k3s-cis-1.23-hardened/config.yaml
+++ b/package/cfg/k3s-cis-1.23-hardened/config.yaml
@@ -25,22 +25,22 @@ master:
     bins:
       - containerd
 
-  node:
-    components:
-      - kubelet
-      - proxy
+node:
+  components:
+    - kubelet
+    - proxy
 
-    kubelet:
-      bins:
-        - containerd
-      defaultkubeconfig: /var/lib/rancher/k3s/agent/kubelet.kubeconfig
-      defaultcafile: /var/lib/rancher/k3s/agent/client-ca.crt
+  kubelet:
+    bins:
+      - containerd
+    defaultkubeconfig: /var/lib/rancher/k3s/agent/kubelet.kubeconfig
+    defaultcafile: /var/lib/rancher/k3s/agent/client-ca.crt
 
-    proxy:
-      bins:
-        - containerd
-      defaultkubeconfig: /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig
+  proxy:
+    bins:
+      - containerd
+    defaultkubeconfig: /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig
 
-  policies:
-    components:
-      - policies
+policies:
+  components:
+    - policies

--- a/package/cfg/k3s-cis-1.23-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.23-hardened/node.yaml
@@ -149,7 +149,7 @@ groups:
 
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
-        audit: "stat -c %U:%G /var/lib/rancher/k3s/server/tls/client-ca.crt"
+        audit: "stat -c %U:%G $kubeletcafile"
         tests:
           test_items:
             - flag: root:root
@@ -258,7 +258,7 @@ groups:
 
       - id: 4.2.4
         text: "Ensure that the --read-only-port argument is set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'read-only-port' "
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'read-only-port' "
         tests:
           bin_op: or
           test_items:
@@ -283,7 +283,7 @@ groups:
 
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'streaming-connection-idle-timeout'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'streaming-connection-idle-timeout'"
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -309,7 +309,7 @@ groups:
 
       - id: 4.2.6
         text: "Ensure that the --protect-kernel-defaults argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'protect-kernel-defaults'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'protect-kernel-defaults'"
         tests:
           test_items:
             - flag: --protect-kernel-defaults

--- a/package/cfg/k3s-cis-1.23-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.23-hardened/node.yaml
@@ -331,7 +331,7 @@ groups:
 
       - id: 4.2.7
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'make-iptables-util-chains'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'make-iptables-util-chains'"
         tests:
           test_items:
             - flag: --make-iptables-util-chains
@@ -398,7 +398,7 @@ groups:
 
       - id: 4.2.10
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --tls-cert-file

--- a/package/cfg/k3s-cis-1.23-permissive/config.yaml
+++ b/package/cfg/k3s-cis-1.23-permissive/config.yaml
@@ -25,22 +25,22 @@ master:
     bins:
       - containerd
 
-  node:
-    components:
-      - kubelet
-      - proxy
+node:
+  components:
+    - kubelet
+    - proxy
 
-    kubelet:
-      bins:
-        - containerd
-      defaultkubeconfig: /var/lib/rancher/k3s/agent/kubelet.kubeconfig
-      defaultcafile: /var/lib/rancher/k3s/agent/client-ca.crt
+  kubelet:
+    bins:
+      - containerd
+    defaultkubeconfig: /var/lib/rancher/k3s/agent/kubelet.kubeconfig
+    defaultcafile: /var/lib/rancher/k3s/agent/client-ca.crt
 
-    proxy:
-      bins:
-        - containerd
-      defaultkubeconfig: /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig
+  proxy:
+    bins:
+      - containerd
+    defaultkubeconfig: /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig
 
-  policies:
-    components:
-      - policies
+policies:
+  components:
+    - policies

--- a/package/cfg/k3s-cis-1.23-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.23-permissive/node.yaml
@@ -149,7 +149,7 @@ groups:
 
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
-        audit: "stat -c %U:%G /var/lib/rancher/k3s/server/tls/client-ca.crt"
+        audit: "stat -c %U:%G $kubeletcafile"
         tests:
           test_items:
             - flag: root:root
@@ -258,7 +258,7 @@ groups:
 
       - id: 4.2.4
         text: "Ensure that the --read-only-port argument is set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'read-only-port' "
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'read-only-port' "
         tests:
           bin_op: or
           test_items:
@@ -283,7 +283,7 @@ groups:
 
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'streaming-connection-idle-timeout'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'streaming-connection-idle-timeout'"
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -309,7 +309,7 @@ groups:
 
       - id: 4.2.6
         text: "Ensure that the --protect-kernel-defaults argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'protect-kernel-defaults'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'protect-kernel-defaults'"
         type: "skip"
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.23-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.23-permissive/node.yaml
@@ -332,7 +332,7 @@ groups:
 
       - id: 4.2.7
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'make-iptables-util-chains'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'make-iptables-util-chains'"
         type: "skip"
         tests:
           test_items:
@@ -400,7 +400,7 @@ groups:
 
       - id: 4.2.10
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --tls-cert-file

--- a/package/cfg/k3s-cis-1.24-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/node.yaml
@@ -296,7 +296,7 @@ groups:
 
       - id: 4.2.7
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'make-iptables-util-chains'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'make-iptables-util-chains'"
         tests:
           test_items:
             - flag: --make-iptables-util-chains
@@ -363,7 +363,7 @@ groups:
 
       - id: 4.2.10
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --tls-cert-file

--- a/package/cfg/k3s-cis-1.24-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/node.yaml
@@ -114,7 +114,7 @@ groups:
 
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
-        audit: "stat -c %U:%G $$kubeletcafile"
+        audit: "stat -c %U:%G $kubeletcafile"
         tests:
           test_items:
             - flag: root:root

--- a/package/cfg/k3s-cis-1.24-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/node.yaml
@@ -114,7 +114,7 @@ groups:
 
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
-        audit: "stat -c %U:%G $$kubeletcafile"
+        audit: "stat -c %U:%G $kubeletcafile"
         tests:
           test_items:
             - flag: root:root

--- a/package/cfg/k3s-cis-1.24-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/node.yaml
@@ -297,7 +297,7 @@ groups:
 
       - id: 4.2.7
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1 | grep 'make-iptables-util-chains'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'make-iptables-util-chains'"
         type: "skip"
         tests:
           test_items:
@@ -365,7 +365,7 @@ groups:
 
       - id: 4.2.10
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --tls-cert-file

--- a/package/cfg/k3s-cis-1.7-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/node.yaml
@@ -110,7 +110,7 @@ groups:
 
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
-        audit: "stat -c %U:%G $$kubeletcafile"
+        audit: "stat -c %U:%G $kubeletcafile"
         tests:
           test_items:
             - flag: root:root

--- a/package/cfg/k3s-cis-1.7-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/node.yaml
@@ -343,7 +343,7 @@ groups:
       - id: 4.2.9
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
         type: "skip"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --tls-cert-file

--- a/package/cfg/k3s-cis-1.7-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/node.yaml
@@ -345,7 +345,7 @@ groups:
       - id: 4.2.9
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
         type: "skip"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --tls-cert-file

--- a/package/cfg/k3s-cis-1.7-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/node.yaml
@@ -110,7 +110,7 @@ groups:
 
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
-        audit: "stat -c %U:%G $$kubeletcafile"
+        audit: "stat -c %U:%G $kubeletcafile"
         tests:
           test_items:
             - flag: root:root

--- a/package/cfg/k3s-cis-1.8-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/node.yaml
@@ -321,7 +321,7 @@ groups:
       - id: 4.2.9
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
         type: "skip"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --tls-cert-file

--- a/package/cfg/k3s-cis-1.8-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/node.yaml
@@ -103,7 +103,7 @@ groups:
         scored: false
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
-        audit: "stat -c %U:%G $$kubeletcafile"
+        audit: "stat -c %U:%G $kubeletcafile"
         tests:
           test_items:
             - flag: root:root

--- a/package/cfg/k3s-cis-1.8-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/node.yaml
@@ -323,7 +323,7 @@ groups:
       - id: 4.2.9
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
         type: "skip"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --tls-cert-file

--- a/package/cfg/k3s-cis-1.8-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/node.yaml
@@ -103,7 +103,7 @@ groups:
         scored: false
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
-        audit: "stat -c %U:%G $$kubeletcafile"
+        audit: "stat -c %U:%G $kubeletcafile"
         tests:
           test_items:
             - flag: root:root


### PR DESCRIPTION
related issue: https://github.com/rancher/cis-operator/issues/254, https://github.com/rancher/cis-operator/issues/255, https://github.com/rancher/cis-operator/issues/258 and https://github.com/rancher/cis-operator/issues/259
- also includes $kubeletcafile variable typo fix
- fixes k8s v1.23 test in k3s profile:

1. k3s-cis-1.7 and k3s-cis-1.8 profile both hardened and permissive:  4.1.8 and 4.2.9
2. k3s-cis-1.24 both hardened and permissive:  4.2.7, 4.1.8, 4.2.10
3. k3s-cis-1.23 both hardened and permissive: tests 4.1.8, 4.2.4, 4.2.5, 4.2.6, 4.2.7, 4.2.10 and config.yaml