### PR TITLE
Use variables instead of hardcoded values when possible in RKE2 CIS

### DIFF
--- a/package/cfg/config.yaml
+++ b/package/cfg/config.yaml
@@ -45,6 +45,8 @@ master:
       - /etc/kubernetes/manifests/kube-scheduler.manifest
       - /var/snap/kube-scheduler/current/args
       - /var/lib/rancher/rke2/agent/pod-manifests/kube-scheduler.yaml
+    kubeconfig:
+      - /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig
     defaultconf: /etc/kubernetes/manifests/kube-scheduler.yaml
 
   controllermanager:
@@ -60,12 +62,17 @@ master:
       - /etc/kubernetes/manifests/kube-controller-manager.manifest
       - /var/snap/kube-controller-manager/current/args
       - /var/lib/rancher/rke2/agent/pod-manifests/kube-controller-manager.yaml
+    kubeconfig:
+      - /var/lib/rancher/rke2/server/cred/controller.kubeconfig
     defaultconf: /etc/kubernetes/manifests/kube-controller-manager.yaml
 
   etcd:
     optional: true
     bins:
       - "etcd"
+    datadirs:
+      - /var/lib/rancher/k3s/server/db/etcd
+      - /var/lib/rancher/rke2/server/db/etcd
     confs:
       - /etc/kubernetes/manifests/etcd.yaml
       - /etc/kubernetes/manifests/etcd.manifest
@@ -170,6 +177,9 @@ etcd:
     bins:
       - "etcd"
       - "containerd"
+    datadirs:
+      - /var/lib/rancher/k3s/server/db/etcd
+      - /var/lib/rancher/rke2/server/db/etcd
     confs:
       - /etc/kubernetes/manifests/etcd.yaml
       - /etc/kubernetes/manifests/etcd.manifest

--- a/package/cfg/rke2-cis-1.23-hardened/config.yaml
+++ b/package/cfg/rke2-cis-1.23-hardened/config.yaml
@@ -21,6 +21,8 @@ master:
       - kube-scheduler
     confs:
       - /var/lib/rancher/rke2/agent/pod-manifests/kube-scheduler.yaml
+    kubeconfig:
+      - /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig
     defaultconf: /var/lib/rancher/rke2/agent/pod-manifests/kube-scheduler.yaml
 
   controllermanager:
@@ -28,6 +30,8 @@ master:
       - kube-controller-manager
     confs:
       - /var/lib/rancher/rke2/agent/pod-manifests/kube-controller-manager.yaml
+    kubeconfig:
+      - /var/lib/rancher/rke2/server/cred/controller.kubeconfig
     defaultconf: /var/lib/rancher/rke2/agent/pod-manifests/kube-controller-manager.yaml
 
   etcd:
@@ -35,6 +39,8 @@ master:
       - etcd
     confs:
       - /var/lib/rancher/rke2/agent/pod-manifests/etcd.yaml
+    datadirs:
+      - /var/lib/rancher/rke2/server/db/etcd
     defaultconf: /var/lib/rancher/rke2/agent/pod-manifests/etcd.yaml
 
   node:

--- a/package/cfg/rke2-cis-1.23-hardened/etcd.yaml
+++ b/package/cfg/rke2-cis-1.23-hardened/etcd.yaml
@@ -130,8 +130,7 @@ groups:
         scored: true
 
       - id: 2.4
-        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are
-        set as appropriate (Automated)"
+        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
         audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
         tests:
           bin_op: and

--- a/package/cfg/rke2-cis-1.23-hardened/etcd.yaml
+++ b/package/cfg/rke2-cis-1.23-hardened/etcd.yaml
@@ -42,7 +42,7 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/db/etcd"
+        audit: "stat -c permissions=%a $etcddatadir"
         tests:
           test_items:
             - flag: "permissions"
@@ -53,12 +53,12 @@ groups:
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.
           Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
+          chmod 700 $etcddatadir
         scored: true
 
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
-        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/db/etcd"
+        audit: "stat -c %U:%G $etcddatadir"
         tests:
           test_items:
             - flag: "etcd:etcd"

--- a/package/cfg/rke2-cis-1.23-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.23-hardened/master.yaml
@@ -98,8 +98,7 @@ groups:
 
       - id: 1.1.7
         text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
-        use_multiple_values: true
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c permissions=%a $etcdconf; fi'"
         tests:
           test_items:
             - flag: "permissions"

--- a/package/cfg/rke2-cis-1.23-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.23-hardened/master.yaml
@@ -95,7 +95,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chown root:root $schedulerconf
         scored: true
-      
+
       - id: 1.1.7
         text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
         audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
