### PR TITLE
Enable auto-bump for kube-bench and sonobuoy

### DIFF
--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -1,16 +1,21 @@
+# renovate: datasource=github-release-attachments depName=kubernetes-sigs/kind
 KIND_VERSION ?= 0.17.0
 KUBERNETES_VERSION ?= v$(KUBECTL_VERSION)
 
-KUBE_BENCH_VERSION ?= 0.7.0
-# github release / kube-bench_${KUBE_BENCH_VERSION}_checksums.txt
+# renovate: datasource=github-release-attachments depName=aquasecurity/kube-bench
+KUBE_BENCH_VERSION ?= v0.7.0
+# renovate: datasource=github-release-attachments depName=aquasecurity/kube-bench digestVersion=v0.7.0
 KUBE_BENCH_SUM_arm64 ?= 53da250a3211d717378e6ef37ee541d2cd212953628b064f2f7e2ca8a5a7bb57
+# renovate: datasource=github-release-attachments depName=aquasecurity/kube-bench digestVersion=v0.7.0
 KUBE_BENCH_SUM_amd64 ?= e9ede7c6f3570cf8f4e81925cd2523fc9c3442fb8304477637f231c7b4647e7d
 
-SONOBUOY_VERSION ?= 0.57.0
-SONOBUOY_IMAGE ?= rancher/mirrored-sonobuoy-sonobuoy:v$(SONOBUOY_VERSION)
+# renovate: datasource=github-release-attachments depName=vmware-tanzu/sonobuoy
+SONOBUOY_VERSION ?= v0.57.0
+SONOBUOY_IMAGE ?= rancher/mirrored-sonobuoy-sonobuoy:$(SONOBUOY_VERSION)
 
-# github release / sonobuoy_${SONOBUOY_VERSION}_checksums.txt
+# renovate: datasource=github-release-attachments depName=vmware-tanzu/sonobuoy digestVersion=v0.57.0
 SONOBUOY_SUM_arm64 ?= 75c6f1d590ade2de2fbe59d53ff8005ff99d31517f2f12a6a36a03573f7e73c3
+# renovate: datasource=github-release-attachments depName=vmware-tanzu/sonobuoy digestVersion=v0.57.0
 SONOBUOY_SUM_amd64 ?= f9006ed997fd5a701b34a96786efffa52d5e77873bfc717bc252c2e5ef8a7f3c
 
 KUBECTL_VERSION ?= 1.28.3

--- a/hack/make/tools.mk
+++ b/hack/make/tools.mk
@@ -10,7 +10,7 @@ $(GOLINT): ## Download golint locally if not yet downloaded.
 
 KUBE_BENCH = $(TOOLS_BIN)/kube-bench
 $(KUBE_BENCH): ## Download kube-bench locally if not yet downloaded.
-	$(call go-install-tool,$(KUBE_BENCH),github.com/aquasecurity/kube-bench@v$(KUBE_BENCH_VERSION))
+	$(call go-install-tool,$(KUBE_BENCH),github.com/aquasecurity/kube-bench@$(KUBE_BENCH_VERSION))
 
 KIND = $(TOOLS_BIN)/kind
 $(KIND): ## Download kind locally if not yet downloaded.

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -59,7 +59,7 @@ ARG KUBE_BENCH_VERSION KUBE_BENCH_SUM_arm64 KUBE_BENCH_SUM_amd64 \
 
 # Stage Sonobuoy into builder.
 ENV SONOBUOY_SUM="SONOBUOY_SUM_${TARGETARCH}"
-RUN curl --output /tmp/sonobuoy.tar.gz -sLf "https://github.com/vmware-tanzu/sonobuoy/releases/download/v${SONOBUOY_VERSION}/sonobuoy_${SONOBUOY_VERSION}_linux_${TARGETARCH}.tar.gz" && \
+RUN curl --output /tmp/sonobuoy.tar.gz -sLf "https://github.com/vmware-tanzu/sonobuoy/releases/download/${SONOBUOY_VERSION}/sonobuoy_${SONOBUOY_VERSION#v}_linux_${TARGETARCH}.tar.gz" && \
     echo "${!SONOBUOY_SUM}  /tmp/sonobuoy.tar.gz" | sha256sum -c - && \
     tar -xvzf /tmp/sonobuoy.tar.gz -C /chroot/usr/bin sonobuoy
 
@@ -73,14 +73,14 @@ RUN echo "${!KUBECTL_SUM}  /chroot/usr/local/bin/kubectl" | sha256sum -c -
 
 # Stage kube-bench into builder.
 ENV KUBE_BENCH_SUM="KUBE_BENCH_SUM_${TARGETARCH}"
-RUN curl --output /tmp/kubebench.tar.gz -sLf "https://github.com/aquasecurity/kube-bench/releases/download/v${KUBE_BENCH_VERSION}/kube-bench_${KUBE_BENCH_VERSION}_linux_${TARGETARCH}.tar.gz" && \
+RUN curl --output /tmp/kubebench.tar.gz -sLf "https://github.com/aquasecurity/kube-bench/releases/download/${KUBE_BENCH_VERSION}/kube-bench_${KUBE_BENCH_VERSION#v}_linux_${TARGETARCH}.tar.gz" && \
     echo "${!KUBE_BENCH_SUM}  /tmp/kubebench.tar.gz" | sha256sum -c - && \
     tar -xvzf /tmp/kubebench.tar.gz -C /chroot/usr/bin
 
 # Copy the files within /cfg straight from the immutable GitHub source to /etc/kube-bench/cfg/ into micro
 RUN mkdir -p /chroot/etc/kube-bench/ && \
-    curl -sLf "https://github.com/aquasecurity/kube-bench/archive/refs/tags/v${KUBE_BENCH_VERSION}.tar.gz" | \
-    tar xvz -C /chroot/etc/kube-bench/ --strip-components=1 "kube-bench-${KUBE_BENCH_VERSION}/cfg"
+    curl -sLf "https://github.com/aquasecurity/kube-bench/archive/refs/tags/${KUBE_BENCH_VERSION}.tar.gz" | \
+    tar xvz -C /chroot/etc/kube-bench/ --strip-components=1 "kube-bench-${KUBE_BENCH_VERSION#v}/cfg"
 
 WORKDIR /src
 COPY go.sum \


### PR DESCRIPTION
Uses the latest changes from https://github.com/rancher/renovate-config/pull/243 to enable auto bump for Sonobuoy and kube-bench. Kubectl will be handled as a separated PR, as it cannot be sourced from github releases.