### PR TITLE
k3s profiles: fix remediation for 1.1.20 and 1.1.21 checks

### DIFF
--- a/package/cfg/k3s-cis-1.23-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.23-hardened/master.yaml
@@ -299,7 +299,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 644 {}+
+          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 644 {} +
         scored: false
 
       - id: 1.1.21
@@ -315,7 +315,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {}+
+          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {} +
         scored: false
 
   - id: 1.2

--- a/package/cfg/k3s-cis-1.23-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.23-permissive/master.yaml
@@ -299,7 +299,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 644 {}+
+          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 644 {} +
         scored: false
 
       - id: 1.1.21
@@ -315,7 +315,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {}+
+          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {} +
         scored: false
 
   - id: 1.2

--- a/package/cfg/k3s-cis-1.24-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/master.yaml
@@ -299,7 +299,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 600 {}+
+          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 600 {} +
         scored: false
 
       - id: 1.1.21
@@ -315,7 +315,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {}+
+          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {} +
         scored: false
 
   - id: 1.2

--- a/package/cfg/k3s-cis-1.24-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/master.yaml
@@ -299,7 +299,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 600 {}+
+          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 600 {} +
         scored: false
 
       - id: 1.1.21
@@ -315,7 +315,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {}+
+          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {} +
         scored: false
 
   - id: 1.2

--- a/package/cfg/k3s-cis-1.7-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/master.yaml
@@ -311,7 +311,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 600 {}+
+          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 600 {} +
         scored: false
 
       - id: 1.1.21
@@ -327,7 +327,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {}+
+          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {} +
         scored: false
 
   - id: 1.2

--- a/package/cfg/k3s-cis-1.7-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/master.yaml
@@ -311,7 +311,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 600 {}+
+          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 600 {} +
         scored: false
 
       - id: 1.1.21
@@ -327,7 +327,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {}+
+          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {} +
         scored: false
 
   - id: 1.2

--- a/package/cfg/k3s-cis-1.8-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/master.yaml
@@ -292,7 +292,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 600 {}+
+          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 600 {} +
         scored: false
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
@@ -307,7 +307,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {}+
+          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {} +
         scored: false
   - id: 1.2
     text: "API Server"

--- a/package/cfg/k3s-cis-1.8-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/master.yaml
@@ -292,7 +292,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 600 {}+
+          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 600 {} +
         scored: false
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
@@ -307,7 +307,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {}+
+          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {} +
         scored: false
   - id: 1.2
     text: "API Server"


### PR DESCRIPTION
https://github.com/rancher/cis-operator/issues/290, https://github.com/rancher/cis-operator/issues/291 and https://github.com/rancher/cis-operator/issues/292

fix command in remediation text for 1.1.20 and 1.1.21 checks.
existing command when used in shell was giving an error:
```find: missing argument to `-exec'```