@@ -127,7 +127,7 @@ groups:
           For example,
           chown root:root $etcdconf
         scored: true
-        
+
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Manual)"
         audit: |

--- a/package/cfg/rke2-cis-1.23-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.23-hardened/master.yaml
@@ -10,7 +10,7 @@ groups:
     checks:
       - id: 1.1.1
         text: "Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Automated)"
-        audit: "stat -c permissions=%a /var/lib/rancher/rke2/agent/pod-manifests/kube-apiserver.yaml"
+        audit: "stat -c permissions=%a $apiserverconf"
         tests:
           test_items:
             - flag: "permissions"
@@ -95,7 +95,39 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chown root:root $schedulerconf
         scored: true
+      
+      - id: 1.1.7
+        text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod 600 $etcdconf
+        scored: true
 
+      - id: 1.1.8
+        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+              compare:
+                op: eq
+                value: "root:root"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root $etcdconf
+        scored: true
+        
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Manual)"
         audit: |
@@ -140,7 +172,7 @@ groups:
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 /etc/kubernetes/admin.conf
+          For example, chmod 600 /var/lib/rancher/rke2/server/cred/admin.kubeconfig
         scored: true
 
       - id: 1.1.14
@@ -160,7 +192,7 @@ groups:
 
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig"
+        audit: "stat -c permissions=%a $schedulerkubeconfig"
         tests:
           test_items:
             - flag: "permissions"
@@ -175,7 +207,7 @@ groups:
 
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
-        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig"
+        audit: "stat -c %U:%G $schedulerkubeconfig"
         tests:
           test_items:
             - flag: "root:root"
@@ -191,7 +223,7 @@ groups:
 
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/cred/controller.kubeconfig"
+        audit: "stat -c permissions=%a $controllermanagerkubeconfig"
         tests:
           test_items:
             - flag: "permissions"
@@ -206,7 +238,7 @@ groups:
 
       - id: 1.1.18
         text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
-        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/cred/controller.kubeconfig"
+        audit: "stat -c %U:%G $controllermanagerkubeconfig"
         tests:
           test_items:
             - flag: "root:root"

--- a/package/cfg/rke2-cis-1.23-permissive/config.yaml
+++ b/package/cfg/rke2-cis-1.23-permissive/config.yaml
@@ -21,6 +21,8 @@ master:
       - kube-scheduler
     confs:
       - /var/lib/rancher/rke2/agent/pod-manifests/kube-scheduler.yaml
+    kubeconfig:
+      - /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig
     defaultconf: /var/lib/rancher/rke2/agent/pod-manifests/kube-scheduler.yaml
 
   controllermanager:
@@ -28,6 +30,8 @@ master:
       - kube-controller-manager
     confs:
       - /var/lib/rancher/rke2/agent/pod-manifests/kube-controller-manager.yaml
+    kubeconfig:
+      - /var/lib/rancher/rke2/server/cred/controller.kubeconfig
     defaultconf: /var/lib/rancher/rke2/agent/pod-manifests/kube-controller-manager.yaml
 
   etcd:
@@ -35,6 +39,8 @@ master:
       - etcd
     confs:
       - /var/lib/rancher/rke2/agent/pod-manifests/etcd.yaml
+    datadirs:
+      - /var/lib/rancher/rke2/server/db/etcd
     defaultconf: /var/lib/rancher/rke2/agent/pod-manifests/etcd.yaml
 
   node:

--- a/package/cfg/rke2-cis-1.23-permissive/etcd.yaml
+++ b/package/cfg/rke2-cis-1.23-permissive/etcd.yaml
@@ -131,8 +131,7 @@ groups:
         scored: true
 
       - id: 2.4
-        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are
-        set as appropriate (Automated)"
+        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
         audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
         tests:
           bin_op: and

--- a/package/cfg/rke2-cis-1.23-permissive/etcd.yaml
+++ b/package/cfg/rke2-cis-1.23-permissive/etcd.yaml
@@ -42,7 +42,7 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/db/etcd"
+        audit: "stat -c permissions=%a $etcddatadir"
         tests:
           test_items:
             - flag: "permissions"
@@ -54,13 +54,13 @@ groups:
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.
           Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
+          chmod 700 $etcddatadir
         scored: true
 
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
         type: "skip"
-        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/db/etcd"
+        audit: "stat -c %U:%G $etcddatadir"
         tests:
           test_items:
             - flag: "etcd:etcd"

--- a/package/cfg/rke2-cis-1.23-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.23-permissive/master.yaml
@@ -98,8 +98,7 @@ groups:
 
       - id: 1.1.7
         text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
-        use_multiple_values: true
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c permissions=%a $etcdconf; fi'"
         tests:
           test_items:
             - flag: "permissions"

