### PR TITLE
fixed 4.1.7 test case audit command for k3s profiles

### DIFF
--- a/package/cfg/k3s-cis-1.23-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.23-hardened/node.yaml
@@ -103,7 +103,7 @@ groups:
 
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Manual)"
-        audit: "stat -c %a $kubeletcafile"
+        audit: "stat -c permissions=%a $kubeletcafile"
         tests:
           test_items:
             - flag: "permissions"

--- a/package/cfg/k3s-cis-1.23-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.23-permissive/node.yaml
@@ -103,7 +103,7 @@ groups:
 
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 644 or more restrictive (Manual)"
-        audit: "stat -c %a $kubeletcafile"
+        audit: "stat -c permissions=%a $kubeletcafile"
         tests:
           test_items:
             - flag: "permissions"

--- a/package/cfg/k3s-cis-1.24-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/node.yaml
@@ -99,7 +99,7 @@ groups:
 
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Manual)"
-        audit: "stat -c %a /var/lib/rancher/k3s/server/tls/server-ca.crt"
+        audit: "stat -c permissions=%a $kubeletcafile"
         tests:
           test_items:
             - flag: "permissions"

--- a/package/cfg/k3s-cis-1.24-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/node.yaml
@@ -99,7 +99,7 @@ groups:
 
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Manual)"
-        audit: "stat -c %a /var/lib/rancher/k3s/server/tls/server-ca.crt"
+        audit: "stat -c permissions=%a $kubeletcafile"
         tests:
           test_items:
             - flag: "permissions"

--- a/package/cfg/k3s-cis-1.7-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/node.yaml
@@ -96,7 +96,7 @@ groups:
 
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Manual)"
-        audit: "stat -c %a /var/lib/rancher/k3s/server/tls/server-ca.crt"
+        audit: "stat -c permissions=%a $kubeletcafile"
         tests:
           test_items:
             - flag: "permissions"

--- a/package/cfg/k3s-cis-1.7-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/node.yaml
@@ -96,7 +96,7 @@ groups:
 
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Manual)"
-        audit: "stat -c %a /var/lib/rancher/k3s/server/tls/server-ca.crt"
+        audit: "stat -c permissions=%a $kubeletcafile"
         tests:
           test_items:
             - flag: "permissions"

--- a/package/cfg/k3s-cis-1.8-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/node.yaml
@@ -90,7 +90,7 @@ groups:
         scored: true
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Manual)"
-        audit: "stat -c %a /var/lib/rancher/k3s/server/tls/server-ca.crt"
+        audit: "stat -c permissions=%a $kubeletcafile"
         tests:
           test_items:
             - flag: "permissions"

--- a/package/cfg/k3s-cis-1.8-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/node.yaml
@@ -90,7 +90,7 @@ groups:
         scored: true
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Manual)"
-        audit: "stat -c %a /var/lib/rancher/k3s/server/tls/server-ca.crt"
+        audit: "stat -c permissions=%a $kubeletcafile"
         tests:
           test_items:
             - flag: "permissions"


### PR DESCRIPTION
issues: https://github.com/rancher/cis-operator/issues/279, https://github.com/rancher/cis-operator/issues/280, https://github.com/rancher/cis-operator/issues/281
fixed audit command for 4.1.7 test case in following k3s profiles:
 **k3s-cis-1.23-permissive,k3s-cis-1.24-permissive,k3s-cis-1.7-permissive,k3s-cis-1.8-permissive, k3s-cis-1.23-hardened,k3s-cis-1.24-hardened,k3s-cis-1.7-hardened,k3s-cis-1.8-hardened**
 1. fixed the cert file path
 2. also fixed the audit command options
 
 tested with custom security scan image on k3s v1.26.13+k3s2 cluster with k3s-cis-1.7-permissive profile
![Screenshot from 2024-03-07 20-24-43](https://github.com/rancher/security-scan/assets/115442970/3b0ae0c1-613a-4eaa-a623-0be5529b9c83)

 