### PR TITLE
Fix audit and remediation for K3s master 1.1.20/1.1.21

### DIFF
--- a/package/cfg/k3s-cis-1.20-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.20-hardened/master.yaml
@@ -298,7 +298,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Manual)"
-        audit: "stat -c %n\ %a /var/lib/rancher/k3s/server/tls/*.crt"
+        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -309,12 +309,12 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 644 /etc/kubernetes/pki/*.crt
+          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 644 {}+
         scored: false
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "stat -c %n\ %a /var/lib/rancher/k3s/server/tls/*.key"
+        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.key' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -325,7 +325,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 600 /etc/kubernetes/pki/*.key
+          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {}+
         scored: false
 
   - id: 1.2

--- a/package/cfg/k3s-cis-1.20-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.20-permissive/master.yaml
@@ -298,7 +298,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Manual)"
-        audit: "stat -c %n\ %a /var/lib/rancher/k3s/server/tls/*.crt"
+        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -309,12 +309,12 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 644 /etc/kubernetes/pki/*.crt
+          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 644 {}+
         scored: false
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "stat -c %n\ %a /var/lib/rancher/k3s/server/tls/*.key"
+        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.key' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -325,7 +325,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 600 /etc/kubernetes/pki/*.key
+          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {}+
         scored: false
 
   - id: 1.2

--- a/package/cfg/k3s-cis-1.23-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.23-hardened/master.yaml
@@ -288,7 +288,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Manual)"
-        audit: "stat -c %n\ %a /var/lib/rancher/k3s/server/tls/*.crt"
+        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -297,14 +297,14 @@ groups:
                 op: bitmask
                 value: "644"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
+          Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 644 /etc/kubernetes/pki/*.crt
+          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 644 {}+
         scored: false
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "stat -c %n\ %a /var/lib/rancher/k3s/server/tls/*.key"
+        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.key' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -313,9 +313,9 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
+          Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 600 /etc/kubernetes/pki/*.key
+          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {}+
         scored: false
 
   - id: 1.2

--- a/package/cfg/k3s-cis-1.23-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.23-permissive/master.yaml
@@ -288,7 +288,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Manual)"
-        audit: "stat -c %n\ %a /var/lib/rancher/k3s/server/tls/*.crt"
+        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -297,14 +297,14 @@ groups:
                 op: bitmask
                 value: "644"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
+          Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 644 /etc/kubernetes/pki/*.crt
+          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 644 {}+
         scored: false
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "stat -c %n\ %a /var/lib/rancher/k3s/server/tls/*.key"
+        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.key' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -313,9 +313,9 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
+          Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 600 /etc/kubernetes/pki/*.key
+          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {}+
         scored: false
 
   - id: 1.2

--- a/package/cfg/k3s-cis-1.24-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/master.yaml
@@ -288,7 +288,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"
-        audit: "stat -c %n\ %a /var/lib/rancher/k3s/server/tls/*.crt"
+        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -297,14 +297,14 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
+          Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 600 /etc/kubernetes/pki/*.crt
+          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 600 {}+
         scored: false
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "stat -c %n\ %a /var/lib/rancher/k3s/server/tls/*.key"
+        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.key' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -313,9 +313,9 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
+          Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 600 /etc/kubernetes/pki/*.key
+          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {}+
         scored: false
 
   - id: 1.2

--- a/package/cfg/k3s-cis-1.24-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/master.yaml
@@ -287,8 +287,8 @@ groups:
         scored: true
 
       - id: 1.1.20
-        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Automated)"
-        audit: "stat -c %n\ %a /var/lib/rancher/k3s/server/tls/*.crt"
+        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"
+        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -297,14 +297,14 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
+          Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 600 /etc/kubernetes/pki/*.crt
+          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 600 {}+
         scored: false
 
       - id: 1.1.21
-        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Automated)"
-        audit: "stat -c %n\ %a /var/lib/rancher/k3s/server/tls/*.key"
+        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
+        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.key' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -313,9 +313,9 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
+          Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 600 /etc/kubernetes/pki/*.key
+          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {}+
         scored: false
 
   - id: 1.2

--- a/package/cfg/k3s-cis-1.6-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.6-hardened/master.yaml
@@ -283,7 +283,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Manual)"
-        audit: "stat -c %n\ %a /var/lib/rancher/k3s/server/tls/*.crt"
+        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -294,12 +294,12 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 644 /etc/kubernetes/pki/*.crt
+          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 644 {}+
         scored: false
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "stat -c %n\ %a /var/lib/rancher/k3s/server/tls/*.key"
+        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.key' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -310,7 +310,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 600 /etc/kubernetes/pki/*.key
+          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {}+
         scored: false
 
   - id: 1.2

--- a/package/cfg/k3s-cis-1.6-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.6-permissive/master.yaml
@@ -265,7 +265,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 644 or more restrictive (Manual)"
-        audit: "stat -c %n\ %a /var/lib/rancher/k3s/server/tls/*.crt"
+        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -276,12 +276,12 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 644 /etc/kubernetes/pki/*.crt
+          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 644 {}+
         scored: false
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "stat -c %n\ %a /var/lib/rancher/k3s/server/tls/*.key"
+        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.key' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -292,7 +292,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 600 /etc/kubernetes/pki/*.key
+          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {}+
         scored: false
 
   - id: 1.2

--- a/package/cfg/k3s-cis-1.7-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/master.yaml
@@ -300,7 +300,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"
-        audit: "stat -c %n\ %a /var/lib/rancher/k3s/server/tls/*.crt"
+        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -309,14 +309,14 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
+          Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 600 /etc/kubernetes/pki/*.crt
+          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 600 {}+
         scored: false
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "stat -c %n\ %a /var/lib/rancher/k3s/server/tls/*.key"
+        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.key' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -325,9 +325,9 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
+          Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 600 /etc/kubernetes/pki/*.key
+          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {}+
         scored: false
 
   - id: 1.2

--- a/package/cfg/k3s-cis-1.7-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/master.yaml
@@ -300,7 +300,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"
-        audit: "stat -c %n\ %a /var/lib/rancher/k3s/server/tls/*.crt"
+        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -309,14 +309,14 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
+          Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 600 /etc/kubernetes/pki/*.crt
+          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 600 {}+
         scored: false
 
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "stat -c %n\ %a /var/lib/rancher/k3s/server/tls/*.key"
+        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.key' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -325,9 +325,9 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
+          Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 600 /etc/kubernetes/pki/*.key
+          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {}+
         scored: false
 
   - id: 1.2

--- a/package/cfg/k3s-cis-1.8-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/master.yaml
@@ -281,7 +281,7 @@ groups:
         scored: true
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"
-        audit: "stat -c %n %a /var/lib/rancher/k3s/server/tls/*.crt"
+        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -290,13 +290,13 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
+          Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 600 /etc/kubernetes/pki/*.crt
+          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 600 {}+
         scored: false
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "stat -c %n %a /var/lib/rancher/k3s/server/tls/*.key"
+        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.key' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -305,9 +305,9 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
+          Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 600 /etc/kubernetes/pki/*.key
+          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {}+
         scored: false
   - id: 1.2
     text: "API Server"

--- a/package/cfg/k3s-cis-1.8-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/master.yaml
@@ -281,7 +281,7 @@ groups:
         scored: true
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"
-        audit: "stat -c %n %a /var/lib/rancher/k3s/server/tls/*.crt"
+        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -290,13 +290,13 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
+          Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 600 /etc/kubernetes/pki/*.crt
+          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 600 {}+
         scored: false
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "stat -c %n %a /var/lib/rancher/k3s/server/tls/*.key"
+        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.key' | xargs stat -c permissions=%a"
         use_multiple_values: true
         tests:
           test_items:
@@ -305,9 +305,9 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
+          Run the below command (based on the file location on your system) on the master node.
           For example,
-          chmod -R 600 /etc/kubernetes/pki/*.key
+          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {}+
         scored: false
   - id: 1.2
     text: "API Server"


### PR DESCRIPTION
### Context

The tests `1.1.20` and `1.1.21` for the K3s's profiles are written in a manner that consistently make leads to failure and then return a `WARN`. Indeed, the flag is expecting `permissions=<perm>` however in the current `audit`, the command returns:
` <path> <perm>`

### Resolution

This PR fixes all profiles from 1.6 to 1.8 for K3s (permissive and hardened) master tests 1.1.20 and 1.1.21, to find and return file's permissions, in the following format:
`permissions=<perm>`

linked issues: https://github.com/rancher/cis-operator/issues/290, https://github.com/rancher/cis-operator/issues/291 and https://github.com/rancher/cis-operator/issues/292