--- a/package/cfg/rke2-cis-1.23-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.23-permissive/master.yaml
@@ -127,7 +127,7 @@ groups:
           For example,
           chown root:root $etcdconf
         scored: true
-        
+
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Manual)"
         audit: |

--- a/package/cfg/rke2-cis-1.23-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.23-permissive/master.yaml
@@ -10,7 +10,7 @@ groups:
     checks:
       - id: 1.1.1
         text: "Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Automated)"
-        audit: "stat -c permissions=%a /var/lib/rancher/rke2/agent/pod-manifests/kube-apiserver.yaml"
+        audit: "stat -c permissions=%a $apiserverconf"
         tests:
           test_items:
             - flag: "permissions"
@@ -96,6 +96,38 @@ groups:
           For example, chown root:root $schedulerconf
         scored: true
 
+      - id: 1.1.7
+        text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod 600 $etcdconf
+        scored: true
+
+      - id: 1.1.8
+        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+              compare:
+                op: eq
+                value: "root:root"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root $etcdconf
+        scored: true
+        
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Manual)"
         audit: |
@@ -140,7 +172,7 @@ groups:
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 /etc/kubernetes/admin.conf
+          For example, chmod 600 /var/lib/rancher/rke2/server/cred/admin.kubeconfig
         scored: true
 
       - id: 1.1.14
@@ -160,7 +192,7 @@ groups:
 
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: "stat -c %a /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig"
+        audit: "stat -c %a $schedulerkubeconfig"
         tests:
           test_items:
             - flag: "644"
@@ -176,7 +208,7 @@ groups:
 
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
-        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig"
+        audit: "stat -c %U:%G $schedulerkubeconfig"
         tests:
           test_items:
             - flag: "root:root"
@@ -192,7 +224,7 @@ groups:
 
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 644 or more restrictive (Automated)"
-        audit: "stat -c %a /var/lib/rancher/rke2/server/cred/controller.kubeconfig"
+        audit: "stat -c %a $controllermanagerkubeconfig"
         tests:
           test_items:
             - flag: "644"
@@ -208,7 +240,7 @@ groups:
 
       - id: 1.1.18
         text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
-        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/cred/controller.kubeconfig"
+        audit: "stat -c %U:%G $controllermanagerkubeconfig"
         tests:
           test_items:
             - flag: "root:root"
@@ -236,7 +268,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
-          chown -R root:root /etc/kubernetes/pki/
+          chown -R root:root /var/lib/rancher/rke2/server/tls
         scored: true
 
       - id: 1.1.20

--- a/package/cfg/rke2-cis-1.24-hardened/config.yaml
+++ b/package/cfg/rke2-cis-1.24-hardened/config.yaml
@@ -21,6 +21,8 @@ master:
       - kube-scheduler
     confs:
       - /var/lib/rancher/rke2/agent/pod-manifests/kube-scheduler.yaml
+    kubeconfig:
+      - /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig
     defaultconf: /var/lib/rancher/rke2/agent/pod-manifests/kube-scheduler.yaml
 
   controllermanager:
@@ -28,6 +30,8 @@ master:
       - kube-controller-manager
     confs:
       - /var/lib/rancher/rke2/agent/pod-manifests/kube-controller-manager.yaml
+    kubeconfig:
+      - /var/lib/rancher/rke2/server/cred/controller.kubeconfig
     defaultconf: /var/lib/rancher/rke2/agent/pod-manifests/kube-controller-manager.yaml
 
   etcd:
@@ -35,6 +39,8 @@ master:
       - etcd
     confs:
       - /var/lib/rancher/rke2/agent/pod-manifests/etcd.yaml
+    datadirs:
+      - /var/lib/rancher/rke2/server/db/etcd
     defaultconf: /var/lib/rancher/rke2/agent/pod-manifests/etcd.yaml
 
   node:

--- a/package/cfg/rke2-cis-1.24-hardened/etcd.yaml
+++ b/package/cfg/rke2-cis-1.24-hardened/etcd.yaml
@@ -130,8 +130,7 @@ groups:
         scored: true
 
       - id: 2.4
-        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are
-        set as appropriate (Automated)"
+        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
         audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
         tests:
           bin_op: and

--- a/package/cfg/rke2-cis-1.24-hardened/etcd.yaml
+++ b/package/cfg/rke2-cis-1.24-hardened/etcd.yaml
@@ -42,7 +42,7 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/db/etcd"
+        audit: "stat -c permissions=%a $etcddatadir"
         tests:
           test_items:
             - flag: "permissions"
@@ -53,12 +53,12 @@ groups:
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.
           Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
