### PR TITLE
build: Remove cross emulation for zypper

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,29 +1,40 @@
-# Final micro image
-FROM registry.suse.com/bci/bci-micro:15.5 AS micro
+# Platform specific images which must support all target architectures.
+FROM registry.suse.com/bci/bci-micro:15.5 AS final
+FROM registry.suse.com/bci/golang:1.22 AS golang
 
-# Image that provides cross compilation tooling.
+# Builder and xx only need to support the host architecture.
 FROM --platform=$BUILDPLATFORM rancher/mirrored-tonistiigi-xx:1.3.0 as xx
-
-FROM registry.suse.com/bci/golang:1.22 AS golang-arch
-
-# Arch-specific temporary build stage for zypper deps that will be copied into the final image.
 FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.22 AS builder
 
-# Copy xx supporting tools to throw-away layer. Not this is not being sent to /chroot.
+# Bring xx supporting tools to the builder layer, but as it is at / it
+# won't be copied to the final image.
 COPY --from=xx / /
 
+# From this point onwards, although everything will be executed at the
+# host architecture, it will fork and run separately for each target
+# arch/platform.
 ARG TARGETPLATFORM TARGETARCH
 RUN mkdir -p /run/lock
 
-# Install system packages using builder image that has zypper 
-COPY --from=micro / /chroot/
+# Set the final image base contents.
+COPY --from=final / /chroot/
 
+# The final image does not have zypper, so we amend the host zypper to
+# look for the target architecture instead, so we can avoid cross-emulation.
 RUN echo "[main]" > /etc/zypp/zypp.conf && \
     echo -n "arch = " >> /etc/zypp/zypp.conf && \
     xx-info march >> /etc/zypp/zypp.conf
 
-COPY --from=golang-arch /etc/products.d/ /etc/products.d/
-COPY --from=golang-arch /etc/zypp/ /chroot/etc/zypp/
+# Zypper uses the architecture defined on the files within /etc/products.d/
+# when fetching packages. Note that we are overriding host-based products.d
+# files, with the same files from golang for the target architecture.
+#
+# On an amd64 host and arm64 target, this will ensure the files used are based
+# on the arm64 version of /etc/products.d/.
+COPY --from=golang /etc/products.d/ /etc/products.d/
+# The zypper operations below will use an installroot. This copies the repository
+# information (based on target arch) to chroot, so that the zypper operation works.
+COPY --from=golang /etc/zypp/ /chroot/etc/zypp/
 
 # OS binaries to run kube-bench audit commands.
 # Before removing dependencies here, ensure they are not needed by cis-operator,
@@ -31,26 +42,28 @@ COPY --from=golang-arch /etc/zypp/ /chroot/etc/zypp/
 RUN zypper --non-interactive refresh && \
     zypper --installroot /chroot -n in --no-recommends findutils tar jq gawk diffutils procps systemd gzip curl && \
     zypper --installroot /chroot clean -a && \
