### PR TITLE
K3s etcd check fix

### DIFF
--- a/package/helper_scripts/check_for_k3s_etcd.sh
+++ b/package/helper_scripts/check_for_k3s_etcd.sh
@@ -15,7 +15,7 @@ if [[ "$(journalctl -D $JOURNAL_LOG --lines=0 2>&1 | grep -s 'No such file or di
   JOURNAL_LOG=/run/log/journal
 fi
 
-if [[ "$(journalctl -D $JOURNAL_LOG -u k3s | grep -m1 'etcd cluster' | wc -l)" -gt 0 ]]; then
+if [[ "$(journalctl -D $JOURNAL_LOG -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]]; then
     case $1 in
         "1.1.11")
             echo $(stat -c %a /var/lib/rancher/k3s/server/db/etcd);;

--- a/package/helper_scripts/check_for_k3s_etcd.sh
+++ b/package/helper_scripts/check_for_k3s_etcd.sh
@@ -10,13 +10,17 @@ handle_error() {
 
 trap 'handle_error' ERR
 
+JOURNAL_LOG="${JOURNAL_LOG:-/var/log/journal}"
+if [[ "$(journalctl -D $JOURNAL_LOG --lines=0 2>&1 | grep -s 'No such file or directory' | wc -l)" -gt 0 ]]; then
+  JOURNAL_LOG=/run/log/journal
+fi
 
-if [[ "$(journalctl -D /var/log/journal -u k3s | grep -m1 'Managed etcd cluster initializing' | wc -l)" -gt 0 ]]; then
-    case $1 in 
+if [[ "$(journalctl -D $JOURNAL_LOG -u k3s | grep -m1 'etcd cluster' | wc -l)" -gt 0 ]]; then
+    case $1 in
         "1.1.11")
             echo $(stat -c %a /var/lib/rancher/k3s/server/db/etcd);;
         "1.2.29")
-            echo $(journalctl -D /var/log/journal -u k3s | grep -m1 'Running kube-apiserver');;
+            echo $(journalctl -D $JOURNAL_LOG -u k3s | grep -m1 'Running kube-apiserver');;
         "2.1")
             echo $(grep -A 5 'client-transport-security' /var/lib/rancher/k3s/server/db/etcd/config | grep -E 'cert-file|key-file');;
         "2.2")

--- a/package/run_sonobuoy_plugin.sh
+++ b/package/run_sonobuoy_plugin.sh
@@ -64,7 +64,7 @@ mkdir -p "${RESULTS_DIR}"
 
 # etcd
 if [[ "${OVERRIDE_BENCHMARK_VERSION}" != "" ]]; then
-  if [[ "$(ps -e | grep etcd | wc -l)" -gt 0  ]]  || [[ "$(journalctl -D $JOURNAL_LOG -u k3s -u k3s-agent | grep -m1 "Managed etcd cluster initializing" | wc -l )" -gt 0 ]]; then
+  if [[ "$(ps -e | grep etcd | wc -l)" -gt 0  ]]  || [[ "$(journalctl -D $JOURNAL_LOG -u k3s -u k3s-agent | grep -m1 "etcd cluster" | wc -l )" -gt 0 ]]; then
     echo "etcd: Using OVERRIDE_BENCHMARK_VERSION=${OVERRIDE_BENCHMARK_VERSION}"
     kube-bench run \
       --targets etcd \


### PR DESCRIPTION
Fixes for the K3s etcd check

**Detection of K3s etcd**
The detection of etcd on K3s was done with `"$(journalctl -D /var/log/journal -u k3s | grep -m1 'Managed etcd cluster initializing' | wc -l)" -gt 0` but `Managed etcd cluster initializing` was only in the logs on first startup of k3s, subsequent startups of K3s had `Managed etcd cluster bootstrap already complete and initialized` in the logs. So changed the grep.

**/run/log/journal as journal dir**
Some Linux distros like SLES use /run/log/journal for the journal, fixed this in the helper script.

The CIS benchmark test now passes on a Hardened K3s installation with ETCD as datastore.