+          chmod 700 $etcddatadir
         scored: true
 
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
-        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/db/etcd"
+        audit: "stat -c %U:%G $etcddatadir"
         tests:
           test_items:
             - flag: "etcd:etcd"

--- a/package/cfg/rke2-cis-1.24-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.24-hardened/master.yaml
@@ -98,8 +98,7 @@ groups:
 
       - id: 1.1.7
         text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
-        use_multiple_values: true
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c permissions=%a $etcdconf; fi'"
         tests:
           test_items:
             - flag: "permissions"

--- a/package/cfg/rke2-cis-1.24-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.24-hardened/master.yaml
@@ -95,7 +95,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chown root:root $schedulerconf
         scored: true
-      
+
       - id: 1.1.7
         text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
         audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
@@ -127,7 +127,7 @@ groups:
           For example,
           chown root:root $etcdconf
         scored: true
-      
+
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Manual)"
         audit: |

--- a/package/cfg/rke2-cis-1.24-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.24-hardened/master.yaml
@@ -10,7 +10,7 @@ groups:
     checks:
       - id: 1.1.1
         text: "Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Automated)"
-        audit: "stat -c permissions=%a /var/lib/rancher/rke2/agent/pod-manifests/kube-apiserver.yaml"
+        audit: "stat -c permissions=%a $apiserverconf"
         tests:
           test_items:
             - flag: "permissions"
@@ -95,7 +95,39 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chown root:root $schedulerconf
         scored: true
+      
+      - id: 1.1.7
+        text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod 600 $etcdconf
+        scored: true
 
+      - id: 1.1.8
+        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+              compare:
+                op: eq
+                value: "root:root"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root $etcdconf
+        scored: true
+      
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Manual)"
         audit: |
@@ -140,7 +172,7 @@ groups:
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 /etc/kubernetes/admin.conf
+          For example, chmod 600 /var/lib/rancher/rke2/server/cred/admin.kubeconfig
         scored: true
 
       - id: 1.1.14
@@ -160,7 +192,7 @@ groups:
 
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig"
+        audit: "stat -c permissions=%a $schedulerkubeconfig"
         tests:
           test_items:
             - flag: "permissions"
@@ -175,7 +207,7 @@ groups:
 
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
-        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig"
+        audit: "stat -c %U:%G $schedulerkubeconfig"
         tests:
           test_items:
             - flag: "root:root"
@@ -191,7 +223,7 @@ groups:
 
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/cred/controller.kubeconfig"
+        audit: "stat -c permissions=%a $controllermanagerkubeconfig"
         tests:
           test_items:
             - flag: "permissions"
@@ -206,7 +238,7 @@ groups:
 
       - id: 1.1.18
         text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
-        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/cred/controller.kubeconfig"
+        audit: "stat -c %U:%G $controllermanagerkubeconfig"
         tests:
           test_items:
             - flag: "root:root"

--- a/package/cfg/rke2-cis-1.24-permissive/config.yaml
+++ b/package/cfg/rke2-cis-1.24-permissive/config.yaml
@@ -21,6 +21,8 @@ master:
       - kube-scheduler
     confs:
       - /var/lib/rancher/rke2/agent/pod-manifests/kube-scheduler.yaml
+    kubeconfig:
+      - /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig
     defaultconf: /var/lib/rancher/rke2/agent/pod-manifests/kube-scheduler.yaml
 
   controllermanager:
@@ -28,6 +30,8 @@ master:
       - kube-controller-manager
     confs:
       - /var/lib/rancher/rke2/agent/pod-manifests/kube-controller-manager.yaml
+    kubeconfig:
+      - /var/lib/rancher/rke2/server/cred/controller.kubeconfig
     defaultconf: /var/lib/rancher/rke2/agent/pod-manifests/kube-controller-manager.yaml
 
   etcd:
@@ -35,6 +39,8 @@ master:
       - etcd
     confs:
       - /var/lib/rancher/rke2/agent/pod-manifests/etcd.yaml
+    datadirs:
+      - /var/lib/rancher/rke2/server/db/etcd
     defaultconf: /var/lib/rancher/rke2/agent/pod-manifests/etcd.yaml
 
   node:

--- a/package/cfg/rke2-cis-1.24-permissive/etcd.yaml
+++ b/package/cfg/rke2-cis-1.24-permissive/etcd.yaml
@@ -131,8 +131,7 @@ groups:
         scored: true
 
       - id: 2.4
-        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are
-        set as appropriate (Automated)"
+        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
         audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
         tests:
           bin_op: and