-    rm -rf /chroot/var/cache/zypp/* /chroot/var/log/zypp/*
+    rm -rf /chroot/var/cache/zypp/* /chroot/var/log/zypp/* /chroot/etc/zypp/
 
+# Safety net to ensure we did not mess up on the zypper operations above,
+# and that the binaries are valid for the target architecture.
 RUN xx-verify /chroot/usr/bin/curl && \
     xx-verify /chroot/usr/bin/diff && \
     xx-verify /chroot/usr/bin/tar && \
     xx-verify /chroot/usr/bin/jq && \
     xx-verify /chroot/usr/bin/gzip
 
-# Define build arguments
+# Define build arguments.
 ARG KUBE_BENCH_VERSION KUBE_BENCH_SUM_arm64 KUBE_BENCH_SUM_amd64 \
     SONOBUOY_VERSION SONOBUOY_SUM_arm64 SONOBUOY_SUM_amd64 \
     KUBECTL_VERSION KUBECTL_SUM_arm64 KUBECTL_SUM_amd64
 
-# Stage Sonobuoy into builder
+# Stage Sonobuoy into builder.
 ENV SONOBUOY_SUM="SONOBUOY_SUM_${TARGETARCH}"
 RUN curl --output /tmp/sonobuoy.tar.gz -sLf "https://github.com/vmware-tanzu/sonobuoy/releases/download/v${SONOBUOY_VERSION}/sonobuoy_${SONOBUOY_VERSION}_linux_${TARGETARCH}.tar.gz" && \
     echo "${!SONOBUOY_SUM}  /tmp/sonobuoy.tar.gz" | sha256sum -c - && \
     tar -xvzf /tmp/sonobuoy.tar.gz -C /chroot/usr/bin sonobuoy
 
-# Stage kubectl into builder
+# Stage kubectl into builder.
 ADD --chown=root:root --chmod=0755 \
     "https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \
     /chroot/usr/local/bin/kubectl
@@ -58,7 +71,7 @@ ADD --chown=root:root --chmod=0755 \
 ENV KUBECTL_SUM="KUBECTL_SUM_${TARGETARCH}"
 RUN echo "${!KUBECTL_SUM}  /chroot/usr/local/bin/kubectl" | sha256sum -c -
 
-# Stage kube-bench into builder
+# Stage kube-bench into builder.
 ENV KUBE_BENCH_SUM="KUBE_BENCH_SUM_${TARGETARCH}"
 RUN curl --output /tmp/kubebench.tar.gz -sLf "https://github.com/aquasecurity/kube-bench/releases/download/v${KUBE_BENCH_VERSION}/kube-bench_${KUBE_BENCH_VERSION}_linux_${TARGETARCH}.tar.gz" && \
     echo "${!KUBE_BENCH_SUM}  /tmp/kubebench.tar.gz" | sha256sum -c - && \
@@ -80,6 +93,7 @@ COPY pkg /src/pkg
 COPY hack /src/hack
 COPY cmd /src/cmd
 
+# Wraps the go compiler so that it automatically takes into account TARGETPLATFORM.
 RUN xx-go --wrap 
 
 # By setting the version as an argument, we can avoid running the version logic 
@@ -88,8 +102,7 @@ RUN xx-go --wrap
 ARG VERSION
 RUN VERSION=${VERSION} TARGET_BIN=/chroot/usr/bin/kb-summarizer make build
 
-# Ensures that the binary that was built was cross-compiled correctly
-# and is valid on the target platform.
+# Ensures that the binary that was built is valid for the target platform.
 RUN xx-verify --static /chroot/usr/bin/kb-summarizer
 
 # Main stage using bci-micro as the base image

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -105,14 +105,16 @@ RUN VERSION=${VERSION} TARGET_BIN=/chroot/usr/bin/kb-summarizer make build
 # Ensures that the binary that was built is valid for the target platform.
 RUN xx-verify --static /chroot/usr/bin/kb-summarizer
 
-# Main stage using bci-micro as the base image
-FROM micro
+# Override kube-bench cfg files without duplicating them on the final image.
+COPY package/cfg/ /chroot/etc/kube-bench/cfg/
 
-# Copy binaries and configuration files from builder and zypper to micro.
+
+# By using scratch we avoid duplicating files on the final image,
+# as otherwise the COPY below would override the differences between
+# /chroot and "final", increasing the image layer by ~10MB. 
+FROM scratch
+
 COPY --from=builder /chroot/ /
-
-# Copy binaries and configuration files from the local repository to micro
-COPY package/cfg/ /etc/kube-bench/cfg/
 COPY package/run.sh \
     package/run_sonobuoy_plugin.sh \
     package/helper_scripts/check_files_permissions.sh \

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -4,11 +4,26 @@ FROM registry.suse.com/bci/bci-micro:15.5 AS micro
 # Image that provides cross compilation tooling.
 FROM --platform=$BUILDPLATFORM rancher/mirrored-tonistiigi-xx:1.3.0 as xx
 
+FROM registry.suse.com/bci/golang:1.22 AS golang-arch
+
 # Arch-specific temporary build stage for zypper deps that will be copied into the final image.
-FROM registry.suse.com/bci/golang:1.22 AS zypper
+FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.22 AS builder
+
+# Copy xx supporting tools to throw-away layer. Not this is not being sent to /chroot.
+COPY --from=xx / /
+
+ARG TARGETPLATFORM TARGETARCH
+RUN mkdir -p /run/lock
 
 # Install system packages using builder image that has zypper 
 COPY --from=micro / /chroot/
+
+RUN echo "[main]" > /etc/zypp/zypp.conf && \
+    echo -n "arch = " >> /etc/zypp/zypp.conf && \
+    xx-info march >> /etc/zypp/zypp.conf
+
+COPY --from=golang-arch /etc/products.d/ /etc/products.d/
+COPY --from=golang-arch /etc/zypp/ /chroot/etc/zypp/
 
 # OS binaries to run kube-bench audit commands.
 # Before removing dependencies here, ensure they are not needed by cis-operator,
@@ -18,17 +33,16 @@ RUN zypper --non-interactive refresh && \
     zypper --installroot /chroot clean -a && \
     rm -rf /chroot/var/cache/zypp/* /chroot/var/log/zypp/*
 
-# Arch-agnostic temporary build stage for things that can be done at build platform arch.
-FROM --platform=$BUILDPLATFORM registry.suse.com/bci/golang:1.22 AS builder
+RUN xx-verify /chroot/usr/bin/curl && \
+    xx-verify /chroot/usr/bin/diff && \
+    xx-verify /chroot/usr/bin/tar && \
+    xx-verify /chroot/usr/bin/jq && \
+    xx-verify /chroot/usr/bin/gzip
 
 # Define build arguments
 ARG KUBE_BENCH_VERSION KUBE_BENCH_SUM_arm64 KUBE_BENCH_SUM_amd64 \
     SONOBUOY_VERSION SONOBUOY_SUM_arm64 SONOBUOY_SUM_amd64 \
     KUBECTL_VERSION KUBECTL_SUM_arm64 KUBECTL_SUM_amd64
-
-ARG TARGETARCH
-
-RUN mkdir -p /chroot/usr/bin
 
 # Stage Sonobuoy into builder
 ENV SONOBUOY_SUM="SONOBUOY_SUM_${TARGETARCH}"
@@ -66,11 +80,7 @@ COPY pkg /src/pkg
 COPY hack /src/hack
 COPY cmd /src/cmd
 
-# Copy xx supporting tools to throw-away layer, not to /chroot.
-COPY --from=xx / /
-
-ARG TARGETPLATFORM
-RUN xx-go --wrap && mkdir -p /run/lock
+RUN xx-go --wrap 
 
 # By setting the version as an argument, we can avoid running the version logic 
 # a second time (inside the Docker build process). Therefore, removing the need
@@ -87,7 +97,6 @@ FROM micro
 
 # Copy binaries and configuration files from builder and zypper to micro.
 COPY --from=builder /chroot/ /
-COPY --from=zypper /chroot/ /
 
 # Copy binaries and configuration files from the local repository to micro
 COPY package/cfg/ /etc/kube-bench/cfg/


### PR DESCRIPTION
This PR aims to remove cross emulation running `zypper` when building images where the target architecture is different than the one at the host. Based solely on the time taken to run `image-test` in CI, the execution time dropped from [3m4s](https://github.com/rancher/security-scan/actions/runs/8203868261/job/22437457248) to [1m35s](https://github.com/rancher/security-scan/actions/runs/8208381590/job/22451733783).

The host-based `zypper` install vs targeting a different architecture now only costs 50% more:
```
 => [linux/amd64 builder  8/23] RUN zypper --non-interactive refresh &&     zypper --installroot /chroot -n in --no-recommends findutils tar jq gawk diffutils procps systemd gzip cu  21.5s
 => [linux/amd64->arm64 builder  8/23] RUN zypper --non-interactive refresh &&     zypper --installroot /chroot -n in --no-recommends findutils tar jq gawk diffutils procps systemd   31.3s
```

When cross emulated, `zypper` was several times slower:
```
=> [linux/amd64 zypper 3/3] RUN zypper --non-interactive refresh &&     zypper --installroot /chroot -n in --no-recommends findutils tar jq gawk diffutils procps systemd gzip curl   32.9s
=> [linux/arm64 zypper 3/3] RUN zypper --non-interactive refresh &&     zypper --installroot /chroot -n in --no-recommends findutils tar jq gawk diffutils procps systemd gzip curl  132.6s
```

As part of the changes, the documentation was reviewed and improved to clarify some of the decisions around the `Dockerfile`. Some operations were changed slightly to reduce the amount of file duplication in the final image.