### PR TITLE
Auto-source KUBECTL digest

### DIFF
--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -19,10 +19,8 @@ SONOBUOY_SUM_arm64 ?= 75c6f1d590ade2de2fbe59d53ff8005ff99d31517f2f12a6a36a03573f
 SONOBUOY_SUM_amd64 ?= f9006ed997fd5a701b34a96786efffa52d5e77873bfc717bc252c2e5ef8a7f3c
 
 KUBECTL_VERSION ?= 1.28.7
-# curk -L "https://dl.k8s.io/release/v$KUBECTL_VERSION/bin/linux/arm64/kubectl.sha256"
-KUBECTL_SUM_arm64 ?= 13d547495bdea49b223fe06bffb6d2bef96436634847f759107655aa80fc990e
-# curk -L "https://dl.k8s.io/release/v$KUBECTL_VERSION/bin/linux/amd64/kubectl.sha256"
-KUBECTL_SUM_amd64 ?= aff42d3167685e4d8e86fda0ad9c6ce6ec6c047bc24d608041d54717a18192ba
+KUBECTL_SUM_arm64 ?= $(shell curl -L "https://dl.k8s.io/release/v$(KUBECTL_VERSION)/bin/linux/arm64/kubectl.sha256")
+KUBECTL_SUM_amd64 ?= $(shell curl -L "https://dl.k8s.io/release/v$(KUBECTL_VERSION)/bin/linux/amd64/kubectl.sha256")
 
 # Reduces the code duplication on Makefile by keeping all args into a single variable.
 IMAGE_ARGS := --build-arg SONOBUOY_VERSION=$(SONOBUOY_VERSION) --build-arg SONOBUOY_SUM_arm64=$(SONOBUOY_SUM_arm64) --build-arg SONOBUOY_SUM_amd64=$(SONOBUOY_SUM_amd64) \


### PR DESCRIPTION
Unfortunately, the current renovate-config does not support the sourcing of digests for kubectl. To bypass this limitation while keeping the auto bumps working, the digest will be sourced on demand based on the dl.k8s.io endpoint.