--- a/package/cfg/rke2-cis-1.24-permissive/etcd.yaml
+++ b/package/cfg/rke2-cis-1.24-permissive/etcd.yaml
@@ -42,7 +42,7 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/db/etcd"
+        audit: "stat -c permissions=%a $etcddatadir"
         tests:
           test_items:
             - flag: "permissions"
@@ -54,13 +54,13 @@ groups:
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.
           Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
+          chmod 700 $etcddatadir
         scored: true
 
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
         type: "skip"
-        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/db/etcd"
+        audit: "stat -c %U:%G $etcddatadir"
         tests:
           test_items:
             - flag: "etcd:etcd"

--- a/package/cfg/rke2-cis-1.24-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.24-permissive/master.yaml
@@ -98,8 +98,7 @@ groups:
 
       - id: 1.1.7
         text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
-        use_multiple_values: true
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c permissions=%a $etcdconf; fi'"
         tests:
           test_items:
             - flag: "permissions"

--- a/package/cfg/rke2-cis-1.24-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.24-permissive/master.yaml
@@ -10,7 +10,7 @@ groups:
     checks:
       - id: 1.1.1
         text: "Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Automated)"
-        audit: "stat -c permissions=%a /var/lib/rancher/rke2/agent/pod-manifests/kube-apiserver.yaml"
+        audit: "stat -c permissions=%a $apiserverconf"
         tests:
           test_items:
             - flag: "permissions"
@@ -96,6 +96,38 @@ groups:
           For example, chown root:root $schedulerconf
         scored: true
 
+      - id: 1.1.7
+        text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod 600 $etcdconf
+        scored: true
+
+      - id: 1.1.8
+        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+              compare:
+                op: eq
+                value: "root:root"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root $etcdconf
+        scored: true
+
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Manual)"
         audit: |
@@ -140,7 +172,7 @@ groups:
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 /etc/kubernetes/admin.conf
+          For example, chmod 600 /var/lib/rancher/rke2/server/cred/admin.kubeconfig
         scored: true
 
       - id: 1.1.14
@@ -160,7 +192,7 @@ groups:
 
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "stat -c %a /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig"
+        audit: "stat -c %a $schedulerkubeconfig"
         tests:
           test_items:
             - flag: "600"
@@ -176,7 +208,7 @@ groups:
 
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
-        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig"
+        audit: "stat -c %U:%G $schedulerkubeconfig"
         tests:
           test_items:
             - flag: "root:root"
@@ -192,7 +224,7 @@ groups:
 
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "stat -c %a /var/lib/rancher/rke2/server/cred/controller.kubeconfig"
+        audit: "stat -c %a $controllermanagerkubeconfig"
         tests:
           test_items:
             - flag: "600"
@@ -208,7 +240,7 @@ groups:
 
       - id: 1.1.18
         text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
-        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/cred/controller.kubeconfig"
+        audit: "stat -c %U:%G $controllermanagerkubeconfig"
         tests:
           test_items:
             - flag: "root:root"
@@ -236,7 +268,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
-          chown -R root:root /etc/kubernetes/pki/
+          chown -R root:root /var/lib/rancher/rke2/server/tls
         scored: true
 
       - id: 1.1.20

--- a/package/cfg/rke2-cis-1.7-hardened/config.yaml
+++ b/package/cfg/rke2-cis-1.7-hardened/config.yaml
@@ -39,6 +39,8 @@ master:
       - etcd
     confs:
       - /var/lib/rancher/rke2/agent/pod-manifests/etcd.yaml
+    datadirs:
+      - /var/lib/rancher/rke2/server/db/etcd
     defaultconf: /var/lib/rancher/rke2/agent/pod-manifests/etcd.yaml
 
   node:

--- a/package/cfg/rke2-cis-1.7-hardened/etcd.yaml
+++ b/package/cfg/rke2-cis-1.7-hardened/etcd.yaml
@@ -42,7 +42,7 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/db/etcd"
+        audit: "stat -c permissions=%a $etcddatadir"
         tests:
           test_items:
             - flag: "permissions"
@@ -54,13 +54,13 @@ groups:
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.
           Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
+          chmod 700 $etcddatadir
         scored: true
 
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
         type: "skip"
-        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/db/etcd"
+        audit: "stat -c %U:%G $etcddatadir"
         tests:
           test_items:
             - flag: "etcd:etcd"

--- a/package/cfg/rke2-cis-1.7-hardened/etcd.yaml
+++ b/package/cfg/rke2-cis-1.7-hardened/etcd.yaml
@@ -133,8 +133,7 @@ groups:
         scored: true
 
       - id: 2.4
-        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are
-        set as appropriate (Automated)"
+        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
         type: "skip"
         audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
         tests:

