### PR TITLE
fix 4.1.7 test case for k3s-cis-1.23-permissive profile

### DIFF
--- a/package/cfg/k3s-cis-1.23-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.23-hardened/node.yaml
@@ -103,45 +103,13 @@ groups:
 
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Manual)"
-        audit: "stat -c %a /var/lib/rancher/k3s/server/tls/server-ca.crt"
+        audit: "stat -c %a $kubeletcafile"
         tests:
           test_items:
-            - flag: "644"
+            - flag: "permissions"
               compare:
-                op: eq
+                op: bitmask
                 value: "644"
-              set: true
-            - flag: "640"
-              compare:
-                op: eq
-                value: "640"
-              set: true
-            - flag: "600"
-              compare:
-                op: eq
-                value: "600"
-              set: true
-            - flag: "444"
-              compare:
-                op: eq
-                value: "444"
-              set: true
-            - flag: "440"
-              compare:
-                op: eq
-                value: "440"
-              set: true
-            - flag: "400"
-              compare:
-                op: eq
-                value: "400"
-              set: true
-            - flag: "000"
-              compare:
-                op: eq
-                value: "000"
-              set: true
-          bin_op: or
         remediation: |
           Run the following command to modify the file permissions of the
           --client-ca-file chmod 644 <filename>

--- a/package/cfg/k3s-cis-1.23-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.23-permissive/node.yaml
@@ -103,49 +103,17 @@ groups:
 
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Manual)"
-        audit: "stat -c %a /var/lib/rancher/k3s/server/tls/server-ca.crt"
+        audit: "stat -c %a $kubeletcafile"
         tests:
           test_items:
-            - flag: "644"
+            - flag: "permissions"
               compare:
-                op: eq
+                op: bitmask
                 value: "644"
-              set: true
-            - flag: "640"
-              compare:
-                op: eq
-                value: "640"
-              set: true
-            - flag: "600"
-              compare:
-                op: eq
-                value: "600"
-              set: true
-            - flag: "444"
-              compare:
-                op: eq
-                value: "444"
-              set: true
-            - flag: "440"
-              compare:
-                op: eq
-                value: "440"
-              set: true
-            - flag: "400"
-              compare:
-                op: eq
-                value: "400"
-              set: true
-            - flag: "000"
-              compare:
-                op: eq
-                value: "000"
-              set: true
-          bin_op: or
         remediation: |
           Run the following command to modify the file permissions of the
           --client-ca-file chmod 644 <filename>
-        scored: true
+        scored: false
 
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"


### PR DESCRIPTION
issue: https://github.com/rancher/cis-operator/issues/262
1. changed `scored: true` to ` scored: false ` for 4.1.7 test case for  k3s-cis-1.23-permissive based on upstream.
2. fix test items for  k3s-cis-1.23-permissive and  k3s-cis-1.23-hardened in test 4.1.7
3. fix file path for certificate file in 4.1.7 test audit in  k3s-cis-1.23-permissive and  k3s-cis-1.23-hardened