### PR TITLE
kube-bench version bump to v0.7.3

### DIFF
--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -3,11 +3,11 @@ KIND_VERSION ?= 0.23.0
 KUBERNETES_VERSION ?= v$(KUBECTL_VERSION)
 
 # renovate: datasource=github-release-attachments depName=aquasecurity/kube-bench
-KUBE_BENCH_VERSION ?= v0.7.0
+KUBE_BENCH_VERSION ?= v0.7.3
 # renovate: datasource=github-release-attachments depName=aquasecurity/kube-bench digestVersion=v0.7.0
-KUBE_BENCH_SUM_arm64 ?= 53da250a3211d717378e6ef37ee541d2cd212953628b064f2f7e2ca8a5a7bb57
+KUBE_BENCH_SUM_arm64 ?= c51f646fb873bd2333352e5d5c83a231390cedbe2207ed2ee4ceb86e069160f6
 # renovate: datasource=github-release-attachments depName=aquasecurity/kube-bench digestVersion=v0.7.0
-KUBE_BENCH_SUM_amd64 ?= e9ede7c6f3570cf8f4e81925cd2523fc9c3442fb8304477637f231c7b4647e7d
+KUBE_BENCH_SUM_amd64 ?= 023884c27593aee37e2e28331158a6a415a0ac2875dd71b2e14881368a527486
 
 # renovate: datasource=github-release-attachments depName=vmware-tanzu/sonobuoy
 SONOBUOY_VERSION ?= v0.57.1


### PR DESCRIPTION
### Updates

- `kube-bench` version bump to `v0.7.3`

### Fixes 

- https://github.com/rancherlabs/image-scanning/issues/3357