--- a/package/cfg/rke2-cis-1.7-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.7-hardened/master.yaml
@@ -98,8 +98,7 @@ groups:
 
       - id: 1.1.7
         text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
-        use_multiple_values: true
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c permissions=%a $etcdconf; fi'"
         tests:
           test_items:
             - flag: "permissions"

--- a/package/cfg/rke2-cis-1.7-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.7-hardened/master.yaml
@@ -10,7 +10,7 @@ groups:
     checks:
       - id: 1.1.1
         text: "Ensure that the API server pod specification file permissions are set to 600 or more restrictive (Automated)"
-        audit: "stat -c permissions=%a /var/lib/rancher/rke2/agent/pod-manifests/kube-apiserver.yaml"
+        audit: "stat -c permissions=%a $apiserverconf"
         tests:
           test_items:
             - flag: "permissions"
@@ -96,6 +96,38 @@ groups:
           For example, chown root:root $schedulerconf
         scored: true
 
+      - id: 1.1.7
+        text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod 600 $etcdconf
+        scored: true
+        
+      - id: 1.1.8
+        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+              compare:
+                op: eq
+                value: "root:root"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root $etcdconf
+        scored: true
+
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Manual)"
         audit: |
@@ -140,7 +172,7 @@ groups:
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 /etc/kubernetes/admin.conf
+          For example, chmod 600 /var/lib/rancher/rke2/server/cred/admin.kubeconfig
         scored: true
 
       - id: 1.1.14
@@ -176,7 +208,7 @@ groups:
 
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
-        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig"
+        audit: "stat -c %U:%G $schedulerkubeconfig"
         tests:
           test_items:
             - flag: "root:root"
@@ -208,7 +240,7 @@ groups:
 
       - id: 1.1.18
         text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
-        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/cred/controller.kubeconfig"
+        audit: "stat -c %U:%G $controllermanagerkubeconfig"
         tests:
           test_items:
             - flag: "root:root"
@@ -236,7 +268,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
-          chown -R root:root /etc/kubernetes/pki/
+          chown -R root:root /var/lib/rancher/rke2/server/tls
         scored: true
 
       - id: 1.1.20

--- a/package/cfg/rke2-cis-1.7-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.7-hardened/master.yaml
@@ -111,7 +111,7 @@ groups:
           For example,
           chmod 600 $etcdconf
         scored: true
-        
+
       - id: 1.1.8
         text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
         audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"

--- a/package/cfg/rke2-cis-1.7-permissive/config.yaml
+++ b/package/cfg/rke2-cis-1.7-permissive/config.yaml
@@ -39,6 +39,8 @@ master:
       - etcd
     confs:
       - /var/lib/rancher/rke2/agent/pod-manifests/etcd.yaml
+    datadirs:
+      - /var/lib/rancher/rke2/server/db/etcd
     defaultconf: /var/lib/rancher/rke2/agent/pod-manifests/etcd.yaml
 
   node:

--- a/package/cfg/rke2-cis-1.7-permissive/etcd.yaml
+++ b/package/cfg/rke2-cis-1.7-permissive/etcd.yaml
@@ -42,7 +42,7 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/db/etcd"
+        audit: "stat -c permissions=%a $etcddatadir"
         tests:
           test_items:
             - flag: "permissions"
@@ -54,13 +54,13 @@ groups:
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.
           Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
+          chmod 700 $etcddatadir
         scored: true
 
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
         type: "skip"
-        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/db/etcd"
+        audit: "stat -c %U:%G $etcddatadir"
         tests:
           test_items:
             - flag: "etcd:etcd"

--- a/package/cfg/rke2-cis-1.7-permissive/etcd.yaml
+++ b/package/cfg/rke2-cis-1.7-permissive/etcd.yaml
@@ -133,8 +133,7 @@ groups:
         scored: true
 
       - id: 2.4
-        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are
-        set as appropriate (Automated)"
+        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
         type: "skip"
         audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
         tests:

--- a/package/cfg/rke2-cis-1.7-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.7-permissive/master.yaml
@@ -98,8 +98,7 @@ groups:
 
       - id: 1.1.7
         text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
-        use_multiple_values: true
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c permissions=%a $etcdconf; fi'"
         tests:
           test_items:
             - flag: "permissions"

--- a/package/cfg/rke2-cis-1.7-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.7-permissive/master.yaml
@@ -10,7 +10,7 @@ groups:
     checks:
       - id: 1.1.1
         text: "Ensure that the API server pod specification file permissions are set to 600 or more restrictive (Automated)"
-        audit: "stat -c permissions=%a /var/lib/rancher/rke2/agent/pod-manifests/kube-apiserver.yaml"
+        audit: "stat -c permissions=%a $apiserverconf"
         tests:
           test_items:
             - flag: "permissions"
@@ -96,6 +96,38 @@ groups:
           For example, chown root:root $schedulerconf
         scored: true
 
+      - id: 1.1.7
+        text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod 600 $etcdconf
+        scored: true
+
+      - id: 1.1.8
+        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+              compare:
+                op: eq
+                value: "root:root"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root $etcdconf
+        scored: true
+
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Manual)"
         audit: |
@@ -140,7 +172,7 @@ groups:
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 /etc/kubernetes/admin.conf
+          For example, chmod 600 /var/lib/rancher/rke2/server/cred/admin.kubeconfig
         scored: true
 
       - id: 1.1.14
@@ -176,7 +208,7 @@ groups:
 
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
-        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig"
+        audit: "stat -c %U:%G $schedulerkubeconfig"
         tests:
           test_items:
             - flag: "root:root"
@@ -208,7 +240,7 @@ groups:
 
       - id: 1.1.18
         text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
-        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/cred/controller.kubeconfig"
+        audit: "stat -c %U:%G $controllermanagerkubeconfig"
         tests:
           test_items:
             - flag: "root:root"
@@ -236,7 +268,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
-          chown -R root:root /etc/kubernetes/pki/
+          chown -R root:root /var/lib/rancher/rke2/server/tls
         scored: true
 
       - id: 1.1.20

--- a/package/cfg/rke2-cis-1.8-hardened/config.yaml
+++ b/package/cfg/rke2-cis-1.8-hardened/config.yaml
@@ -35,6 +35,8 @@ master:
       - etcd
     confs:
       - /var/lib/rancher/rke2/agent/pod-manifests/etcd.yaml
+    datadirs:
+      - /var/lib/rancher/rke2/server/db/etcd
     defaultconf: /var/lib/rancher/rke2/agent/pod-manifests/etcd.yaml
 node:
   components:

--- a/package/cfg/rke2-cis-1.8-hardened/etcd.yaml
+++ b/package/cfg/rke2-cis-1.8-hardened/etcd.yaml
@@ -40,7 +40,7 @@ groups:
         scored: true
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/db/etcd"
+        audit: "stat -c permissions=%a $etcddatadir"
         tests:
           test_items:
             - flag: "permissions"
@@ -52,12 +52,12 @@ groups:
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.
           Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
+          chmod 700 $etcddatadir
         scored: true
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
         type: "skip"
-        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/db/etcd"
+        audit: "stat -c %U:%G $etcddatadir"
         tests:
           test_items:
             - flag: "etcd:etcd"

--- a/package/cfg/rke2-cis-1.8-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.8-hardened/master.yaml
@@ -92,8 +92,7 @@ groups:
         scored: true
       - id: 1.1.7
         text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
-        use_multiple_values: true
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c permissions=%a $etcdconf; fi'"
         tests:
           test_items:
             - flag: "permissions"

--- a/package/cfg/rke2-cis-1.8-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.8-hardened/master.yaml
@@ -10,7 +10,7 @@ groups:
     checks:
       - id: 1.1.1
         text: "Ensure that the API server pod specification file permissions are set to 600 or more restrictive (Automated)"
-        audit: "stat -c permissions=%a /var/lib/rancher/rke2/agent/pod-manifests/kube-apiserver.yaml"
+        audit: "stat -c permissions=%a $apiserverconf"
         tests:
           test_items:
             - flag: "permissions"
@@ -90,6 +90,36 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chown root:root $schedulerconf
         scored: true
+      - id: 1.1.8
+        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+              compare:
+                op: eq
+                value: "root:root"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root $etcdconf
+        scored: true
+      - id: 1.1.7
+        text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod 600 $etcdconf
+        scored: true
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Manual)"
         audit: |
@@ -132,7 +162,7 @@ groups:
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 /etc/kubernetes/admin.conf
+          For example, chmod 600 /var/lib/rancher/rke2/server/cred/admin.kubeconfig
         scored: true
       - id: 1.1.14
         text: "Ensure that the admin.conf file ownership is set to root:root (Automated)"
@@ -165,7 +195,7 @@ groups:
         scored: true
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
-        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig"
+        audit: "stat -c %U:%G $schedulerkubeconfig"
         tests:
           test_items:
             - flag: "root:root"
@@ -195,7 +225,7 @@ groups:
         scored: true
       - id: 1.1.18
         text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
-        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/cred/controller.kubeconfig"
+        audit: "stat -c %U:%G $controllermanagerkubeconfig"
         tests:
           test_items:
             - flag: "root:root"
@@ -222,7 +252,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
-          chown -R root:root /etc/kubernetes/pki/
+          chown -R root:root /var/lib/rancher/rke2/server/tls
         scored: true
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"

--- a/package/cfg/rke2-cis-1.8-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.8-hardened/master.yaml
@@ -90,21 +90,6 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chown root:root $schedulerconf
         scored: true
-      - id: 1.1.8
-        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
-        tests:
-          test_items:
-            - flag: "root:root"
-              compare:
-                op: eq
-                value: "root:root"
-              set: true
-        remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chown root:root $etcdconf
-        scored: true
       - id: 1.1.7
         text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
         audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
@@ -119,6 +104,21 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chmod 600 $etcdconf
+        scored: true
+      - id: 1.1.8
+        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+              compare:
+                op: eq
+                value: "root:root"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root $etcdconf
         scored: true
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Manual)"

--- a/package/cfg/rke2-cis-1.8-permissive/config.yaml
+++ b/package/cfg/rke2-cis-1.8-permissive/config.yaml
@@ -35,6 +35,8 @@ master:
       - etcd
     confs:
       - /var/lib/rancher/rke2/agent/pod-manifests/etcd.yaml
+    datadirs:
+      - /var/lib/rancher/rke2/server/db/etcd
     defaultconf: /var/lib/rancher/rke2/agent/pod-manifests/etcd.yaml
 node:
   components:

--- a/package/cfg/rke2-cis-1.8-permissive/etcd.yaml
+++ b/package/cfg/rke2-cis-1.8-permissive/etcd.yaml
@@ -40,7 +40,7 @@ groups:
         scored: true
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/db/etcd"
+        audit: "stat -c permissions=%a $etcddatadir"
         tests:
           test_items:
             - flag: "permissions"
@@ -52,12 +52,12 @@ groups:
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.
           Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
+          chmod 700 $etcddatadir
         scored: true
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
         type: "skip"
-        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/db/etcd"
+        audit: "stat -c %U:%G $etcddatadir"
         tests:
           test_items:
             - flag: "etcd:etcd"

--- a/package/cfg/rke2-cis-1.8-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.8-permissive/master.yaml
@@ -92,8 +92,7 @@ groups:
         scored: true
       - id: 1.1.7
         text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
-        use_multiple_values: true
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c permissions=%a $etcdconf; fi'"
         tests:
           test_items:
             - flag: "permissions"

--- a/package/cfg/rke2-cis-1.8-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.8-permissive/master.yaml
@@ -10,7 +10,7 @@ groups:
     checks:
       - id: 1.1.1
         text: "Ensure that the API server pod specification file permissions are set to 600 or more restrictive (Automated)"
-        audit: "stat -c permissions=%a /var/lib/rancher/rke2/agent/pod-manifests/kube-apiserver.yaml"
+        audit: "stat -c permissions=%a $apiserverconf"
         tests:
           test_items:
             - flag: "permissions"
@@ -90,6 +90,36 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chown root:root $schedulerconf
         scored: true
+      - id: 1.1.7
+        text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod 600 $etcdconf
+        scored: true
+      - id: 1.1.8
+        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+              compare:
+                op: eq
+                value: "root:root"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root $etcdconf
+        scored: true
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Manual)"
         audit: |
@@ -132,7 +162,7 @@ groups:
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 /etc/kubernetes/admin.conf
+          For example, chmod 600 /var/lib/rancher/rke2/server/cred/admin.kubeconfig
         scored: true
       - id: 1.1.14
         text: "Ensure that the admin.conf file ownership is set to root:root (Automated)"
@@ -165,7 +195,7 @@ groups:
         scored: true
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
-        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig"
+        audit: "stat -c %U:%G $schedulerkubeconfig"
         tests:
           test_items:
             - flag: "root:root"
@@ -195,7 +225,7 @@ groups:
         scored: true
       - id: 1.1.18
         text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
-        audit: "stat -c %U:%G /var/lib/rancher/rke2/server/cred/controller.kubeconfig"
+        audit: "stat -c %U:%G $controllermanagerkubeconfig"
         tests:
           test_items:
             - flag: "root:root"
@@ -222,7 +252,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
-          chown -R root:root /etc/kubernetes/pki/
+          chown -R root:root /var/lib/rancher/rke2/server/tls
         scored: true
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"


### PR DESCRIPTION
Various fixes for RKE2 cis scans:
- Add missing 1.1.7 and 1.1.8 checks. We pass these automatically, I am unsure why they were never included.
- Use variables instead of hard-coding values in scans, includes things like etcd data dir, various kubeconfigs,
- Replace generic and incorrect K8s "remediation" with RKE2 specific remediation that match the actual audit.