### PR TITLE
Add proper remediation info for K3s 4.2.XX sections

### DIFF
--- a/package/cfg/k3s-cis-1.23-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.23-hardened/node.yaml
@@ -415,7 +415,7 @@ groups:
         scored: true
 
       - id: 4.2.12
-        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
+        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
         type: "skip"
         tests:

--- a/package/cfg/k3s-cis-1.23-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.23-permissive/node.yaml
@@ -417,7 +417,7 @@ groups:
         scored: true
 
       - id: 4.2.12
-        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
+        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
         type: "skip"
         tests:

--- a/package/cfg/k3s-cis-1.24-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/node.yaml
@@ -376,7 +376,7 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          By default, K3s does not set the --rotate-certificates argument. If you have set this to a different value, you should remove it.
+          By default, K3s does not set the --rotate-certificates argument. If you have set this flag with a value of `false`, you should either set it to `true` or completely remove the flag.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any rotate-certificates parameter.
           If using the command line, remove the K3s flag --kublet-arg="rotate-certificates".
           Based on your system, restart the k3s service. For example,
@@ -384,7 +384,7 @@ groups:
         scored: true
 
       - id: 4.2.12
-        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
+        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Automated)"
         audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           bin_op: or
@@ -398,14 +398,13 @@ groups:
               path: '{.featureGates.RotateKubeletServerCertificate}'
               set: false
         remediation: |
-          Not Applicable.
           By default, K3s does not set the RotateKubeletServerCertificate feature gate.
           If you have enabled this feature gate, you should remove it.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any feature-gate=RotateKubeletServerCertificate parameter.
           If using the command line, remove the K3s flag --kublet-arg="feature-gate=RotateKubeletServerCertificate".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
-        scored: false
+        scored: true
 
       - id: 4.2.13
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"

--- a/package/cfg/k3s-cis-1.24-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/node.yaml
@@ -169,10 +169,10 @@ groups:
         remediation: |
           By default, K3s sets the --anonymous-auth to false. If you have set this to a different value, you
           should set it back to false. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
-          kublet-arg:
+          kubelet-arg:
           - "anonymous-auth=true"
           If using the command line, edit the K3s service file and remove the below argument.
-          --kublet-arg="anonymous-auth=true"
+          --kubelet-arg="anonymous-auth=true"
           Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
           systemctl restart k3s.service
@@ -192,10 +192,10 @@ groups:
         remediation: |
           By default, K3s does not set the --authorization-mode to AlwaysAllow.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
-          kublet-arg:
+          kubelet-arg:
           - "authorization-mode=AlwaysAllow"
           If using the command line, edit the K3s service file and remove the below argument.
-          --kublet-arg="authorization-mode=AlwaysAllow"
+          --kubelet-arg="authorization-mode=AlwaysAllow"
           Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
           systemctl restart k3s.service
@@ -231,10 +231,10 @@ groups:
         remediation: |
           By default, K3s sets the --read-only-port to 0. If you have set this to a different value, you
           should set it back to 0. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
-          kublet-arg:
+          kubelet-arg:
           - "read-only-port=XXXX"
           If using the command line, edit the K3s service file and remove the below argument.
-          --kublet-arg="read-only-port=XXXX"
+          --kubelet-arg="read-only-port=XXXX"
           Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
           systemctl restart k3s.service
@@ -256,9 +256,9 @@ groups:
           bin_op: or
         remediation: |
           If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
-          kublet-arg:
+          kubelet-arg:
           - "streaming-connection-idle-timeout=5m"
-          If using the command line, run K3s with --kublet-arg="streaming-connection-idle-timeout=5m".
+          If using the command line, run K3s with --kubelet-arg="streaming-connection-idle-timeout=5m".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: false
@@ -299,9 +299,9 @@ groups:
           bin_op: or
         remediation: |
           If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter.
-          kublet-arg:
+          kubelet-arg:
           - "make-iptables-util-chains=true"
-          If using the command line, run K3s with --kublet-arg="make-iptables-util-chains=true".
+          If using the command line, run K3s with --kubelet-arg="make-iptables-util-chains=true".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: true
@@ -334,9 +334,9 @@ groups:
         remediation: |
           By default, K3s sets the event-qps to 0. Should you wish to change this,
           If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
-          kublet-arg:
+          kubelet-arg:
           - "event-qps=<value>"
-          If using the command line, run K3s with --kublet-arg="event-qps=<value>".
+          If using the command line, run K3s with --kubelet-arg="event-qps=<value>".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: false
@@ -378,7 +378,7 @@ groups:
         remediation: |
           By default, K3s does not set the --rotate-certificates argument. If you have set this flag with a value of `false`, you should either set it to `true` or completely remove the flag.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any rotate-certificates parameter.
-          If using the command line, remove the K3s flag --kublet-arg="rotate-certificates".
+          If using the command line, remove the K3s flag --kubelet-arg="rotate-certificates".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: true
@@ -401,7 +401,7 @@ groups:
           By default, K3s does not set the RotateKubeletServerCertificate feature gate.
           If you have enabled this feature gate, you should remove it.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any feature-gate=RotateKubeletServerCertificate parameter.
-          If using the command line, remove the K3s flag --kublet-arg="feature-gate=RotateKubeletServerCertificate".
+          If using the command line, remove the K3s flag --kubelet-arg="feature-gate=RotateKubeletServerCertificate".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: true

--- a/package/cfg/k3s-cis-1.24-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/node.yaml
@@ -168,20 +168,20 @@ groups:
                 value: false
               set: true
         remediation: |
-          If using a Kubelet config file, edit the file to set `authentication: anonymous: enabled` to
-          `false`.
-          If using executable arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          `--anonymous-auth=false`
-          Based on your system, restart the kubelet service. For example,
+          By default, K3s sets the --anonymous-auth to false. If you have set this to a different value, you
+          should set it back to false. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
+          kublet-arg:
+          - "anonymous-auth=true"
+          If using the command line, edit the K3s service file and remove the below argument.
+          --kublet-arg="anonymous-auth=true"
+          Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
-          systemctl restart kubelet.service
+          systemctl restart k3s.service
         scored: true
 
       - id: 4.2.2
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
-        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode" | grep -v grep; else echo "--authorization-mode=Webhook"; fi'' '
+        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode"; else echo "--authorization-mode=Webhook"; fi'' '
         tests:
           test_items:
             - flag: --authorization-mode
@@ -191,39 +191,33 @@ groups:
                 value: AlwaysAllow
               set: true
         remediation: |
-          If using a Kubelet config file, edit the file to set `authorization.mode` to Webhook. If
-          using executable arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_AUTHZ_ARGS variable.
-          --authorization-mode=Webhook
-          Based on your system, restart the kubelet service. For example,
+          By default, K3s does not set the --authorization-mode to AlwaysAllow. 
+          If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
+          kublet-arg:
+          - "authorization-mode=AlwaysAllow"
+          If using the command line, edit the K3s service file and remove the below argument.
+          --kublet-arg="authorization-mode=AlwaysAllow"
+          Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
-          systemctl restart kubelet.service
+          systemctl restart k3s.service
         scored: true
 
       - id: 4.2.3
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
-        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file" | grep -v grep; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
+        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file"; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
         tests:
           test_items:
             - flag: --client-ca-file
               path: '{.authentication.x509.clientCAFile}'
               set: true
         remediation: |
-          If using a Kubelet config file, edit the file to set `authentication.x509.clientCAFile` to
-          the location of the client CA file.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_AUTHZ_ARGS variable.
-          --client-ca-file=<path/to/client-ca-file>
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          By default, K3s automatically provides the client ca certificate for the Kubelet.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/client-ca.crt
         scored: true
 
       - id: 4.2.4
         text: "Verify that the --read-only-port argument is set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'read-only-port' "
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -236,19 +230,20 @@ groups:
               path: '{.readOnlyPort}'
               set: false
         remediation: |
-          If using a Kubelet config file, edit the file to set `readOnlyPort` to 0.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          --read-only-port=0
-          Based on your system, restart the kubelet service. For example,
+          By default, K3s sets the --read-only-port to 0. If you have set this to a different value, you
+          should set it back to 0. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
+          kublet-arg:
+          - "read-only-port=XXXX"
+          If using the command line, edit the K3s service file and remove the below argument.
+          --kublet-arg="read-only-port=XXXX"
+          Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
-          systemctl restart kubelet.service
+          systemctl restart k3s.service
         scored: false
 
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'streaming-connection-idle-timeout'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -261,20 +256,17 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          If using a Kubelet config file, edit the file to set `streamingConnectionIdleTimeout` to a
-          value other than 0.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          --streaming-connection-idle-timeout=5m
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
+          kublet-arg:
+          - "streaming-connection-idle-timeout=5m"
+          If using the command line, run K3s with --kublet-arg="streaming-connection-idle-timeout=5m".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
 
       - id: 4.2.6
         text: "Ensure that the --protect-kernel-defaults argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'protect-kernel-defaults'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --protect-kernel-defaults
@@ -284,19 +276,16 @@ groups:
                 value: true
               set: true
         remediation: |
-          If using a Kubelet config file, edit the file to set `protectKernelDefaults` to `true`.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          --protect-kernel-defaults=true
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter.
+          protect-kernel-defaults: true
+          If using the command line, run K3s with --protect-kernel-defaults=true.
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: true
 
       - id: 4.2.7
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'make-iptables-util-chains'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --make-iptables-util-chains
@@ -310,39 +299,31 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          If using a Kubelet config file, edit the file to set `makeIPTablesUtilChains` to `true`.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          remove the --make-iptables-util-chains argument from the
-          KUBELET_SYSTEM_PODS_ARGS variable.
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter.
+          kublet-arg:
+          - "make-iptables-util-chains=true"
+          If using the command line, run K3s with --kublet-arg="make-iptables-util-chains=true".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: true
 
       - id: 4.2.8
         text: "Ensure that the --hostname-override argument is not set (Manual)"
-        # This is one of those properties that can only be set as a command line argument.
-        # To check if the property is set as expected, we need to parse the kubelet command
-        # instead reading the Kubelet Configuration file.
-        audit: "/bin/ps -fC $kubeletbin "
         type: "skip"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --hostname-override
               set: false
         remediation: |
-          Edit the kubelet service file $kubeletsvc
-          on each worker node and remove the --hostname-override argument from the
-          KUBELET_SYSTEM_PODS_ARGS variable.
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          Not Applicable.
+          By default, K3s does set the --hostname-override argument. Per CIS guidelines, this is to comply
+          with cloud providers that require this flag to ensure that hostname matches node names.
         scored: false
 
       - id: 4.2.9
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
           test_items:
@@ -352,13 +333,13 @@ groups:
                 op: eq
                 value: 0
         remediation: |
-          If using a Kubelet config file, edit the file to set `eventRecordQPS` to an appropriate level.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          By default, K3s sets the event-qps to 0. Should you wish to change this,
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
+          kublet-arg:
+          - "event-qps=<value>"
+          If using the command line, run K3s with --kublet-arg="event-qps=<value>".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
 
       - id: 4.2.10
@@ -371,22 +352,18 @@ groups:
             - flag: --tls-private-key-file
               path: '/var/lib/rancher/k3s/agent/serving-kubelet.key'
         remediation: |
-          If using a Kubelet config file, edit the file to set `tlsCertFile` to the location
-          of the certificate file to use to identify this Kubelet, and `tlsPrivateKeyFile`
-          to the location of the corresponding private key file.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameters in KUBELET_CERTIFICATE_ARGS variable.
-          --tls-cert-file=<path/to/tls-certificate-file>
-          --tls-private-key-file=<path/to/tls-key-file>
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          By default, K3s automatically provides the TLS certificate and private key for the Kubelet.
+          They are generated and located at /var/lib/rancher/k3s/agent/serving-kubelet.crt and /var/lib/rancher/k3s/agent/serving-kubelet.key
+          If for some reason you need to provide your own certificate and key, you can set the
+          the below parameters in the K3s config file /etc/rancher/k3s/config.yaml.
+          kubelet-arg:
+          - "tls-cert-file=<path/to/tls-cert-file>"
+          - "tls-private-key-file=<path/to/tls-private-key-file>"
         scored: false
 
       - id: 4.2.11
         text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -400,21 +377,17 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          If using a Kubelet config file, edit the file to add the line `rotateCertificates` to `true` or
-          remove it altogether to use the default value.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          remove --rotate-certificates=false argument from the KUBELET_CERTIFICATE_ARGS
-          variable.
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          Not Applicable.
+          By default, K3s does not set the --rotate-certificates argument. If you have set this to a different value, you should remove it.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, remove any rotate-certificates parameter.
+          If using the command line, remove the K3s flag --kublet-arg="rotate-certificates".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: true
 
       - id: 4.2.12
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
-        type: "skip"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -427,17 +400,18 @@ groups:
               path: '{.featureGates.RotateKubeletServerCertificate}'
               set: false
         remediation: |
-          Edit the kubelet service file $kubeletsvc
-          on each worker node and set the below parameter in KUBELET_CERTIFICATE_ARGS variable.
-          --feature-gates=RotateKubeletServerCertificate=true
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          Not Applicable.
+          By default, K3s does not set the RotateKubeletServerCertificate feature gate. 
+          If you have enabled this feature gate, you should remove it.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, remove any feature-gate=RotateKubeletServerCertificate parameter.
+          If using the command line, remove the K3s flag --kublet-arg="feature-gate=RotateKubeletServerCertificate".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
 
       - id: 4.2.13
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
           test_items:
@@ -447,14 +421,11 @@ groups:
                 op: valid_elements
                 value: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
         remediation: |
-          If using a Kubelet config file, edit the file to set `TLSCipherSuites` to
-          TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+          If using a K3s config file /etc/rancher/k3s/config.yaml, edit the file to set `TLSCipherSuites` to
+          kubelet-arg:
+          - "tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
           or to a subset of these values.
-          If using executable arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the --tls-cipher-suites parameter as follows, or to a subset of these values.
-          --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          If using the command line, add the K3s flag --kubelet-arg="tls-cipher-suites=<same values as above>"
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false

--- a/package/cfg/k3s-cis-1.24-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/node.yaml
@@ -38,7 +38,7 @@ groups:
 
       - id: 4.1.3
         text: "If proxy kubeconfig file exists ensure permissions are set to 600 or more restrictive (Manual)"
-        audit: 'stat -c %a /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig'
+        audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c permissions=%a $proxykubeconfig; fi'' '
         tests:
           bin_op: or
           test_items:
@@ -67,14 +67,13 @@ groups:
 
       - id: 4.1.5
         text: "Ensure that the --kubeconfig kubelet.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: 'stat -c %a /var/lib/rancher/k3s/agent/kubelet.kubeconfig '
+        audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c permissions=%a $kubeletkubeconfig; fi'' '
         tests:
           test_items:
-            - flag: "600"
+            - flag: "permissions"
               compare:
-                op: eq
+                op: bitmask
                 value: "600"
-              set: true
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
@@ -377,7 +376,6 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          Not Applicable.
           By default, K3s does not set the --rotate-certificates argument. If you have set this to a different value, you should remove it.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any rotate-certificates parameter.
           If using the command line, remove the K3s flag --kublet-arg="rotate-certificates".

--- a/package/cfg/k3s-cis-1.24-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/node.yaml
@@ -191,7 +191,7 @@ groups:
                 value: AlwaysAllow
               set: true
         remediation: |
-          By default, K3s does not set the --authorization-mode to AlwaysAllow. 
+          By default, K3s does not set the --authorization-mode to AlwaysAllow.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
           kublet-arg:
           - "authorization-mode=AlwaysAllow"
@@ -401,7 +401,7 @@ groups:
               set: false
         remediation: |
           Not Applicable.
-          By default, K3s does not set the RotateKubeletServerCertificate feature gate. 
+          By default, K3s does not set the RotateKubeletServerCertificate feature gate.
           If you have enabled this feature gate, you should remove it.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any feature-gate=RotateKubeletServerCertificate parameter.
           If using the command line, remove the K3s flag --kublet-arg="feature-gate=RotateKubeletServerCertificate".

--- a/package/cfg/k3s-cis-1.24-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/node.yaml
@@ -168,20 +168,20 @@ groups:
                 value: false
               set: true
         remediation: |
-          If using a Kubelet config file, edit the file to set `authentication: anonymous: enabled` to
-          `false`.
-          If using executable arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          `--anonymous-auth=false`
-          Based on your system, restart the kubelet service. For example,
+          By default, K3s sets the --anonymous-auth to false. If you have set this to a different value, you
+          should set it back to false. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
+          kublet-arg:
+          - "anonymous-auth=true"
+          If using the command line, edit the K3s service file and remove the below argument.
+          --kublet-arg="anonymous-auth=true"
+          Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
-          systemctl restart kubelet.service
+          systemctl restart k3s.service
         scored: true
 
       - id: 4.2.2
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
-        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode" | grep -v grep; else echo "--authorization-mode=Webhook"; fi'' '
+        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode"; else echo "--authorization-mode=Webhook"; fi'' '
         tests:
           test_items:
             - flag: --authorization-mode
@@ -191,39 +191,33 @@ groups:
                 value: AlwaysAllow
               set: true
         remediation: |
-          If using a Kubelet config file, edit the file to set `authorization.mode` to Webhook. If
-          using executable arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_AUTHZ_ARGS variable.
-          --authorization-mode=Webhook
-          Based on your system, restart the kubelet service. For example,
+          By default, K3s does not set the --authorization-mode to AlwaysAllow. 
+          If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
+          kublet-arg:
+          - "authorization-mode=AlwaysAllow"
+          If using the command line, edit the K3s service file and remove the below argument.
+          --kublet-arg="authorization-mode=AlwaysAllow"
+          Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
-          systemctl restart kubelet.service
+          systemctl restart k3s.service
         scored: true
 
       - id: 4.2.3
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
-        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file" | grep -v grep; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
+        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file"; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
         tests:
           test_items:
             - flag: --client-ca-file
               path: '{.authentication.x509.clientCAFile}'
               set: true
         remediation: |
-          If using a Kubelet config file, edit the file to set `authentication.x509.clientCAFile` to
-          the location of the client CA file.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_AUTHZ_ARGS variable.
-          --client-ca-file=<path/to/client-ca-file>
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          By default, K3s automatically provides the client ca certificate for the Kubelet.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/client-ca.crt
         scored: true
 
       - id: 4.2.4
         text: "Verify that the --read-only-port argument is set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'read-only-port' "
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -236,19 +230,20 @@ groups:
               path: '{.readOnlyPort}'
               set: false
         remediation: |
-          If using a Kubelet config file, edit the file to set `readOnlyPort` to 0.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          --read-only-port=0
-          Based on your system, restart the kubelet service. For example,
+          By default, K3s sets the --read-only-port to 0. If you have set this to a different value, you
+          should set it back to 0. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
+          kublet-arg:
+          - "read-only-port=XXXX"
+          If using the command line, edit the K3s service file and remove the below argument.
+          --kublet-arg="read-only-port=XXXX"
+          Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
-          systemctl restart kubelet.service
+          systemctl restart k3s.service
         scored: false
 
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'streaming-connection-idle-timeout'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -261,20 +256,17 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          If using a Kubelet config file, edit the file to set `streamingConnectionIdleTimeout` to a
-          value other than 0.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          --streaming-connection-idle-timeout=5m
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
+          kublet-arg:
+          - "streaming-connection-idle-timeout=5m"
+          If using the command line, run K3s with --kublet-arg="streaming-connection-idle-timeout=5m".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
 
       - id: 4.2.6
         text: "Ensure that the --protect-kernel-defaults argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'protect-kernel-defaults'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -285,19 +277,16 @@ groups:
                 value: true
               set: true
         remediation: |
-          If using a Kubelet config file, edit the file to set `protectKernelDefaults` to `true`.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          --protect-kernel-defaults=true
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter.
+          protect-kernel-defaults: true
+          If using the command line, run K3s with --protect-kernel-defaults=true.
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: true
 
       - id: 4.2.7
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'make-iptables-util-chains'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -312,14 +301,12 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          If using a Kubelet config file, edit the file to set `makeIPTablesUtilChains` to `true`.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          remove the --make-iptables-util-chains argument from the
-          KUBELET_SYSTEM_PODS_ARGS variable.
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter.
+          kublet-arg:
+          - "make-iptables-util-chains=true"
+          If using the command line, run K3s with --kublet-arg="make-iptables-util-chains=true".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: true
 
       - id: 4.2.8
@@ -327,24 +314,21 @@ groups:
         # This is one of those properties that can only be set as a command line argument.
         # To check if the property is set as expected, we need to parse the kubelet command
         # instead reading the Kubelet Configuration file.
-        audit: "/bin/ps -fC $kubeletbin "
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         type: "skip"
         tests:
           test_items:
             - flag: --hostname-override
               set: false
         remediation: |
-          Edit the kubelet service file $kubeletsvc
-          on each worker node and remove the --hostname-override argument from the
-          KUBELET_SYSTEM_PODS_ARGS variable.
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          Not Applicable.
+          By default, K3s does set the --hostname-override argument. Per CIS guidelines, this is to comply
+          with cloud providers that require this flag to ensure that hostname matches node names.
         scored: false
 
       - id: 4.2.9
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
           test_items:
@@ -354,13 +338,13 @@ groups:
                 op: eq
                 value: 0
         remediation: |
-          If using a Kubelet config file, edit the file to set `eventRecordQPS` to an appropriate level.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          By default, K3s sets the event-qps to 0. Should you wish to change this,
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
+          kublet-arg:
+          - "event-qps=<value>"
+          If using the command line, run K3s with --kublet-arg="event-qps=<value>".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
 
       - id: 4.2.10
@@ -373,22 +357,18 @@ groups:
             - flag: --tls-private-key-file
               path: '/var/lib/rancher/k3s/agent/serving-kubelet.key'
         remediation: |
-          If using a Kubelet config file, edit the file to set `tlsCertFile` to the location
-          of the certificate file to use to identify this Kubelet, and `tlsPrivateKeyFile`
-          to the location of the corresponding private key file.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameters in KUBELET_CERTIFICATE_ARGS variable.
-          --tls-cert-file=<path/to/tls-certificate-file>
-          --tls-private-key-file=<path/to/tls-key-file>
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          By default, K3s automatically provides the TLS certificate and private key for the Kubelet.
+          They are generated and located at /var/lib/rancher/k3s/agent/serving-kubelet.crt and /var/lib/rancher/k3s/agent/serving-kubelet.key
+          If for some reason you need to provide your own certificate and key, you can set the
+          the below parameters in the K3s config file /etc/rancher/k3s/config.yaml.
+          kubelet-arg:
+          - "tls-cert-file=<path/to/tls-cert-file>"
+          - "tls-private-key-file=<path/to/tls-private-key-file>"
         scored: false
 
       - id: 4.2.11
         text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
           test_items:
@@ -402,20 +382,17 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          If using a Kubelet config file, edit the file to add the line `rotateCertificates` to `true` or
-          remove it altogether to use the default value.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          remove --rotate-certificates=false argument from the KUBELET_CERTIFICATE_ARGS
-          variable.
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          Not Applicable.
+          By default, K3s does not set the --rotate-certificates argument. If you have set this to a different value, you should remove it.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, remove any rotate-certificates parameter.
+          If using the command line, remove the K3s flag --kublet-arg="rotate-certificates".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: true
 
       - id: 4.2.12
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
           bin_op: or
@@ -429,17 +406,18 @@ groups:
               path: '{.featureGates.RotateKubeletServerCertificate}'
               set: false
         remediation: |
-          Edit the kubelet service file $kubeletsvc
-          on each worker node and set the below parameter in KUBELET_CERTIFICATE_ARGS variable.
-          --feature-gates=RotateKubeletServerCertificate=true
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          Not Applicable.
+          By default, K3s does not set the RotateKubeletServerCertificate feature gate. 
+          If you have enabled this feature gate, you should remove it.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, remove any feature-gate=RotateKubeletServerCertificate parameter.
+          If using the command line, remove the K3s flag --kublet-arg="feature-gate=RotateKubeletServerCertificate".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
 
       - id: 4.2.13
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
           test_items:
@@ -449,14 +427,11 @@ groups:
                 op: valid_elements
                 value: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
         remediation: |
-          If using a Kubelet config file, edit the file to set `TLSCipherSuites` to
-          TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+          If using a K3s config file /etc/rancher/k3s/config.yaml, edit the file to set `TLSCipherSuites` to
+          kubelet-arg:
+          - "tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
           or to a subset of these values.
-          If using executable arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the --tls-cipher-suites parameter as follows, or to a subset of these values.
-          --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          If using the command line, add the K3s flag --kubelet-arg="tls-cipher-suites=<same values as above>"
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false

--- a/package/cfg/k3s-cis-1.24-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/node.yaml
@@ -381,7 +381,7 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          By default, K3s does not set the --rotate-certificates argument. If you have set this to a different value, you should remove it.
+          By default, K3s does not set the --rotate-certificates argument. If you have set this flag with a value of `false`, you should either set it to `true` or completely remove the flag.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any rotate-certificates parameter.
           If using the command line, remove the K3s flag --kublet-arg="rotate-certificates".
           Based on your system, restart the k3s service. For example,
@@ -389,7 +389,7 @@ groups:
         scored: true
 
       - id: 4.2.12
-        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
+        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Automated)"
         audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
@@ -404,14 +404,13 @@ groups:
               path: '{.featureGates.RotateKubeletServerCertificate}'
               set: false
         remediation: |
-          Not Applicable.
           By default, K3s does not set the RotateKubeletServerCertificate feature gate.
           If you have enabled this feature gate, you should remove it.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any feature-gate=RotateKubeletServerCertificate parameter.
           If using the command line, remove the K3s flag --kublet-arg="feature-gate=RotateKubeletServerCertificate".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
-        scored: false
+        scored: true
 
       - id: 4.2.13
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"

--- a/package/cfg/k3s-cis-1.24-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/node.yaml
@@ -169,10 +169,10 @@ groups:
         remediation: |
           By default, K3s sets the --anonymous-auth to false. If you have set this to a different value, you
           should set it back to false. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
-          kublet-arg:
+          kubelet-arg:
           - "anonymous-auth=true"
           If using the command line, edit the K3s service file and remove the below argument.
-          --kublet-arg="anonymous-auth=true"
+          --kubelet-arg="anonymous-auth=true"
           Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
           systemctl restart k3s.service
@@ -192,10 +192,10 @@ groups:
         remediation: |
           By default, K3s does not set the --authorization-mode to AlwaysAllow.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
-          kublet-arg:
+          kubelet-arg:
           - "authorization-mode=AlwaysAllow"
           If using the command line, edit the K3s service file and remove the below argument.
-          --kublet-arg="authorization-mode=AlwaysAllow"
+          --kubelet-arg="authorization-mode=AlwaysAllow"
           Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
           systemctl restart k3s.service
@@ -231,10 +231,10 @@ groups:
         remediation: |
           By default, K3s sets the --read-only-port to 0. If you have set this to a different value, you
           should set it back to 0. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
-          kublet-arg:
+          kubelet-arg:
           - "read-only-port=XXXX"
           If using the command line, edit the K3s service file and remove the below argument.
-          --kublet-arg="read-only-port=XXXX"
+          --kubelet-arg="read-only-port=XXXX"
           Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
           systemctl restart k3s.service
@@ -256,9 +256,9 @@ groups:
           bin_op: or
         remediation: |
           If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
-          kublet-arg:
+          kubelet-arg:
           - "streaming-connection-idle-timeout=5m"
-          If using the command line, run K3s with --kublet-arg="streaming-connection-idle-timeout=5m".
+          If using the command line, run K3s with --kubelet-arg="streaming-connection-idle-timeout=5m".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: false
@@ -301,9 +301,9 @@ groups:
           bin_op: or
         remediation: |
           If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter.
-          kublet-arg:
+          kubelet-arg:
           - "make-iptables-util-chains=true"
-          If using the command line, run K3s with --kublet-arg="make-iptables-util-chains=true".
+          If using the command line, run K3s with --kubelet-arg="make-iptables-util-chains=true".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: true
@@ -339,9 +339,9 @@ groups:
         remediation: |
           By default, K3s sets the event-qps to 0. Should you wish to change this,
           If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
-          kublet-arg:
+          kubelet-arg:
           - "event-qps=<value>"
-          If using the command line, run K3s with --kublet-arg="event-qps=<value>".
+          If using the command line, run K3s with --kubelet-arg="event-qps=<value>".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: false
@@ -383,7 +383,7 @@ groups:
         remediation: |
           By default, K3s does not set the --rotate-certificates argument. If you have set this flag with a value of `false`, you should either set it to `true` or completely remove the flag.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any rotate-certificates parameter.
-          If using the command line, remove the K3s flag --kublet-arg="rotate-certificates".
+          If using the command line, remove the K3s flag --kubelet-arg="rotate-certificates".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: true
@@ -407,7 +407,7 @@ groups:
           By default, K3s does not set the RotateKubeletServerCertificate feature gate.
           If you have enabled this feature gate, you should remove it.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any feature-gate=RotateKubeletServerCertificate parameter.
-          If using the command line, remove the K3s flag --kublet-arg="feature-gate=RotateKubeletServerCertificate".
+          If using the command line, remove the K3s flag --kubelet-arg="feature-gate=RotateKubeletServerCertificate".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: true

--- a/package/cfg/k3s-cis-1.24-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/node.yaml
@@ -191,7 +191,7 @@ groups:
                 value: AlwaysAllow
               set: true
         remediation: |
-          By default, K3s does not set the --authorization-mode to AlwaysAllow. 
+          By default, K3s does not set the --authorization-mode to AlwaysAllow.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
           kublet-arg:
           - "authorization-mode=AlwaysAllow"
@@ -407,7 +407,7 @@ groups:
               set: false
         remediation: |
           Not Applicable.
-          By default, K3s does not set the RotateKubeletServerCertificate feature gate. 
+          By default, K3s does not set the RotateKubeletServerCertificate feature gate.
           If you have enabled this feature gate, you should remove it.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any feature-gate=RotateKubeletServerCertificate parameter.
           If using the command line, remove the K3s flag --kublet-arg="feature-gate=RotateKubeletServerCertificate".

--- a/package/cfg/k3s-cis-1.24-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/node.yaml
@@ -38,7 +38,7 @@ groups:
 
       - id: 4.1.3
         text: "If proxy kubeconfig file exists ensure permissions are set to 600 or more restrictive (Manual)"
-        audit: 'stat -c %a /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig'
+        audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c permissions=%a $proxykubeconfig; fi'' '
         tests:
           bin_op: or
           test_items:
@@ -67,14 +67,13 @@ groups:
 
       - id: 4.1.5
         text: "Ensure that the --kubeconfig kubelet.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: 'stat -c %a /var/lib/rancher/k3s/agent/kubelet.kubeconfig '
+        audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c permissions=%a $kubeletkubeconfig; fi'' '
         tests:
           test_items:
-            - flag: "600"
+            - flag: "permissions"
               compare:
-                op: eq
+                op: bitmask
                 value: "600"
-              set: true
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
@@ -382,7 +381,6 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          Not Applicable.
           By default, K3s does not set the --rotate-certificates argument. If you have set this to a different value, you should remove it.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any rotate-certificates parameter.
           If using the command line, remove the K3s flag --kublet-arg="rotate-certificates".

--- a/package/cfg/k3s-cis-1.7-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/node.yaml
@@ -41,7 +41,7 @@ groups:
 
       - id: 4.1.3
         text: "If proxy kubeconfig file exists ensure permissions are set to 600 or more restrictive (Manual)"
-        audit: 'stat -c %a /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig'
+        audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c permissions=%a $proxykubeconfig; fi'' '
         tests:
           bin_op: or
           test_items:
@@ -358,7 +358,6 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          Not Applicable.
           By default, K3s does not set the --rotate-certificates argument. If you have set this to a different value, you should remove it.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any rotate-certificates parameter.
           If using the command line, remove the K3s flag --kublet-arg="rotate-certificates".

--- a/package/cfg/k3s-cis-1.7-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/node.yaml
@@ -188,7 +188,7 @@ groups:
                 op: nothave
                 value: AlwaysAllow
         remediation: |
-          By default, K3s does not set the --authorization-mode to AlwaysAllow. 
+          By default, K3s does not set the --authorization-mode to AlwaysAllow.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
           kublet-arg:
           - "authorization-mode=AlwaysAllow"
@@ -383,7 +383,7 @@ groups:
               set: false
         remediation: |
           Not Applicable.
-          By default, K3s does not set the RotateKubeletServerCertificate feature gate. 
+          By default, K3s does not set the RotateKubeletServerCertificate feature gate.
           If you have enabled this feature gate, you should remove it.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any feature-gate=RotateKubeletServerCertificate parameter.
           If using the command line, remove the K3s flag --kublet-arg="feature-gate=RotateKubeletServerCertificate".

--- a/package/cfg/k3s-cis-1.7-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/node.yaml
@@ -358,7 +358,7 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          By default, K3s does not set the --rotate-certificates argument. If you have set this to a different value, you should remove it.
+          By default, K3s does not set the --rotate-certificates argument. If you have set this flag with a value of `false`, you should either set it to `true` or completely remove the flag.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any rotate-certificates parameter.
           If using the command line, remove the K3s flag --kublet-arg="rotate-certificates".
           Based on your system, restart the k3s service. For example,
@@ -366,7 +366,7 @@ groups:
         scored: false
 
       - id: 4.2.11
-        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
+        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Automated)"
         audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
@@ -381,14 +381,13 @@ groups:
               path: '{.featureGates.RotateKubeletServerCertificate}'
               set: false
         remediation: |
-          Not Applicable.
           By default, K3s does not set the RotateKubeletServerCertificate feature gate.
           If you have enabled this feature gate, you should remove it.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any feature-gate=RotateKubeletServerCertificate parameter.
           If using the command line, remove the K3s flag --kublet-arg="feature-gate=RotateKubeletServerCertificate".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
-        scored: false
+        scored: true
 
       - id: 4.2.12
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"

--- a/package/cfg/k3s-cis-1.7-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/node.yaml
@@ -167,10 +167,10 @@ groups:
         remediation: |
           By default, K3s sets the --anonymous-auth to false. If you have set this to a different value, you
           should set it back to false. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
-          kublet-arg:
+          kubelet-arg:
           - "anonymous-auth=true"
           If using the command line, edit the K3s service file and remove the below argument.
-          --kublet-arg="anonymous-auth=true"
+          --kubelet-arg="anonymous-auth=true"
           Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
           systemctl restart k3s.service
@@ -190,10 +190,10 @@ groups:
         remediation: |
           By default, K3s does not set the --authorization-mode to AlwaysAllow.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
-          kublet-arg:
+          kubelet-arg:
           - "authorization-mode=AlwaysAllow"
           If using the command line, edit the K3s service file and remove the below argument.
-          --kublet-arg="authorization-mode=AlwaysAllow"
+          --kubelet-arg="authorization-mode=AlwaysAllow"
           Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
           systemctl restart k3s.service
@@ -229,10 +229,10 @@ groups:
         remediation: |
           By default, K3s sets the --read-only-port to 0. If you have set this to a different value, you
           should set it back to 0. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
-          kublet-arg:
+          kubelet-arg:
           - "read-only-port=XXXX"
           If using the command line, edit the K3s service file and remove the below argument.
-          --kublet-arg="read-only-port=XXXX"
+          --kubelet-arg="read-only-port=XXXX"
           Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
           systemctl restart k3s.service
@@ -254,9 +254,9 @@ groups:
           bin_op: or
         remediation: |
           If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
-          kublet-arg:
+          kubelet-arg:
           - "streaming-connection-idle-timeout=5m"
-          If using the command line, run K3s with --kublet-arg="streaming-connection-idle-timeout=5m".
+          If using the command line, run K3s with --kubelet-arg="streaming-connection-idle-timeout=5m".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: false
@@ -277,9 +277,9 @@ groups:
           bin_op: or
         remediation: |
           If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter.
-          kublet-arg:
+          kubelet-arg:
           - "make-iptables-util-chains=true"
-          If using the command line, run K3s with --kublet-arg="make-iptables-util-chains=true".
+          If using the command line, run K3s with --kubelet-arg="make-iptables-util-chains=true".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: true
@@ -316,9 +316,9 @@ groups:
         remediation: |
           By default, K3s sets the event-qps to 0. Should you wish to change this,
           If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
-          kublet-arg:
+          kubelet-arg:
           - "event-qps=<value>"
-          If using the command line, run K3s with --kublet-arg="event-qps=<value>".
+          If using the command line, run K3s with --kubelet-arg="event-qps=<value>".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: false
@@ -360,7 +360,7 @@ groups:
         remediation: |
           By default, K3s does not set the --rotate-certificates argument. If you have set this flag with a value of `false`, you should either set it to `true` or completely remove the flag.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any rotate-certificates parameter.
-          If using the command line, remove the K3s flag --kublet-arg="rotate-certificates".
+          If using the command line, remove the K3s flag --kubelet-arg="rotate-certificates".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: false
@@ -384,7 +384,7 @@ groups:
           By default, K3s does not set the RotateKubeletServerCertificate feature gate.
           If you have enabled this feature gate, you should remove it.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any feature-gate=RotateKubeletServerCertificate parameter.
-          If using the command line, remove the K3s flag --kublet-arg="feature-gate=RotateKubeletServerCertificate".
+          If using the command line, remove the K3s flag --kubelet-arg="feature-gate=RotateKubeletServerCertificate".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: true

--- a/package/cfg/k3s-cis-1.7-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/node.yaml
@@ -165,20 +165,20 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          If using a Kubelet config file, edit the file to set `authentication: anonymous: enabled` to
-          `false`.
-          If using executable arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          `--anonymous-auth=false`
-          Based on your system, restart the kubelet service. For example,
+          By default, K3s sets the --anonymous-auth to false. If you have set this to a different value, you
+          should set it back to false. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
+          kublet-arg:
+          - "anonymous-auth=true"
+          If using the command line, edit the K3s service file and remove the below argument.
+          --kublet-arg="anonymous-auth=true"
+          Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
-          systemctl restart kubelet.service
+          systemctl restart k3s.service
         scored: true
 
       - id: 4.2.2
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
-        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode" | grep -v grep; else echo "--authorization-mode=Webhook"; fi'' '
+        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode"; else echo "--authorization-mode=Webhook"; fi'' '
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -188,38 +188,32 @@ groups:
                 op: nothave
                 value: AlwaysAllow
         remediation: |
-          If using a Kubelet config file, edit the file to set `authorization.mode` to Webhook. If
-          using executable arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_AUTHZ_ARGS variable.
-          --authorization-mode=Webhook
-          Based on your system, restart the kubelet service. For example,
+          By default, K3s does not set the --authorization-mode to AlwaysAllow. 
+          If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
+          kublet-arg:
+          - "authorization-mode=AlwaysAllow"
+          If using the command line, edit the K3s service file and remove the below argument.
+          --kublet-arg="authorization-mode=AlwaysAllow"
+          Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
-          systemctl restart kubelet.service
+          systemctl restart k3s.service
         scored: true
 
       - id: 4.2.3
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
-        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file" | grep -v grep; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
+        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file"; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
         tests:
           test_items:
             - flag: --client-ca-file
               path: '{.authentication.x509.clientCAFile}'
         remediation: |
-          If using a Kubelet config file, edit the file to set `authentication.x509.clientCAFile` to
-          the location of the client CA file.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_AUTHZ_ARGS variable.
-          --client-ca-file=<path/to/client-ca-file>
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          By default, K3s automatically provides the client ca certificate for the Kubelet.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/client-ca.crt
         scored: true
 
       - id: 4.2.4
         text: "Verify that the --read-only-port argument is set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'read-only-port' "
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           bin_op: or
@@ -233,19 +227,20 @@ groups:
               path: '{.readOnlyPort}'
               set: false
         remediation: |
-          If using a Kubelet config file, edit the file to set `readOnlyPort` to 0.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          --read-only-port=0
-          Based on your system, restart the kubelet service. For example,
+          By default, K3s sets the --read-only-port to 0. If you have set this to a different value, you
+          should set it back to 0. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
+          kublet-arg:
+          - "read-only-port=XXXX"
+          If using the command line, edit the K3s service file and remove the below argument.
+          --kublet-arg="read-only-port=XXXX"
+          Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
-          systemctl restart kubelet.service
+          systemctl restart k3s.service
         scored: false
 
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'streaming-connection-idle-timeout'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -258,20 +253,17 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          If using a Kubelet config file, edit the file to set `streamingConnectionIdleTimeout` to a
-          value other than 0.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          --streaming-connection-idle-timeout=5m
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
+          kublet-arg:
+          - "streaming-connection-idle-timeout=5m"
+          If using the command line, run K3s with --kublet-arg="streaming-connection-idle-timeout=5m".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
 
       - id: 4.2.6
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'make-iptables-util-chains'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --make-iptables-util-chains
@@ -284,40 +276,31 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          If using a Kubelet config file, edit the file to set `makeIPTablesUtilChains` to `true`.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          remove the --make-iptables-util-chains argument from the
-          KUBELET_SYSTEM_PODS_ARGS variable.
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter.
+          kublet-arg:
+          - "make-iptables-util-chains=true"
+          If using the command line, run K3s with --kublet-arg="make-iptables-util-chains=true".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: true
 
       - id: 4.2.7
         text: "Ensure that the --hostname-override argument is not set (Manual)"
-        # This is one of those properties that can only be set as a command line argument.
-        # To check if the property is set as expected, we need to parse the kubelet command
-        # instead reading the Kubelet Configuration file.
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         type: "skip"
-        audit: "/bin/ps -fC $kubeletbin "
         tests:
           test_items:
             - flag: --hostname-override
               set: false
         remediation: |
-          Edit the kubelet service file $kubeletsvc
-          on each worker node and remove the --hostname-override argument from the
-          KUBELET_SYSTEM_PODS_ARGS variable.
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
           Not Applicable.
+          By default, K3s does set the --hostname-override argument. Per CIS guidelines, this is to comply
+          with cloud providers that require this flag to ensure that hostname matches node names.
         scored: false
 
       - id: 4.2.8
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -331,18 +314,17 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          If using a Kubelet config file, edit the file to set `eventRecordQPS` to an appropriate level.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          By default, K3s sets the event-qps to 0. Should you wish to change this,
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
+          kublet-arg:
+          - "event-qps=<value>"
+          If using the command line, run K3s with --kublet-arg="event-qps=<value>".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
 
       - id: 4.2.9
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
-        type: "skip"
         audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
@@ -351,23 +333,18 @@ groups:
             - flag: --tls-private-key-file
               path: '/var/lib/rancher/k3s/agent/serving-kubelet.key'
         remediation: |
-          If using a Kubelet config file, edit the file to set `tlsCertFile` to the location
-          of the certificate file to use to identify this Kubelet, and `tlsPrivateKeyFile`
-          to the location of the corresponding private key file.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameters in KUBELET_CERTIFICATE_ARGS variable.
-          --tls-cert-file=<path/to/tls-certificate-file>
-          --tls-private-key-file=<path/to/tls-key-file>
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
-          Permissive - When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
+         By default, K3s automatically provides the TLS certificate and private key for the Kubelet.
+         They are generated and located at /var/lib/rancher/k3s/agent/serving-kubelet.crt and /var/lib/rancher/k3s/agent/serving-kubelet.key
+         If for some reason you need to provide your own certificate and key, you can set the
+         the below parameters in the K3s config file /etc/rancher/k3s/config.yaml.
+         kubelet-arg:
+         - "tls-cert-file=<path/to/tls-cert-file>"
+         - "tls-private-key-file=<path/to/tls-private-key-file>"
         scored: false
 
       - id: 4.2.10
         text: "Ensure that the --rotate-certificates argument is not set to false (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -381,20 +358,17 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          If using a Kubelet config file, edit the file to add the line `rotateCertificates` to `true` or
-          remove it altogether to use the default value.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          remove --rotate-certificates=false argument from the KUBELET_CERTIFICATE_ARGS
-          variable.
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          Not Applicable.
+          By default, K3s does not set the --rotate-certificates argument. If you have set this to a different value, you should remove it.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, remove any rotate-certificates parameter.
+          If using the command line, remove the K3s flag --kublet-arg="rotate-certificates".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
 
       - id: 4.2.11
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
           bin_op: or
@@ -408,18 +382,18 @@ groups:
               path: '{.featureGates.RotateKubeletServerCertificate}'
               set: false
         remediation: |
-          Edit the kubelet service file $kubeletsvc
-          on each worker node and set the below parameter in KUBELET_CERTIFICATE_ARGS variable.
-          --feature-gates=RotateKubeletServerCertificate=true
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload
-          systemctl restart kubelet.service
           Not Applicable.
+          By default, K3s does not set the RotateKubeletServerCertificate feature gate. 
+          If you have enabled this feature gate, you should remove it.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, remove any feature-gate=RotateKubeletServerCertificate parameter.
+          If using the command line, remove the K3s flag --kublet-arg="feature-gate=RotateKubeletServerCertificate".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
 
       - id: 4.2.12
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -429,21 +403,18 @@ groups:
                 op: valid_elements
                 value: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
         remediation: |
-          If using a Kubelet config file, edit the file to set `TLSCipherSuites` to
-          TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+          If using a K3s config file /etc/rancher/k3s/config.yaml, edit the file to set `TLSCipherSuites` to
+          kubelet-arg:
+          - "tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
           or to a subset of these values.
-          If using executable arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the --tls-cipher-suites parameter as follows, or to a subset of these values.
-          --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          If using the command line, add the K3s flag --kubelet-arg="tls-cipher-suites=<same values as above>"
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
 
       - id: 4.2.13
         text: "Ensure that a limit is set on pod PIDs (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -451,5 +422,7 @@ groups:
               path: '{.podPidsLimit}'
         remediation: |
           Decide on an appropriate level for this parameter and set it,
-          either via the --pod-max-pids command line parameter or the PodPidsLimit configuration file setting.
+          If using a K3s config file /etc/rancher/k3s/config.yaml, edit the file to set `podPidsLimit` to
+          kubelet-arg:
+          - "pod-max-pids=<value>"
         scored: false

--- a/package/cfg/k3s-cis-1.7-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/node.yaml
@@ -188,7 +188,7 @@ groups:
                 op: nothave
                 value: AlwaysAllow
         remediation: |
-          By default, K3s does not set the --authorization-mode to AlwaysAllow. 
+          By default, K3s does not set the --authorization-mode to AlwaysAllow.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
           kublet-arg:
           - "authorization-mode=AlwaysAllow"
@@ -387,7 +387,7 @@ groups:
               set: false
         remediation: |
           Not Applicable.
-          By default, K3s does not set the RotateKubeletServerCertificate feature gate. 
+          By default, K3s does not set the RotateKubeletServerCertificate feature gate.
           If you have enabled this feature gate, you should remove it.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any feature-gate=RotateKubeletServerCertificate parameter.
           If using the command line, remove the K3s flag --kublet-arg="feature-gate=RotateKubeletServerCertificate".

--- a/package/cfg/k3s-cis-1.7-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/node.yaml
@@ -165,20 +165,20 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          If using a Kubelet config file, edit the file to set `authentication: anonymous: enabled` to
-          `false`.
-          If using executable arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          `--anonymous-auth=false`
-          Based on your system, restart the kubelet service. For example,
+          By default, K3s sets the --anonymous-auth to false. If you have set this to a different value, you
+          should set it back to false. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
+          kublet-arg:
+          - "anonymous-auth=true"
+          If using the command line, edit the K3s service file and remove the below argument.
+          --kublet-arg="anonymous-auth=true"
+          Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
-          systemctl restart kubelet.service
+          systemctl restart k3s.service
         scored: true
 
       - id: 4.2.2
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
-        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode" | grep -v grep; else echo "--authorization-mode=Webhook"; fi'' '
+        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode"; else echo "--authorization-mode=Webhook"; fi'' '
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -188,33 +188,27 @@ groups:
                 op: nothave
                 value: AlwaysAllow
         remediation: |
-          If using a Kubelet config file, edit the file to set `authorization.mode` to Webhook. If
-          using executable arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_AUTHZ_ARGS variable.
-          --authorization-mode=Webhook
-          Based on your system, restart the kubelet service. For example,
+          By default, K3s does not set the --authorization-mode to AlwaysAllow. 
+          If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
+          kublet-arg:
+          - "authorization-mode=AlwaysAllow"
+          If using the command line, edit the K3s service file and remove the below argument.
+          --kublet-arg="authorization-mode=AlwaysAllow"
+          Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
-          systemctl restart kubelet.service
+          systemctl restart k3s.service
         scored: true
 
       - id: 4.2.3
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
-        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file" | grep -v grep; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
+        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file"; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
         tests:
           test_items:
             - flag: --client-ca-file
               path: '{.authentication.x509.clientCAFile}'
         remediation: |
-          If using a Kubelet config file, edit the file to set `authentication.x509.clientCAFile` to
-          the location of the client CA file.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_AUTHZ_ARGS variable.
-          --client-ca-file=<path/to/client-ca-file>
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          By default, K3s automatically provides the client ca certificate for the Kubelet.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/client-ca.crt
         scored: true
 
       - id: 4.2.4
@@ -233,14 +227,15 @@ groups:
               path: '{.readOnlyPort}'
               set: false
         remediation: |
-          If using a Kubelet config file, edit the file to set `readOnlyPort` to 0.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          --read-only-port=0
-          Based on your system, restart the kubelet service. For example,
+          By default, K3s sets the --read-only-port to 0. If you have set this to a different value, you
+          should set it back to 0. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
+          kublet-arg:
+          - "read-only-port=XXXX"
+          If using the command line, edit the K3s service file and remove the below argument.
+          --kublet-arg="read-only-port=XXXX"
+          Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
-          systemctl restart kubelet.service
+          systemctl restart k3s.service
         scored: false
 
       - id: 4.2.5
@@ -258,15 +253,12 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          If using a Kubelet config file, edit the file to set `streamingConnectionIdleTimeout` to a
-          value other than 0.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          --streaming-connection-idle-timeout=5m
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
+          kublet-arg:
+          - "streaming-connection-idle-timeout=5m"
+          If using the command line, run K3s with --kublet-arg="streaming-connection-idle-timeout=5m".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
 
       - id: 4.2.6
@@ -285,41 +277,32 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          If using a Kubelet config file, edit the file to set `makeIPTablesUtilChains` to `true`.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          remove the --make-iptables-util-chains argument from the
-          KUBELET_SYSTEM_PODS_ARGS variable.
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter.
+          kublet-arg:
+          - "make-iptables-util-chains=true"
+          If using the command line, run K3s with --kublet-arg="make-iptables-util-chains=true".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
           Permissive.
         scored: true
 
       - id: 4.2.7
         text: "Ensure that the --hostname-override argument is not set (Manual)"
-        # This is one of those properties that can only be set as a command line argument.
-        # To check if the property is set as expected, we need to parse the kubelet command
-        # instead reading the Kubelet Configuration file.
         type: "skip"
-        audit: "/bin/ps -fC $kubeletbin "
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --hostname-override
               set: false
         remediation: |
-          Edit the kubelet service file $kubeletsvc
-          on each worker node and remove the --hostname-override argument from the
-          KUBELET_SYSTEM_PODS_ARGS variable.
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
           Not Applicable.
+          By default, K3s does set the --hostname-override argument. Per CIS guidelines, this is to comply
+          with cloud providers that require this flag to ensure that hostname matches node names.
         scored: false
 
       - id: 4.2.8
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -333,13 +316,13 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          If using a Kubelet config file, edit the file to set `eventRecordQPS` to an appropriate level.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          By default, K3s sets the event-qps to 0. Should you wish to change this,
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
+          kublet-arg:
+          - "event-qps=<value>"
+          If using the command line, run K3s with --kublet-arg="event-qps=<value>".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
 
       - id: 4.2.9
@@ -353,23 +336,19 @@ groups:
             - flag: --tls-private-key-file
               path: '/var/lib/rancher/k3s/agent/serving-kubelet.key'
         remediation: |
-          If using a Kubelet config file, edit the file to set `tlsCertFile` to the location
-          of the certificate file to use to identify this Kubelet, and `tlsPrivateKeyFile`
-          to the location of the corresponding private key file.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameters in KUBELET_CERTIFICATE_ARGS variable.
-          --tls-cert-file=<path/to/tls-certificate-file>
-          --tls-private-key-file=<path/to/tls-key-file>
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          By default, K3s automatically provides the TLS certificate and private key for the Kubelet.
+          They are generated and located at /var/lib/rancher/k3s/agent/serving-kubelet.crt and /var/lib/rancher/k3s/agent/serving-kubelet.key
+          If for some reason you need to provide your own certificate and key, you can set the
+          the below parameters in the K3s config file /etc/rancher/k3s/config.yaml.
+          kubelet-arg:
+          - "tls-cert-file=<path/to/tls-cert-file>"
+          - "tls-private-key-file=<path/to/tls-private-key-file>"
           Permissive - When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
         scored: false
 
       - id: 4.2.10
         text: "Ensure that the --rotate-certificates argument is not set to false (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -383,20 +362,17 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          If using a Kubelet config file, edit the file to add the line `rotateCertificates` to `true` or
-          remove it altogether to use the default value.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          remove --rotate-certificates=false argument from the KUBELET_CERTIFICATE_ARGS
-          variable.
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          Not Applicable.
+          By default, K3s does not set the --rotate-certificates argument. If you have set this to a different value, you should remove it.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, remove any rotate-certificates parameter.
+          If using the command line, remove the K3s flag --kublet-arg="rotate-certificates".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
 
       - id: 4.2.11
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
           bin_op: or
@@ -410,18 +386,18 @@ groups:
               path: '{.featureGates.RotateKubeletServerCertificate}'
               set: false
         remediation: |
-          Edit the kubelet service file $kubeletsvc
-          on each worker node and set the below parameter in KUBELET_CERTIFICATE_ARGS variable.
-          --feature-gates=RotateKubeletServerCertificate=true
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload
-          systemctl restart kubelet.service
           Not Applicable.
+          By default, K3s does not set the RotateKubeletServerCertificate feature gate. 
+          If you have enabled this feature gate, you should remove it.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, remove any feature-gate=RotateKubeletServerCertificate parameter.
+          If using the command line, remove the K3s flag --kublet-arg="feature-gate=RotateKubeletServerCertificate".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
 
       - id: 4.2.12
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -431,21 +407,18 @@ groups:
                 op: valid_elements
                 value: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
         remediation: |
-          If using a Kubelet config file, edit the file to set `TLSCipherSuites` to
-          TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+          If using a K3s config file /etc/rancher/k3s/config.yaml, edit the file to set `TLSCipherSuites` to
+          kubelet-arg:
+          - "tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
           or to a subset of these values.
-          If using executable arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the --tls-cipher-suites parameter as follows, or to a subset of these values.
-          --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          If using the command line, add the K3s flag --kubelet-arg="tls-cipher-suites=<same values as above>"
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
 
       - id: 4.2.13
         text: "Ensure that a limit is set on pod PIDs (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -453,5 +426,7 @@ groups:
               path: '{.podPidsLimit}'
         remediation: |
           Decide on an appropriate level for this parameter and set it,
-          either via the --pod-max-pids command line parameter or the PodPidsLimit configuration file setting.
+          If using a K3s config file /etc/rancher/k3s/config.yaml, edit the file to set `podPidsLimit` to
+          kubelet-arg:
+          - "pod-max-pids=<value>"
         scored: false

--- a/package/cfg/k3s-cis-1.7-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/node.yaml
@@ -41,7 +41,7 @@ groups:
 
       - id: 4.1.3
         text: "If proxy kubeconfig file exists ensure permissions are set to 600 or more restrictive (Manual)"
-        audit: 'stat -c %a /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig'
+        audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c permissions=%a $proxykubeconfig; fi'' '
         tests:
           bin_op: or
           test_items:
@@ -362,7 +362,6 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          Not Applicable.
           By default, K3s does not set the --rotate-certificates argument. If you have set this to a different value, you should remove it.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any rotate-certificates parameter.
           If using the command line, remove the K3s flag --kublet-arg="rotate-certificates".

--- a/package/cfg/k3s-cis-1.7-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/node.yaml
@@ -362,7 +362,7 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          By default, K3s does not set the --rotate-certificates argument. If you have set this to a different value, you should remove it.
+          By default, K3s does not set the --rotate-certificates argument. If you have set this flag with a value of `false`, you should either set it to `true` or completely remove the flag.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any rotate-certificates parameter.
           If using the command line, remove the K3s flag --kublet-arg="rotate-certificates".
           Based on your system, restart the k3s service. For example,
@@ -370,7 +370,7 @@ groups:
         scored: false
 
       - id: 4.2.11
-        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
+        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Automated)"
         audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
@@ -385,14 +385,13 @@ groups:
               path: '{.featureGates.RotateKubeletServerCertificate}'
               set: false
         remediation: |
-          Not Applicable.
           By default, K3s does not set the RotateKubeletServerCertificate feature gate.
           If you have enabled this feature gate, you should remove it.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any feature-gate=RotateKubeletServerCertificate parameter.
           If using the command line, remove the K3s flag --kublet-arg="feature-gate=RotateKubeletServerCertificate".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
-        scored: false
+        scored: true
 
       - id: 4.2.12
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"

--- a/package/cfg/k3s-cis-1.7-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/node.yaml
@@ -167,10 +167,10 @@ groups:
         remediation: |
           By default, K3s sets the --anonymous-auth to false. If you have set this to a different value, you
           should set it back to false. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
-          kublet-arg:
+          kubelet-arg:
           - "anonymous-auth=true"
           If using the command line, edit the K3s service file and remove the below argument.
-          --kublet-arg="anonymous-auth=true"
+          --kubelet-arg="anonymous-auth=true"
           Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
           systemctl restart k3s.service
@@ -190,10 +190,10 @@ groups:
         remediation: |
           By default, K3s does not set the --authorization-mode to AlwaysAllow.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
-          kublet-arg:
+          kubelet-arg:
           - "authorization-mode=AlwaysAllow"
           If using the command line, edit the K3s service file and remove the below argument.
-          --kublet-arg="authorization-mode=AlwaysAllow"
+          --kubelet-arg="authorization-mode=AlwaysAllow"
           Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
           systemctl restart k3s.service
@@ -229,10 +229,10 @@ groups:
         remediation: |
           By default, K3s sets the --read-only-port to 0. If you have set this to a different value, you
           should set it back to 0. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
-          kublet-arg:
+          kubelet-arg:
           - "read-only-port=XXXX"
           If using the command line, edit the K3s service file and remove the below argument.
-          --kublet-arg="read-only-port=XXXX"
+          --kubelet-arg="read-only-port=XXXX"
           Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
           systemctl restart k3s.service
@@ -254,9 +254,9 @@ groups:
           bin_op: or
         remediation: |
           If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
-          kublet-arg:
+          kubelet-arg:
           - "streaming-connection-idle-timeout=5m"
-          If using the command line, run K3s with --kublet-arg="streaming-connection-idle-timeout=5m".
+          If using the command line, run K3s with --kubelet-arg="streaming-connection-idle-timeout=5m".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: false
@@ -278,9 +278,9 @@ groups:
           bin_op: or
         remediation: |
           If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter.
-          kublet-arg:
+          kubelet-arg:
           - "make-iptables-util-chains=true"
-          If using the command line, run K3s with --kublet-arg="make-iptables-util-chains=true".
+          If using the command line, run K3s with --kubelet-arg="make-iptables-util-chains=true".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
           Permissive.
@@ -318,9 +318,9 @@ groups:
         remediation: |
           By default, K3s sets the event-qps to 0. Should you wish to change this,
           If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
-          kublet-arg:
+          kubelet-arg:
           - "event-qps=<value>"
-          If using the command line, run K3s with --kublet-arg="event-qps=<value>".
+          If using the command line, run K3s with --kubelet-arg="event-qps=<value>".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: false
@@ -364,7 +364,7 @@ groups:
         remediation: |
           By default, K3s does not set the --rotate-certificates argument. If you have set this flag with a value of `false`, you should either set it to `true` or completely remove the flag.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any rotate-certificates parameter.
-          If using the command line, remove the K3s flag --kublet-arg="rotate-certificates".
+          If using the command line, remove the K3s flag --kubelet-arg="rotate-certificates".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: false
@@ -388,7 +388,7 @@ groups:
           By default, K3s does not set the RotateKubeletServerCertificate feature gate.
           If you have enabled this feature gate, you should remove it.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any feature-gate=RotateKubeletServerCertificate parameter.
-          If using the command line, remove the K3s flag --kublet-arg="feature-gate=RotateKubeletServerCertificate".
+          If using the command line, remove the K3s flag --kubelet-arg="feature-gate=RotateKubeletServerCertificate".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: true

--- a/package/cfg/k3s-cis-1.8-hardened/controlplane.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/controlplane.yaml
@@ -15,7 +15,7 @@ groups:
           Alternative mechanisms provided by Kubernetes such as the use of OIDC should be
           implemented in place of client certificates.
         scored: false
-      
+
       - id: 3.1.2
         text: "Service account token authentication should not be used for users (Manual)"
         type: "manual"
@@ -23,7 +23,7 @@ groups:
           Alternative mechanisms provided by Kubernetes such as the use of OIDC should be implemented
           in place of service account tokens.
         scored: false
-      
+
       - id: 3.1.3
         text: "Bootstrap token authentication should not be used for users (Manual)"
         type: "manual"
@@ -31,7 +31,7 @@ groups:
           Alternative mechanisms provided by Kubernetes such as the use of OIDC should be implemented
           in place of bootstrap tokens.
         scored: false
-  
+
   - id: 3.2
     text: "Logging"
     checks:
@@ -45,7 +45,7 @@ groups:
         remediation: |
           Create an audit policy file for your cluster.
         scored: false
-      
+
       - id: 3.2.2
         text: "Ensure that the audit policy covers key security concerns (Manual)"
         type: "manual"

--- a/package/cfg/k3s-cis-1.8-hardened/controlplane.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/controlplane.yaml
@@ -15,6 +15,7 @@ groups:
           Alternative mechanisms provided by Kubernetes such as the use of OIDC should be
           implemented in place of client certificates.
         scored: false
+      
       - id: 3.1.2
         text: "Service account token authentication should not be used for users (Manual)"
         type: "manual"
@@ -22,6 +23,7 @@ groups:
           Alternative mechanisms provided by Kubernetes such as the use of OIDC should be implemented
           in place of service account tokens.
         scored: false
+      
       - id: 3.1.3
         text: "Bootstrap token authentication should not be used for users (Manual)"
         type: "manual"
@@ -29,6 +31,7 @@ groups:
           Alternative mechanisms provided by Kubernetes such as the use of OIDC should be implemented
           in place of bootstrap tokens.
         scored: false
+  
   - id: 3.2
     text: "Logging"
     checks:
@@ -42,6 +45,7 @@ groups:
         remediation: |
           Create an audit policy file for your cluster.
         scored: false
+      
       - id: 3.2.2
         text: "Ensure that the audit policy covers key security concerns (Manual)"
         type: "manual"

--- a/package/cfg/k3s-cis-1.8-hardened/etcd.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/etcd.yaml
@@ -27,7 +27,7 @@ groups:
           --cert-file=</path/to/ca-file>
           --key-file=</path/to/key-file>
         scored: true
-      
+
       - id: 2.2
         text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
         audit: "check_for_k3s_etcd.sh 2.2"
@@ -47,7 +47,7 @@ groups:
           node and set the below parameter.
           --client-cert-auth="true"
         scored: true
-      
+
       - id: 2.3
         text: "Ensure that the --auto-tls argument is not set to true (Automated)"
         audit: "check_for_k3s_etcd.sh 2.3"
@@ -67,7 +67,7 @@ groups:
           node and either remove the --auto-tls parameter or set it to false.
             --auto-tls=false
         scored: true
-      
+
       - id: 2.4
         text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
         audit: "check_for_k3s_etcd.sh 2.4"
@@ -88,7 +88,7 @@ groups:
           --peer-client-file=</path/to/peer-cert-file>
           --peer-key-file=</path/to/peer-key-file>
         scored: true
-      
+
       - id: 2.5
         text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
         audit: "check_for_k3s_etcd.sh 2.5"
@@ -108,7 +108,7 @@ groups:
           node and set the below parameter.
           --peer-client-cert-auth=true
         scored: true
-      
+
       - id: 2.6
         text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
         audit: "check_for_k3s_etcd.sh 2.6"
@@ -129,7 +129,7 @@ groups:
           node and either remove the --peer-auto-tls parameter or set it to false.
           --peer-auto-tls=false
         scored: true
-      
+
       - id: 2.7
         text: "Ensure that a unique Certificate Authority is used for etcd (Automated)"
         audit: "check_for_k3s_etcd.sh 2.7"

--- a/package/cfg/k3s-cis-1.8-hardened/etcd.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/etcd.yaml
@@ -27,6 +27,7 @@ groups:
           --cert-file=</path/to/ca-file>
           --key-file=</path/to/key-file>
         scored: true
+      
       - id: 2.2
         text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
         audit: "check_for_k3s_etcd.sh 2.2"
@@ -46,6 +47,7 @@ groups:
           node and set the below parameter.
           --client-cert-auth="true"
         scored: true
+      
       - id: 2.3
         text: "Ensure that the --auto-tls argument is not set to true (Automated)"
         audit: "check_for_k3s_etcd.sh 2.3"
@@ -65,6 +67,7 @@ groups:
           node and either remove the --auto-tls parameter or set it to false.
             --auto-tls=false
         scored: true
+      
       - id: 2.4
         text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
         audit: "check_for_k3s_etcd.sh 2.4"
@@ -85,6 +88,7 @@ groups:
           --peer-client-file=</path/to/peer-cert-file>
           --peer-key-file=</path/to/peer-key-file>
         scored: true
+      
       - id: 2.5
         text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
         audit: "check_for_k3s_etcd.sh 2.5"
@@ -104,6 +108,7 @@ groups:
           node and set the below parameter.
           --peer-client-cert-auth=true
         scored: true
+      
       - id: 2.6
         text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
         audit: "check_for_k3s_etcd.sh 2.6"
@@ -124,6 +129,7 @@ groups:
           node and either remove the --peer-auto-tls parameter or set it to false.
           --peer-auto-tls=false
         scored: true
+      
       - id: 2.7
         text: "Ensure that a unique Certificate Authority is used for etcd (Automated)"
         audit: "check_for_k3s_etcd.sh 2.7"

--- a/package/cfg/k3s-cis-1.8-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/master.yaml
@@ -24,7 +24,7 @@ groups:
           For example, chmod 600 $apiserverconf
           Not Applicable.
         scored: true
-      
+
       - id: 1.1.2
         text: "Ensure that the API server pod specification file ownership is set to root:root (Automated)"
         type: "skip"
@@ -37,7 +37,7 @@ groups:
           For example, chown root:root $apiserverconf
           Not Applicable.
         scored: true
-      
+
       - id: 1.1.3
         text: "Ensure that the controller manager pod specification file permissions are set to 600 or more restrictive (Automated)"
         type: "skip"
@@ -53,7 +53,7 @@ groups:
           For example, chmod 600 $controllermanagerconf
           Not Applicable.
         scored: true
-      
+
       - id: 1.1.4
         text: "Ensure that the controller manager pod specification file ownership is set to root:root (Automated)"
         type: "skip"
@@ -66,7 +66,7 @@ groups:
           For example, chown root:root $controllermanagerconf
           Not Applicable.
         scored: true
-      
+
       - id: 1.1.5
         text: "Ensure that the scheduler pod specification file permissions are set to 600 or more restrictive (Automated)"
         type: "skip"
@@ -82,7 +82,7 @@ groups:
           For example, chmod 600 $schedulerconf
           Not Applicable.
         scored: true
-      
+
       - id: 1.1.6
         text: "Ensure that the scheduler pod specification file ownership is set to root:root (Automated)"
         type: "skip"
@@ -95,7 +95,7 @@ groups:
           For example, chown root:root $schedulerconf
           Not Applicable.
         scored: true
-      
+
       - id: 1.1.7
         text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
         type: "skip"
@@ -113,7 +113,7 @@ groups:
           chmod 600 $etcdconf
           Not Applicable.
         scored: true
-      
+
       - id: 1.1.8
         text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
         type: "skip"
@@ -128,7 +128,7 @@ groups:
           chown root:root $etcdconf
           Not Applicable.
         scored: true
-      
+
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Automated)"
         type: "skip"
@@ -147,7 +147,7 @@ groups:
           For example, chmod 600 <path/to/cni/files>
           Not Applicable.
         scored: false
-      
+
       - id: 1.1.10
         text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
         type: skip
@@ -164,7 +164,7 @@ groups:
           chown root:root <path/to/cni/files>
           Not Applicable.
         scored: false
-      
+
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
         audit: "check_for_k3s_etcd.sh 1.1.11"
@@ -181,7 +181,7 @@ groups:
           Run the below command (based on the etcd data directory found above). For example,
           chmod 700 /var/lib/etcd
         scored: true
-      
+
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
         audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G
@@ -196,7 +196,7 @@ groups:
           For example, chown etcd:etcd /var/lib/etcd
           Not Applicable.
         scored: true
-      
+
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 600 or more restrictive (Automated)"
         audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/admin.kubeconfig'"
@@ -211,7 +211,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chmod 600 /var/lib/rancher/k3s/server/cred/admin.kubeconfig
         scored: true
-      
+
       - id: 1.1.14
         text: "Ensure that the admin.conf file ownership is set to root:root (Automated)"
         audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c %U:%G /var/lib/rancher/k3s/server/cred/admin.kubeconfig; fi'"
@@ -226,7 +226,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chown root:root /etc/kubernetes/admin.conf
         scored: true
-      
+
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 600 or more restrictive (Automated)"
         audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
@@ -241,7 +241,7 @@ groups:
           For example,
           chmod 600 $schedulerkubeconfig
         scored: true
-      
+
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
         audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c %U:%G /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
@@ -253,7 +253,7 @@ groups:
           For example,
           chown root:root $schedulerkubeconfig
         scored: true
-      
+
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 600 or more restrictive (Automated)"
         audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/controller.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/controller.kubeconfig; fi'"
@@ -268,7 +268,7 @@ groups:
           For example,
           chmod 600 $controllermanagerkubeconfig
         scored: true
-      
+
       - id: 1.1.18
         text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
         audit: "stat -c %U:%G /var/lib/rancher/k3s/server/cred/controller.kubeconfig"
@@ -284,7 +284,7 @@ groups:
           For example,
           chown root:root $controllermanagerkubeconfig
         scored: true
-      
+
       - id: 1.1.19
         text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
         audit: "stat -c %U:%G /var/lib/rancher/k3s/server/tls"
@@ -297,7 +297,7 @@ groups:
           For example,
           chown -R root:root /var/lib/rancher/k3s/server/tls
         scored: true
-      
+
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"
         audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' | xargs stat -c permissions=%a"
@@ -313,7 +313,7 @@ groups:
           For example,
           find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 600 {} +
         scored: false
-      
+
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
         audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.key' | xargs stat -c permissions=%a"
@@ -329,7 +329,7 @@ groups:
           For example,
           find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {} +
         scored: false
-  
+
   - id: 1.2
     text: "API Server"
     checks:
@@ -347,7 +347,7 @@ groups:
           on the control plane node and set the below parameter.
           --anonymous-auth=false
         scored: false
-      
+
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -360,7 +360,7 @@ groups:
           edit the API server pod specification file $apiserverconf
           on the control plane node and remove the --token-auth-file=<filename> parameter.
         scored: true
-      
+
       - id: 1.2.3
         text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -379,7 +379,7 @@ groups:
           on the control plane node and remove the `DenyServiceExternalIPs`
           from enabled admission plugins.
         scored: true
-      
+
       - id: 1.2.4
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
@@ -396,7 +396,7 @@ groups:
           --kubelet-client-certificate=<path/to/client-certificate-file>
           --kubelet-client-key=<path/to/client-key-file>
         scored: true
-      
+
       - id: 1.2.5
         text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
         type: "skip"
@@ -412,7 +412,7 @@ groups:
           --kubelet-certificate-authority=<ca-string>
           Permissive - When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
         scored: true
-      
+
       - id: 1.2.6
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
@@ -428,7 +428,7 @@ groups:
           One such example could be as below.
           --authorization-mode=RBAC
         scored: true
-      
+
       - id: 1.2.7
         text: "Ensure that the --authorization-mode argument includes Node (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
@@ -443,7 +443,7 @@ groups:
           on the control plane node and set the --authorization-mode parameter to a value that includes Node.
           --authorization-mode=Node,RBAC
         scored: true
-      
+
       - id: 1.2.8
         text: "Ensure that the --authorization-mode argument includes RBAC (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
@@ -458,7 +458,7 @@ groups:
           on the control plane node and set the --authorization-mode parameter to a value that includes RBAC,
           for example `--authorization-mode=Node,RBAC`.
         scored: true
-      
+
       - id: 1.2.9
         text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
@@ -475,7 +475,7 @@ groups:
           --enable-admission-plugins=...,EventRateLimit,...
           --admission-control-config-file=<path/to/configuration/file>
         scored: false
-      
+
       - id: 1.2.10
         text: "Ensure that the admission control plugin AlwaysAdmit is not set (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
@@ -493,7 +493,7 @@ groups:
           on the control plane node and either remove the --enable-admission-plugins parameter, or set it to a
           value that does not include AlwaysAdmit.
         scored: true
-      
+
       - id: 1.2.11
         text: "Ensure that the admission control plugin AlwaysPullImages is set (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -509,7 +509,7 @@ groups:
           AlwaysPullImages.
           --enable-admission-plugins=...,AlwaysPullImages,...
         scored: false
-      
+
       - id: 1.2.12
         text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)"
         type: "skip"
@@ -532,7 +532,7 @@ groups:
           --enable-admission-plugins=...,SecurityContextDeny,...
           Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
         scored: false
-      
+
       - id: 1.2.13
         text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -551,7 +551,7 @@ groups:
           on the control plane node and ensure that the --disable-admission-plugins parameter is set to a
           value that does not include ServiceAccount.
         scored: true
-      
+
       - id: 1.2.14
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -569,7 +569,7 @@ groups:
           on the control plane node and set the --disable-admission-plugins parameter to
           ensure it does not include NamespaceLifecycle.
         scored: true
-      
+
       - id: 1.2.15
         text: "Ensure that the admission control plugin NodeRestriction is set (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
@@ -586,7 +586,7 @@ groups:
           value that includes NodeRestriction.
           --enable-admission-plugins=...,NodeRestriction,...
         scored: true
-      
+
       - id: 1.2.16
         text: "Ensure that the --profiling argument is set to false (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'profiling'"
@@ -601,7 +601,7 @@ groups:
           on the control plane node and set the below parameter.
           --profiling=false
         scored: true
-      
+
       - id: 1.2.17
         text: "Ensure that the --audit-log-path argument is set (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -616,7 +616,7 @@ groups:
           --audit-log-path=/var/log/apiserver/audit.log
           Permissive.
         scored: true
-      
+
       - id: 1.2.18
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -634,7 +634,7 @@ groups:
           --audit-log-maxage=30
           Permissive.
         scored: true
-      
+
       - id: 1.2.19
         text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -652,7 +652,7 @@ groups:
           --audit-log-maxbackup=10
           Permissive.
         scored: true
-      
+
       - id: 1.2.20
         text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -669,7 +669,7 @@ groups:
           For example, to set it as 100 MB, --audit-log-maxsize=100
           Permissive.
         scored: true
-      
+
       - id: 1.2.21
         text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -683,7 +683,7 @@ groups:
           For example, --request-timeout=300s
           Permissive.
         scored: false
-      
+
       - id: 1.2.22
         text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -703,7 +703,7 @@ groups:
           Alternatively, you can delete the --service-account-lookup parameter from this file so
           that the default takes effect.
         scored: true
-      
+
       - id: 1.2.23
         text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -717,7 +717,7 @@ groups:
           to the public key file for service accounts. For example,
           --service-account-key-file=<filename>
         scored: true
-      
+
       - id: 1.2.24
         text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
         audit: "check_for_k3s_etcd.sh 1.2.29"
@@ -735,7 +735,7 @@ groups:
           --etcd-certfile=<path/to/client-certificate-file>
           --etcd-keyfile=<path/to/client-key-file>
         scored: true
-      
+
       - id: 1.2.25
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal -u k3s | grep -A1 'Running kube-apiserver' | tail -n2"
@@ -753,7 +753,7 @@ groups:
           --tls-cert-file=<path/to/tls-certificate-file>
           --tls-private-key-file=<path/to/tls-key-file>
         scored: true
-      
+
       - id: 1.2.26
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'client-ca-file'"
@@ -766,7 +766,7 @@ groups:
           on the control plane node and set the client certificate authority file.
           --client-ca-file=<path/to/client-ca-file>
         scored: true
-      
+
       - id: 1.2.27
         text: "Ensure that the --etcd-cafile argument is set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-cafile'"
@@ -779,7 +779,7 @@ groups:
           on the control plane node and set the etcd certificate authority file parameter.
           --etcd-cafile=<path/to/ca-file>
         scored: true
-      
+
       - id: 1.2.28
         text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
         type: "skip"
@@ -794,7 +794,7 @@ groups:
           For example, --encryption-provider-config=</path/to/EncryptionConfig/File>
           Permissive - Enabling encryption changes how data can be recovered as data is encrypted.
         scored: false
-      
+
       - id: 1.2.29
         text: "Ensure that encryption providers are appropriately configured (Manual)"
         type: "skip"
@@ -812,7 +812,7 @@ groups:
           In this file, choose aescbc, kms or secretbox as the encryption provider.
           Permissive - Enabling encryption changes how data can be recovered as data is encrypted.
         scored: false
-      
+
       - id: 1.2.30
         text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Automated)"
         audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'tls-cipher-suites'"
@@ -829,7 +829,7 @@ groups:
           kube-apiserver-arg:
           - "tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
         scored: true
-  
+
   - id: 1.3
     text: "Controller Manager"
     checks:
@@ -844,7 +844,7 @@ groups:
           on the control plane node and set the --terminated-pod-gc-threshold to an appropriate threshold,
           for example, --terminated-pod-gc-threshold=10
         scored: false
-      
+
       - id: 1.3.2
         text: "Ensure that the --profiling argument is set to false (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'profiling'"
@@ -859,7 +859,7 @@ groups:
           on the control plane node and set the below parameter.
           --profiling=false
         scored: true
-      
+
       - id: 1.3.3
         text: "Ensure that the --use-service-account-credentials argument is set to true (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'use-service-account-credentials'"
@@ -874,7 +874,7 @@ groups:
           on the control plane node to set the below parameter.
           --use-service-account-credentials=true
         scored: true
-      
+
       - id: 1.3.4
         text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'service-account-private-key-file'"
@@ -887,7 +887,7 @@ groups:
           to the private key file for service accounts.
           --service-account-private-key-file=<filename>
         scored: true
-      
+
       - id: 1.3.5
         text: "Ensure that the --root-ca-file argument is set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'root-ca-file'"
@@ -899,7 +899,7 @@ groups:
           on the control plane node and set the --root-ca-file parameter to the certificate bundle file`.
           --root-ca-file=<path/to/file>
         scored: true
-      
+
       - id: 1.3.6
         text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
         type: "skip"
@@ -920,7 +920,7 @@ groups:
           --feature-gates=RotateKubeletServerCertificate=true
           Not Applicable.
         scored: true
-      
+
       - id: 1.3.7
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
         audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
@@ -938,7 +938,7 @@ groups:
           Edit the Controller Manager pod specification file $controllermanagerconf
           on the control plane node and ensure the correct value for the --bind-address parameter
         scored: true
-  
+
   - id: 1.4
     text: "Scheduler"
     checks:
@@ -957,7 +957,7 @@ groups:
           on the control plane node and set the below parameter.
           --profiling=false
         scored: true
-      
+
       - id: 1.4.2
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'bind-address'"

--- a/package/cfg/k3s-cis-1.8-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/master.yaml
@@ -24,6 +24,7 @@ groups:
           For example, chmod 600 $apiserverconf
           Not Applicable.
         scored: true
+      
       - id: 1.1.2
         text: "Ensure that the API server pod specification file ownership is set to root:root (Automated)"
         type: "skip"
@@ -36,6 +37,7 @@ groups:
           For example, chown root:root $apiserverconf
           Not Applicable.
         scored: true
+      
       - id: 1.1.3
         text: "Ensure that the controller manager pod specification file permissions are set to 600 or more restrictive (Automated)"
         type: "skip"
@@ -51,6 +53,7 @@ groups:
           For example, chmod 600 $controllermanagerconf
           Not Applicable.
         scored: true
+      
       - id: 1.1.4
         text: "Ensure that the controller manager pod specification file ownership is set to root:root (Automated)"
         type: "skip"
@@ -63,6 +66,7 @@ groups:
           For example, chown root:root $controllermanagerconf
           Not Applicable.
         scored: true
+      
       - id: 1.1.5
         text: "Ensure that the scheduler pod specification file permissions are set to 600 or more restrictive (Automated)"
         type: "skip"
@@ -78,6 +82,7 @@ groups:
           For example, chmod 600 $schedulerconf
           Not Applicable.
         scored: true
+      
       - id: 1.1.6
         text: "Ensure that the scheduler pod specification file ownership is set to root:root (Automated)"
         type: "skip"
@@ -90,6 +95,7 @@ groups:
           For example, chown root:root $schedulerconf
           Not Applicable.
         scored: true
+      
       - id: 1.1.7
         text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
         type: "skip"
@@ -107,6 +113,7 @@ groups:
           chmod 600 $etcdconf
           Not Applicable.
         scored: true
+      
       - id: 1.1.8
         text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
         type: "skip"
@@ -121,6 +128,7 @@ groups:
           chown root:root $etcdconf
           Not Applicable.
         scored: true
+      
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Automated)"
         type: "skip"
@@ -139,6 +147,7 @@ groups:
           For example, chmod 600 <path/to/cni/files>
           Not Applicable.
         scored: false
+      
       - id: 1.1.10
         text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
         type: skip
@@ -155,6 +164,7 @@ groups:
           chown root:root <path/to/cni/files>
           Not Applicable.
         scored: false
+      
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
         audit: "check_for_k3s_etcd.sh 1.1.11"
@@ -171,6 +181,7 @@ groups:
           Run the below command (based on the etcd data directory found above). For example,
           chmod 700 /var/lib/etcd
         scored: true
+      
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
         audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G
@@ -185,6 +196,7 @@ groups:
           For example, chown etcd:etcd /var/lib/etcd
           Not Applicable.
         scored: true
+      
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 600 or more restrictive (Automated)"
         audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/admin.kubeconfig'"
@@ -199,6 +211,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chmod 600 /var/lib/rancher/k3s/server/cred/admin.kubeconfig
         scored: true
+      
       - id: 1.1.14
         text: "Ensure that the admin.conf file ownership is set to root:root (Automated)"
         audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c %U:%G /var/lib/rancher/k3s/server/cred/admin.kubeconfig; fi'"
@@ -213,6 +226,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chown root:root /etc/kubernetes/admin.conf
         scored: true
+      
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 600 or more restrictive (Automated)"
         audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
@@ -227,6 +241,7 @@ groups:
           For example,
           chmod 600 $schedulerkubeconfig
         scored: true
+      
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
         audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c %U:%G /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
@@ -238,6 +253,7 @@ groups:
           For example,
           chown root:root $schedulerkubeconfig
         scored: true
+      
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 600 or more restrictive (Automated)"
         audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/controller.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/controller.kubeconfig; fi'"
@@ -252,6 +268,7 @@ groups:
           For example,
           chmod 600 $controllermanagerkubeconfig
         scored: true
+      
       - id: 1.1.18
         text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
         audit: "stat -c %U:%G /var/lib/rancher/k3s/server/cred/controller.kubeconfig"
@@ -267,6 +284,7 @@ groups:
           For example,
           chown root:root $controllermanagerkubeconfig
         scored: true
+      
       - id: 1.1.19
         text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
         audit: "stat -c %U:%G /var/lib/rancher/k3s/server/tls"
@@ -279,6 +297,7 @@ groups:
           For example,
           chown -R root:root /var/lib/rancher/k3s/server/tls
         scored: true
+      
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"
         audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' | xargs stat -c permissions=%a"
@@ -294,6 +313,7 @@ groups:
           For example,
           find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 600 {} +
         scored: false
+      
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
         audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.key' | xargs stat -c permissions=%a"
@@ -309,6 +329,7 @@ groups:
           For example,
           find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {} +
         scored: false
+  
   - id: 1.2
     text: "API Server"
     checks:
@@ -326,6 +347,7 @@ groups:
           on the control plane node and set the below parameter.
           --anonymous-auth=false
         scored: false
+      
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -338,6 +360,7 @@ groups:
           edit the API server pod specification file $apiserverconf
           on the control plane node and remove the --token-auth-file=<filename> parameter.
         scored: true
+      
       - id: 1.2.3
         text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -356,6 +379,7 @@ groups:
           on the control plane node and remove the `DenyServiceExternalIPs`
           from enabled admission plugins.
         scored: true
+      
       - id: 1.2.4
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
@@ -372,6 +396,7 @@ groups:
           --kubelet-client-certificate=<path/to/client-certificate-file>
           --kubelet-client-key=<path/to/client-key-file>
         scored: true
+      
       - id: 1.2.5
         text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
         type: "skip"
@@ -387,6 +412,7 @@ groups:
           --kubelet-certificate-authority=<ca-string>
           Permissive - When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
         scored: true
+      
       - id: 1.2.6
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
@@ -402,6 +428,7 @@ groups:
           One such example could be as below.
           --authorization-mode=RBAC
         scored: true
+      
       - id: 1.2.7
         text: "Ensure that the --authorization-mode argument includes Node (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
@@ -416,6 +443,7 @@ groups:
           on the control plane node and set the --authorization-mode parameter to a value that includes Node.
           --authorization-mode=Node,RBAC
         scored: true
+      
       - id: 1.2.8
         text: "Ensure that the --authorization-mode argument includes RBAC (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
@@ -430,6 +458,7 @@ groups:
           on the control plane node and set the --authorization-mode parameter to a value that includes RBAC,
           for example `--authorization-mode=Node,RBAC`.
         scored: true
+      
       - id: 1.2.9
         text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
@@ -446,6 +475,7 @@ groups:
           --enable-admission-plugins=...,EventRateLimit,...
           --admission-control-config-file=<path/to/configuration/file>
         scored: false
+      
       - id: 1.2.10
         text: "Ensure that the admission control plugin AlwaysAdmit is not set (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
@@ -463,6 +493,7 @@ groups:
           on the control plane node and either remove the --enable-admission-plugins parameter, or set it to a
           value that does not include AlwaysAdmit.
         scored: true
+      
       - id: 1.2.11
         text: "Ensure that the admission control plugin AlwaysPullImages is set (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -478,6 +509,7 @@ groups:
           AlwaysPullImages.
           --enable-admission-plugins=...,AlwaysPullImages,...
         scored: false
+      
       - id: 1.2.12
         text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)"
         type: "skip"
@@ -500,6 +532,7 @@ groups:
           --enable-admission-plugins=...,SecurityContextDeny,...
           Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
         scored: false
+      
       - id: 1.2.13
         text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -518,6 +551,7 @@ groups:
           on the control plane node and ensure that the --disable-admission-plugins parameter is set to a
           value that does not include ServiceAccount.
         scored: true
+      
       - id: 1.2.14
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -535,6 +569,7 @@ groups:
           on the control plane node and set the --disable-admission-plugins parameter to
           ensure it does not include NamespaceLifecycle.
         scored: true
+      
       - id: 1.2.15
         text: "Ensure that the admission control plugin NodeRestriction is set (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
@@ -551,6 +586,7 @@ groups:
           value that includes NodeRestriction.
           --enable-admission-plugins=...,NodeRestriction,...
         scored: true
+      
       - id: 1.2.16
         text: "Ensure that the --profiling argument is set to false (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'profiling'"
@@ -565,6 +601,7 @@ groups:
           on the control plane node and set the below parameter.
           --profiling=false
         scored: true
+      
       - id: 1.2.17
         text: "Ensure that the --audit-log-path argument is set (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -579,6 +616,7 @@ groups:
           --audit-log-path=/var/log/apiserver/audit.log
           Permissive.
         scored: true
+      
       - id: 1.2.18
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -596,6 +634,7 @@ groups:
           --audit-log-maxage=30
           Permissive.
         scored: true
+      
       - id: 1.2.19
         text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -613,6 +652,7 @@ groups:
           --audit-log-maxbackup=10
           Permissive.
         scored: true
+      
       - id: 1.2.20
         text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -629,6 +669,7 @@ groups:
           For example, to set it as 100 MB, --audit-log-maxsize=100
           Permissive.
         scored: true
+      
       - id: 1.2.21
         text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -642,6 +683,7 @@ groups:
           For example, --request-timeout=300s
           Permissive.
         scored: false
+      
       - id: 1.2.22
         text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -661,6 +703,7 @@ groups:
           Alternatively, you can delete the --service-account-lookup parameter from this file so
           that the default takes effect.
         scored: true
+      
       - id: 1.2.23
         text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -674,6 +717,7 @@ groups:
           to the public key file for service accounts. For example,
           --service-account-key-file=<filename>
         scored: true
+      
       - id: 1.2.24
         text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
         audit: "check_for_k3s_etcd.sh 1.2.29"
@@ -691,6 +735,7 @@ groups:
           --etcd-certfile=<path/to/client-certificate-file>
           --etcd-keyfile=<path/to/client-key-file>
         scored: true
+      
       - id: 1.2.25
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal -u k3s | grep -A1 'Running kube-apiserver' | tail -n2"
@@ -708,6 +753,7 @@ groups:
           --tls-cert-file=<path/to/tls-certificate-file>
           --tls-private-key-file=<path/to/tls-key-file>
         scored: true
+      
       - id: 1.2.26
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'client-ca-file'"
@@ -720,6 +766,7 @@ groups:
           on the control plane node and set the client certificate authority file.
           --client-ca-file=<path/to/client-ca-file>
         scored: true
+      
       - id: 1.2.27
         text: "Ensure that the --etcd-cafile argument is set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-cafile'"
@@ -732,6 +779,7 @@ groups:
           on the control plane node and set the etcd certificate authority file parameter.
           --etcd-cafile=<path/to/ca-file>
         scored: true
+      
       - id: 1.2.28
         text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
         type: "skip"
@@ -746,6 +794,7 @@ groups:
           For example, --encryption-provider-config=</path/to/EncryptionConfig/File>
           Permissive - Enabling encryption changes how data can be recovered as data is encrypted.
         scored: false
+      
       - id: 1.2.29
         text: "Ensure that encryption providers are appropriately configured (Manual)"
         type: "skip"
@@ -763,6 +812,7 @@ groups:
           In this file, choose aescbc, kms or secretbox as the encryption provider.
           Permissive - Enabling encryption changes how data can be recovered as data is encrypted.
         scored: false
+      
       - id: 1.2.30
         text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Automated)"
         audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'tls-cipher-suites'"
@@ -779,6 +829,7 @@ groups:
           kube-apiserver-arg:
           - "tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
         scored: true
+  
   - id: 1.3
     text: "Controller Manager"
     checks:
@@ -793,6 +844,7 @@ groups:
           on the control plane node and set the --terminated-pod-gc-threshold to an appropriate threshold,
           for example, --terminated-pod-gc-threshold=10
         scored: false
+      
       - id: 1.3.2
         text: "Ensure that the --profiling argument is set to false (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'profiling'"
@@ -807,6 +859,7 @@ groups:
           on the control plane node and set the below parameter.
           --profiling=false
         scored: true
+      
       - id: 1.3.3
         text: "Ensure that the --use-service-account-credentials argument is set to true (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'use-service-account-credentials'"
@@ -821,6 +874,7 @@ groups:
           on the control plane node to set the below parameter.
           --use-service-account-credentials=true
         scored: true
+      
       - id: 1.3.4
         text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'service-account-private-key-file'"
@@ -833,6 +887,7 @@ groups:
           to the private key file for service accounts.
           --service-account-private-key-file=<filename>
         scored: true
+      
       - id: 1.3.5
         text: "Ensure that the --root-ca-file argument is set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'root-ca-file'"
@@ -844,6 +899,7 @@ groups:
           on the control plane node and set the --root-ca-file parameter to the certificate bundle file`.
           --root-ca-file=<path/to/file>
         scored: true
+      
       - id: 1.3.6
         text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
         type: "skip"
@@ -864,6 +920,7 @@ groups:
           --feature-gates=RotateKubeletServerCertificate=true
           Not Applicable.
         scored: true
+      
       - id: 1.3.7
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
         audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
@@ -881,6 +938,7 @@ groups:
           Edit the Controller Manager pod specification file $controllermanagerconf
           on the control plane node and ensure the correct value for the --bind-address parameter
         scored: true
+  
   - id: 1.4
     text: "Scheduler"
     checks:
@@ -899,6 +957,7 @@ groups:
           on the control plane node and set the below parameter.
           --profiling=false
         scored: true
+      
       - id: 1.4.2
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'bind-address'"

--- a/package/cfg/k3s-cis-1.8-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/node.yaml
@@ -23,7 +23,7 @@ groups:
           For example, chmod 600 $kubeletsvc
           Not Applicable - All configuration is passed in as arguments at container run time.
         scored: true
-      
+
       - id: 4.1.2
         text: "Ensure that the kubelet service file ownership is set to root:root (Automated)"
         type: "skip"
@@ -38,7 +38,7 @@ groups:
           Not Applicable.
            All configuration is passed in as arguments at container run time.
         scored: true
-      
+
       - id: 4.1.3
         text: "If proxy kubeconfig file exists ensure permissions are set to 600 or more restrictive (Manual)"
         audit: 'stat -c %a /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig'
@@ -54,7 +54,7 @@ groups:
           For example,
           chmod 600 $proxykubeconfig
         scored: false
-      
+
       - id: 4.1.4
         text: "If proxy kubeconfig file exists ensure ownership is set to root:root (Manual)"
         audit: '/bin/sh -c ''if test -e /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig; then stat -c %U:%G /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig; fi'' '
@@ -66,7 +66,7 @@ groups:
           Run the below command (based on the file location on your system) on the each worker node.
           For example, chown root:root $proxykubeconfig
         scored: false
-      
+
       - id: 4.1.5
         text: "Ensure that the --kubeconfig kubelet.conf file permissions are set to 600 or more restrictive (Automated)"
         audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c permissions=%a $kubeletkubeconfig; fi'' '
@@ -81,7 +81,7 @@ groups:
           For example,
           chmod 600 $kubeletkubeconfig
         scored: true
-      
+
       - id: 4.1.6
         text: "Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root (Automated)"
         audit: 'stat -c %U:%G /var/lib/rancher/k3s/agent/kubelet.kubeconfig'
@@ -93,7 +93,7 @@ groups:
           For example,
           chown root:root $kubeletkubeconfig
         scored: true
-      
+
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Manual)"
         audit: "stat -c permissions=%a $kubeletcafile"
@@ -107,7 +107,7 @@ groups:
           Run the following command to modify the file permissions of the
           --client-ca-file chmod 600 <filename>
         scored: false
-      
+
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
         audit: "stat -c %U:%G $kubeletcafile"
@@ -121,7 +121,7 @@ groups:
           Run the following command to modify the ownership of the --client-ca-file.
           chown root:root <filename>
         scored: false
-      
+
       - id: 4.1.9
         text: "Ensure that the kubelet --config configuration file has permissions set to 600 or more restrictive (Automated)"
         audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c permissions=%a $kubeletconf; fi'' '
@@ -135,7 +135,7 @@ groups:
           Run the following command (using the config file location identified in the Audit step)
           chmod 600 $kubeletconf
         scored: true
-      
+
       - id: 4.1.10
         text: "Ensure that the kubelet --config configuration file ownership is set to root:root (Automated)"
         audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c %U:%G $kubeletconf; fi'' '
@@ -146,7 +146,7 @@ groups:
           Run the following command (using the config file location identified in the Audit step)
           chown root:root $kubeletconf
         scored: true
-  
+
   - id: 4.2
     text: "Kubelet"
     checks:
@@ -171,7 +171,7 @@ groups:
           systemctl daemon-reload
           systemctl restart k3s.service
         scored: true
-      
+
       - id: 4.2.2
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
         audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode"; else echo "--authorization-mode=Webhook"; fi'' '
@@ -184,7 +184,7 @@ groups:
                 op: nothave
                 value: AlwaysAllow
         remediation: |
-          By default, K3s does not set the --authorization-mode to AlwaysAllow. 
+          By default, K3s does not set the --authorization-mode to AlwaysAllow.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
           kublet-arg:
           - "authorization-mode=AlwaysAllow"
@@ -194,7 +194,7 @@ groups:
           systemctl daemon-reload
           systemctl restart k3s.service
         scored: true
-      
+
       - id: 4.2.3
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
         audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file"; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
@@ -206,7 +206,7 @@ groups:
           By default, K3s automatically provides the client ca certificate for the Kubelet.
           It is generated and located at /var/lib/rancher/k3s/server/tls/client-ca.crt
         scored: true
-      
+
       - id: 4.2.4
         text: "Verify that the --read-only-port argument is set to 0 (Manual)"
         audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
@@ -233,7 +233,7 @@ groups:
           systemctl daemon-reload
           systemctl restart k3s.service
         scored: false
-      
+
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
         audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
@@ -256,7 +256,7 @@ groups:
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: false
-      
+
       - id: 4.2.6
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
         audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
@@ -279,7 +279,7 @@ groups:
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: true
-      
+
       - id: 4.2.7
         text: "Ensure that the --hostname-override argument is not set (Manual)"
         audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
@@ -293,7 +293,7 @@ groups:
           By default, K3s does set the --hostname-override argument. Per CIS guidelines, this is to comply
           with cloud providers that require this flag to ensure that hostname matches node names.
         scored: false
-      
+
       - id: 4.2.8
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
         audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
@@ -318,7 +318,7 @@ groups:
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: false
-      
+
       - id: 4.2.9
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
         audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
@@ -337,7 +337,7 @@ groups:
           - "tls-cert-file=<path/to/tls-cert-file>"
           - "tls-private-key-file=<path/to/tls-private-key-file>"
         scored: false
-      
+
       - id: 4.2.10
         text: "Ensure that the --rotate-certificates argument is not set to false (Manual)"
         audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
@@ -361,7 +361,7 @@ groups:
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: false
-      
+
       - id: 4.2.11
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
         audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
@@ -379,14 +379,14 @@ groups:
               set: false
         remediation: |
           Not Applicable.
-          By default, K3s does not set the RotateKubeletServerCertificate feature gate. 
+          By default, K3s does not set the RotateKubeletServerCertificate feature gate.
           If you have enabled this feature gate, you should remove it.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any feature-gate=RotateKubeletServerCertificate parameter.
           If using the command line, remove the K3s flag --kublet-arg="feature-gate=RotateKubeletServerCertificate".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: false
-      
+
       - id: 4.2.12
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
         audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
@@ -407,7 +407,7 @@ groups:
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: false
-      
+
       - id: 4.2.13
         text: "Ensure that a limit is set on pod PIDs (Manual)"
         audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"

--- a/package/cfg/k3s-cis-1.8-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/node.yaml
@@ -354,7 +354,7 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          By default, K3s does not set the --rotate-certificates argument. If you have set this to a different value, you should remove it.
+          By default, K3s does not set the --rotate-certificates argument. If you have set this flag with a value of `false`, you should either set it to `true` or completely remove the flag.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any rotate-certificates parameter.
           If using the command line, remove the K3s flag --kublet-arg="rotate-certificates".
           Based on your system, restart the k3s service. For example,
@@ -362,7 +362,7 @@ groups:
         scored: false
 
       - id: 4.2.11
-        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
+        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Automated)"
         audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
@@ -377,14 +377,13 @@ groups:
               path: '{.featureGates.RotateKubeletServerCertificate}'
               set: false
         remediation: |
-          Not Applicable.
           By default, K3s does not set the RotateKubeletServerCertificate feature gate.
           If you have enabled this feature gate, you should remove it.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any feature-gate=RotateKubeletServerCertificate parameter.
           If using the command line, remove the K3s flag --kublet-arg="feature-gate=RotateKubeletServerCertificate".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
-        scored: false
+        scored: true
 
       - id: 4.2.12
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"

--- a/package/cfg/k3s-cis-1.8-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/node.yaml
@@ -161,20 +161,20 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          If using a Kubelet config file, edit the file to set `authentication: anonymous: enabled` to
-          `false`.
-          If using executable arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          `--anonymous-auth=false`
-          Based on your system, restart the kubelet service. For example,
+          By default, K3s sets the --anonymous-auth to false. If you have set this to a different value, you
+          should set it back to false. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
+          kublet-arg:
+          - "anonymous-auth=true"
+          If using the command line, edit the K3s service file and remove the below argument.
+          --kublet-arg="anonymous-auth=true"
+          Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
-          systemctl restart kubelet.service
+          systemctl restart k3s.service
         scored: true
       
       - id: 4.2.2
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
-        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode" | grep -v grep; else echo "--authorization-mode=Webhook"; fi'' '
+        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode"; else echo "--authorization-mode=Webhook"; fi'' '
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -184,38 +184,32 @@ groups:
                 op: nothave
                 value: AlwaysAllow
         remediation: |
-          If using a Kubelet config file, edit the file to set `authorization.mode` to Webhook. If
-          using executable arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_AUTHZ_ARGS variable.
-          --authorization-mode=Webhook
-          Based on your system, restart the kubelet service. For example,
+          By default, K3s does not set the --authorization-mode to AlwaysAllow. 
+          If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
+          kublet-arg:
+          - "authorization-mode=AlwaysAllow"
+          If using the command line, edit the K3s service file and remove the below argument.
+          --kublet-arg="authorization-mode=AlwaysAllow"
+          Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
-          systemctl restart kubelet.service
+          systemctl restart k3s.service
         scored: true
       
       - id: 4.2.3
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
-        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file" | grep -v grep; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
+        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file"; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
         tests:
           test_items:
             - flag: --client-ca-file
               path: '{.authentication.x509.clientCAFile}'
         remediation: |
-          If using a Kubelet config file, edit the file to set `authentication.x509.clientCAFile` to
-          the location of the client CA file.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_AUTHZ_ARGS variable.
-          --client-ca-file=<path/to/client-ca-file>
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          By default, K3s automatically provides the client ca certificate for the Kubelet.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/client-ca.crt
         scored: true
       
       - id: 4.2.4
         text: "Verify that the --read-only-port argument is set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'read-only-port' "
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           bin_op: or
@@ -229,19 +223,20 @@ groups:
               path: '{.readOnlyPort}'
               set: false
         remediation: |
-          If using a Kubelet config file, edit the file to set `readOnlyPort` to 0.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          --read-only-port=0
-          Based on your system, restart the kubelet service. For example,
+          By default, K3s sets the --read-only-port to 0. If you have set this to a different value, you
+          should set it back to 0. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
+          kublet-arg:
+          - "read-only-port=XXXX"
+          If using the command line, edit the K3s service file and remove the below argument.
+          --kublet-arg="read-only-port=XXXX"
+          Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
-          systemctl restart kubelet.service
+          systemctl restart k3s.service
         scored: false
       
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'streaming-connection-idle-timeout'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -254,20 +249,17 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          If using a Kubelet config file, edit the file to set `streamingConnectionIdleTimeout` to a
-          value other than 0.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          --streaming-connection-idle-timeout=5m
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
+          kublet-arg:
+          - "streaming-connection-idle-timeout=5m"
+          If using the command line, run K3s with --kublet-arg="streaming-connection-idle-timeout=5m".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
       
       - id: 4.2.6
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'make-iptables-util-chains'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --make-iptables-util-chains
@@ -280,40 +272,31 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          If using a Kubelet config file, edit the file to set `makeIPTablesUtilChains` to `true`.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          remove the --make-iptables-util-chains argument from the
-          KUBELET_SYSTEM_PODS_ARGS variable.
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter.
+          kublet-arg:
+          - "make-iptables-util-chains=true"
+          If using the command line, run K3s with --kublet-arg="make-iptables-util-chains=true".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: true
       
       - id: 4.2.7
         text: "Ensure that the --hostname-override argument is not set (Manual)"
-        # This is one of those properties that can only be set as a command line argument.
-        # To check if the property is set as expected, we need to parse the kubelet command
-        # instead reading the Kubelet Configuration file.
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         type: "skip"
-        audit: "/bin/ps -fC $kubeletbin "
         tests:
           test_items:
             - flag: --hostname-override
               set: false
         remediation: |
-          Edit the kubelet service file $kubeletsvc
-          on each worker node and remove the --hostname-override argument from the
-          KUBELET_SYSTEM_PODS_ARGS variable.
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
           Not Applicable.
+          By default, K3s does set the --hostname-override argument. Per CIS guidelines, this is to comply
+          with cloud providers that require this flag to ensure that hostname matches node names.
         scored: false
       
       - id: 4.2.8
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -327,18 +310,17 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          If using a Kubelet config file, edit the file to set `eventRecordQPS` to an appropriate level.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          By default, K3s sets the event-qps to 0. Should you wish to change this,
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
+          kublet-arg:
+          - "event-qps=<value>"
+          If using the command line, run K3s with --kublet-arg="event-qps=<value>".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
       
       - id: 4.2.9
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
-        type: "skip"
         audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
@@ -347,23 +329,18 @@ groups:
             - flag: --tls-private-key-file
               path: '/var/lib/rancher/k3s/agent/serving-kubelet.key'
         remediation: |
-          If using a Kubelet config file, edit the file to set `tlsCertFile` to the location
-          of the certificate file to use to identify this Kubelet, and `tlsPrivateKeyFile`
-          to the location of the corresponding private key file.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameters in KUBELET_CERTIFICATE_ARGS variable.
-          --tls-cert-file=<path/to/tls-certificate-file>
-          --tls-private-key-file=<path/to/tls-key-file>
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
-          Permissive - When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
+          By default, K3s automatically provides the TLS certificate and private key for the Kubelet.
+          They are generated and located at /var/lib/rancher/k3s/agent/serving-kubelet.crt and /var/lib/rancher/k3s/agent/serving-kubelet.key
+          If for some reason you need to provide your own certificate and key, you can set the
+          the below parameters in the K3s config file /etc/rancher/k3s/config.yaml.
+          kubelet-arg:
+          - "tls-cert-file=<path/to/tls-cert-file>"
+          - "tls-private-key-file=<path/to/tls-private-key-file>"
         scored: false
       
       - id: 4.2.10
         text: "Ensure that the --rotate-certificates argument is not set to false (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -377,20 +354,17 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          If using a Kubelet config file, edit the file to add the line `rotateCertificates` to `true` or
-          remove it altogether to use the default value.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          remove --rotate-certificates=false argument from the KUBELET_CERTIFICATE_ARGS
-          variable.
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          Not Applicable.
+          By default, K3s does not set the --rotate-certificates argument. If you have set this to a different value, you should remove it.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, remove any rotate-certificates parameter.
+          If using the command line, remove the K3s flag --kublet-arg="rotate-certificates".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
       
       - id: 4.2.11
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
           bin_op: or
@@ -404,18 +378,18 @@ groups:
               path: '{.featureGates.RotateKubeletServerCertificate}'
               set: false
         remediation: |
-          Edit the kubelet service file $kubeletsvc
-          on each worker node and set the below parameter in KUBELET_CERTIFICATE_ARGS variable.
-          --feature-gates=RotateKubeletServerCertificate=true
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload
-          systemctl restart kubelet.service
           Not Applicable.
+          By default, K3s does not set the RotateKubeletServerCertificate feature gate. 
+          If you have enabled this feature gate, you should remove it.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, remove any feature-gate=RotateKubeletServerCertificate parameter.
+          If using the command line, remove the K3s flag --kublet-arg="feature-gate=RotateKubeletServerCertificate".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
       
       - id: 4.2.12
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -425,21 +399,18 @@ groups:
                 op: valid_elements
                 value: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
         remediation: |
-          If using a Kubelet config file, edit the file to set `TLSCipherSuites` to
-          TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+          If using a K3s config file /etc/rancher/k3s/config.yaml, edit the file to set `TLSCipherSuites` to
+          kubelet-arg:
+          - "tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
           or to a subset of these values.
-          If using executable arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the --tls-cipher-suites parameter as follows, or to a subset of these values.
-          --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          If using the command line, add the K3s flag --kubelet-arg="tls-cipher-suites=<same values as above>"
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
       
       - id: 4.2.13
         text: "Ensure that a limit is set on pod PIDs (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -447,5 +418,7 @@ groups:
               path: '{.podPidsLimit}'
         remediation: |
           Decide on an appropriate level for this parameter and set it,
-          either via the --pod-max-pids command line parameter or the PodPidsLimit configuration file setting.
+          If using a K3s config file /etc/rancher/k3s/config.yaml, edit the file to set `podPidsLimit` to
+          kubelet-arg:
+          - "pod-max-pids=<value>"
         scored: false

--- a/package/cfg/k3s-cis-1.8-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/node.yaml
@@ -41,7 +41,7 @@ groups:
 
       - id: 4.1.3
         text: "If proxy kubeconfig file exists ensure permissions are set to 600 or more restrictive (Manual)"
-        audit: 'stat -c %a /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig'
+        audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c permissions=%a $proxykubeconfig; fi'' '
         tests:
           bin_op: or
           test_items:
@@ -354,7 +354,6 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          Not Applicable.
           By default, K3s does not set the --rotate-certificates argument. If you have set this to a different value, you should remove it.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any rotate-certificates parameter.
           If using the command line, remove the K3s flag --kublet-arg="rotate-certificates".

--- a/package/cfg/k3s-cis-1.8-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/node.yaml
@@ -163,10 +163,10 @@ groups:
         remediation: |
           By default, K3s sets the --anonymous-auth to false. If you have set this to a different value, you
           should set it back to false. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
-          kublet-arg:
+          kubelet-arg:
           - "anonymous-auth=true"
           If using the command line, edit the K3s service file and remove the below argument.
-          --kublet-arg="anonymous-auth=true"
+          --kubelet-arg="anonymous-auth=true"
           Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
           systemctl restart k3s.service
@@ -186,10 +186,10 @@ groups:
         remediation: |
           By default, K3s does not set the --authorization-mode to AlwaysAllow.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
-          kublet-arg:
+          kubelet-arg:
           - "authorization-mode=AlwaysAllow"
           If using the command line, edit the K3s service file and remove the below argument.
-          --kublet-arg="authorization-mode=AlwaysAllow"
+          --kubelet-arg="authorization-mode=AlwaysAllow"
           Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
           systemctl restart k3s.service
@@ -225,10 +225,10 @@ groups:
         remediation: |
           By default, K3s sets the --read-only-port to 0. If you have set this to a different value, you
           should set it back to 0. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
-          kublet-arg:
+          kubelet-arg:
           - "read-only-port=XXXX"
           If using the command line, edit the K3s service file and remove the below argument.
-          --kublet-arg="read-only-port=XXXX"
+          --kubelet-arg="read-only-port=XXXX"
           Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
           systemctl restart k3s.service
@@ -250,9 +250,9 @@ groups:
           bin_op: or
         remediation: |
           If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
-          kublet-arg:
+          kubelet-arg:
           - "streaming-connection-idle-timeout=5m"
-          If using the command line, run K3s with --kublet-arg="streaming-connection-idle-timeout=5m".
+          If using the command line, run K3s with --kubelet-arg="streaming-connection-idle-timeout=5m".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: false
@@ -273,9 +273,9 @@ groups:
           bin_op: or
         remediation: |
           If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter.
-          kublet-arg:
+          kubelet-arg:
           - "make-iptables-util-chains=true"
-          If using the command line, run K3s with --kublet-arg="make-iptables-util-chains=true".
+          If using the command line, run K3s with --kubelet-arg="make-iptables-util-chains=true".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: true
@@ -312,9 +312,9 @@ groups:
         remediation: |
           By default, K3s sets the event-qps to 0. Should you wish to change this,
           If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
-          kublet-arg:
+          kubelet-arg:
           - "event-qps=<value>"
-          If using the command line, run K3s with --kublet-arg="event-qps=<value>".
+          If using the command line, run K3s with --kubelet-arg="event-qps=<value>".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: false
@@ -356,7 +356,7 @@ groups:
         remediation: |
           By default, K3s does not set the --rotate-certificates argument. If you have set this flag with a value of `false`, you should either set it to `true` or completely remove the flag.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any rotate-certificates parameter.
-          If using the command line, remove the K3s flag --kublet-arg="rotate-certificates".
+          If using the command line, remove the K3s flag --kubelet-arg="rotate-certificates".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: false
@@ -380,7 +380,7 @@ groups:
           By default, K3s does not set the RotateKubeletServerCertificate feature gate.
           If you have enabled this feature gate, you should remove it.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any feature-gate=RotateKubeletServerCertificate parameter.
-          If using the command line, remove the K3s flag --kublet-arg="feature-gate=RotateKubeletServerCertificate".
+          If using the command line, remove the K3s flag --kubelet-arg="feature-gate=RotateKubeletServerCertificate".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: true

--- a/package/cfg/k3s-cis-1.8-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/node.yaml
@@ -23,6 +23,7 @@ groups:
           For example, chmod 600 $kubeletsvc
           Not Applicable - All configuration is passed in as arguments at container run time.
         scored: true
+      
       - id: 4.1.2
         text: "Ensure that the kubelet service file ownership is set to root:root (Automated)"
         type: "skip"
@@ -37,6 +38,7 @@ groups:
           Not Applicable.
            All configuration is passed in as arguments at container run time.
         scored: true
+      
       - id: 4.1.3
         text: "If proxy kubeconfig file exists ensure permissions are set to 600 or more restrictive (Manual)"
         audit: 'stat -c %a /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig'
@@ -52,6 +54,7 @@ groups:
           For example,
           chmod 600 $proxykubeconfig
         scored: false
+      
       - id: 4.1.4
         text: "If proxy kubeconfig file exists ensure ownership is set to root:root (Manual)"
         audit: '/bin/sh -c ''if test -e /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig; then stat -c %U:%G /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig; fi'' '
@@ -63,6 +66,7 @@ groups:
           Run the below command (based on the file location on your system) on the each worker node.
           For example, chown root:root $proxykubeconfig
         scored: false
+      
       - id: 4.1.5
         text: "Ensure that the --kubeconfig kubelet.conf file permissions are set to 600 or more restrictive (Automated)"
         audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c permissions=%a $kubeletkubeconfig; fi'' '
@@ -77,6 +81,7 @@ groups:
           For example,
           chmod 600 $kubeletkubeconfig
         scored: true
+      
       - id: 4.1.6
         text: "Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root (Automated)"
         audit: 'stat -c %U:%G /var/lib/rancher/k3s/agent/kubelet.kubeconfig'
@@ -88,6 +93,7 @@ groups:
           For example,
           chown root:root $kubeletkubeconfig
         scored: true
+      
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Manual)"
         audit: "stat -c permissions=%a $kubeletcafile"
@@ -101,6 +107,7 @@ groups:
           Run the following command to modify the file permissions of the
           --client-ca-file chmod 600 <filename>
         scored: false
+      
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
         audit: "stat -c %U:%G $kubeletcafile"
@@ -114,6 +121,7 @@ groups:
           Run the following command to modify the ownership of the --client-ca-file.
           chown root:root <filename>
         scored: false
+      
       - id: 4.1.9
         text: "Ensure that the kubelet --config configuration file has permissions set to 600 or more restrictive (Automated)"
         audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c permissions=%a $kubeletconf; fi'' '
@@ -127,6 +135,7 @@ groups:
           Run the following command (using the config file location identified in the Audit step)
           chmod 600 $kubeletconf
         scored: true
+      
       - id: 4.1.10
         text: "Ensure that the kubelet --config configuration file ownership is set to root:root (Automated)"
         audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c %U:%G $kubeletconf; fi'' '
@@ -137,6 +146,7 @@ groups:
           Run the following command (using the config file location identified in the Audit step)
           chown root:root $kubeletconf
         scored: true
+  
   - id: 4.2
     text: "Kubelet"
     checks:
@@ -161,6 +171,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: true
+      
       - id: 4.2.2
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
         audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode" | grep -v grep; else echo "--authorization-mode=Webhook"; fi'' '
@@ -182,6 +193,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: true
+      
       - id: 4.2.3
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
         audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file" | grep -v grep; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
@@ -200,6 +212,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: true
+      
       - id: 4.2.4
         text: "Verify that the --read-only-port argument is set to 0 (Manual)"
         audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'read-only-port' "
@@ -225,6 +238,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: false
+      
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
         audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'streaming-connection-idle-timeout'"
@@ -250,6 +264,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: false
+      
       - id: 4.2.6
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
         audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'make-iptables-util-chains'"
@@ -274,6 +289,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: true
+      
       - id: 4.2.7
         text: "Ensure that the --hostname-override argument is not set (Manual)"
         # This is one of those properties that can only be set as a command line argument.
@@ -294,6 +310,7 @@ groups:
           systemctl restart kubelet.service
           Not Applicable.
         scored: false
+      
       - id: 4.2.8
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
         audit: "/bin/ps -fC $kubeletbin"
@@ -318,6 +335,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: false
+      
       - id: 4.2.9
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
         type: "skip"
@@ -342,6 +360,7 @@ groups:
           systemctl restart kubelet.service
           Permissive - When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
         scored: false
+      
       - id: 4.2.10
         text: "Ensure that the --rotate-certificates argument is not set to false (Manual)"
         audit: "/bin/ps -fC $kubeletbin"
@@ -368,6 +387,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: false
+      
       - id: 4.2.11
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
         audit: "/bin/ps -fC $kubeletbin"
@@ -392,6 +412,7 @@ groups:
           systemctl restart kubelet.service
           Not Applicable.
         scored: false
+      
       - id: 4.2.12
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
         audit: "/bin/ps -fC $kubeletbin"
@@ -415,6 +436,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: false
+      
       - id: 4.2.13
         text: "Ensure that a limit is set on pod PIDs (Manual)"
         audit: "/bin/ps -fC $kubeletbin"

--- a/package/cfg/k3s-cis-1.8-hardened/policies.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/policies.yaml
@@ -18,14 +18,14 @@ groups:
           clusterrolebinding to the cluster-admin role :
           kubectl delete clusterrolebinding [name]
         scored: false
-      
+
       - id: 5.1.2
         text: "Minimize access to secrets (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove get, list and watch access to Secret objects in the cluster.
         scored: false
-      
+
       - id: 5.1.3
         text: "Minimize wildcard use in Roles and ClusterRoles (Manual)"
         type: "manual"
@@ -33,14 +33,14 @@ groups:
           Where possible replace any use of wildcards in clusterroles and roles with specific
           objects or actions.
         scored: false
-      
+
       - id: 5.1.4
         text: "Minimize access to create pods (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove create access to pod objects in the cluster.
         scored: false
-      
+
       - id: 5.1.5
         text: "Ensure that default service accounts are not actively used. (Manual)"
         audit: check_for_default_sa.sh
@@ -57,7 +57,7 @@ groups:
           Modify the configuration of each default service account to include this value
           automountServiceAccountToken: false
         scored: false
-      
+
       - id: 5.1.6
         text: "Ensure that Service Account Tokens are only mounted where necessary (Manual)"
         type: "manual"
@@ -65,56 +65,56 @@ groups:
           Modify the definition of pods and service accounts which do not need to mount service
           account tokens to disable it.
         scored: false
-      
+
       - id: 5.1.7
         text: "Avoid use of system:masters group (Manual)"
         type: "manual"
         remediation: |
           Remove the system:masters group from all users in the cluster.
         scored: false
-      
+
       - id: 5.1.8
         text: "Limit use of the Bind, Impersonate and Escalate permissions in the Kubernetes cluster (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove the impersonate, bind and escalate rights from subjects.
         scored: false
-      
+
       - id: 5.1.9
         text: "Minimize access to create persistent volumes (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove create access to PersistentVolume objects in the cluster.
         scored: false
-      
+
       - id: 5.1.10
         text: "Minimize access to the proxy sub-resource of nodes (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove access to the proxy sub-resource of node objects.
         scored: false
-      
+
       - id: 5.1.11
         text: "Minimize access to the approval sub-resource of certificatesigningrequests objects (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove access to the approval sub-resource of certificatesigningrequest objects.
         scored: false
-      
+
       - id: 5.1.12
         text: "Minimize access to webhook configuration objects (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove access to the validatingwebhookconfigurations or mutatingwebhookconfigurations objects
         scored: false
-      
+
       - id: 5.1.13
         text: "Minimize access to the service account token creation (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove access to the token sub-resource of serviceaccount objects.
         scored: false
-  
+
   - id: 5.2
     text: "Pod Security Standards"
     checks:
@@ -125,7 +125,7 @@ groups:
           Ensure that either Pod Security Admission or an external policy control system is in place
           for every namespace which contains user workloads.
         scored: false
-      
+
       - id: 5.2.2
         text: "Minimize the admission of privileged containers (Manual)"
         type: "manual"
@@ -133,28 +133,28 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of privileged containers.
         scored: false
-      
+
       - id: 5.2.3
         text: "Minimize the admission of containers wishing to share the host process ID namespace (Automated)"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostPID` containers.
         scored: false
-      
+
       - id: 5.2.4
         text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostIPC` containers.
         scored: false
-      
+
       - id: 5.2.5
         text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostNetwork` containers.
         scored: false
-      
+
       - id: 5.2.6
         text: "Minimize the admission of containers with allowPrivilegeEscalation (Automated)"
         type: "manual"
@@ -162,7 +162,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with `.spec.allowPrivilegeEscalation` set to `true`.
         scored: true
-      
+
       - id: 5.2.7
         text: "Minimize the admission of root containers (Automated)"
         type: "manual"
@@ -170,7 +170,7 @@ groups:
           Create a policy for each namespace in the cluster, ensuring that either `MustRunAsNonRoot`
           or `MustRunAs` with the range of UIDs not including 0, is set.
         scored: false
-      
+
       - id: 5.2.8
         text: "Minimize the admission of containers with the NET_RAW capability (Automated)"
         type: "manual"
@@ -178,7 +178,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with the `NET_RAW` capability.
         scored: false
-      
+
       - id: 5.2.9
         text: "Minimize the admission of containers with added capabilities (Automated)"
         type: "manual"
@@ -186,7 +186,7 @@ groups:
           Ensure that `allowedCapabilities` is not present in policies for the cluster unless
           it is set to an empty array.
         scored: false
-      
+
       - id: 5.2.10
         text: "Minimize the admission of containers with capabilities assigned (Manual)"
         type: "manual"
@@ -195,7 +195,7 @@ groups:
           contains applicaions which do not require any Linux capabities to operate consider adding
           a PSP which forbids the admission of containers which do not drop all capabilities.
         scored: false
-      
+
       - id: 5.2.11
         text: "Minimize the admission of Windows HostProcess containers (Manual)"
         type: "manual"
@@ -203,7 +203,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers that have `.securityContext.windowsOptions.hostProcess` set to `true`.
         scored: false
-      
+
       - id: 5.2.12
         text: "Minimize the admission of HostPath volumes (Manual)"
         type: "manual"
@@ -211,7 +211,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with `hostPath` volumes.
         scored: false
-      
+
       - id: 5.2.13
         text: "Minimize the admission of containers which use HostPorts (Manual)"
         type: "manual"
@@ -219,7 +219,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers which use `hostPort` sections.
         scored: false
-  
+
   - id: 5.3
     text: "Network Policies and CNI"
     checks:
@@ -231,13 +231,13 @@ groups:
           making use of a different plugin, or finding an alternate mechanism for restricting traffic
           in the Kubernetes cluster.
         scored: false
-      
+
       - id: 5.3.2
         text: "Ensure that all Namespaces have NetworkPolicies defined (Manual)"
         remediation: |
           Follow the documentation and create NetworkPolicy objects as you need them.
         scored: false
-  
+
   - id: 5.4
     text: "Secrets Management"
     checks:
@@ -248,7 +248,7 @@ groups:
           If possible, rewrite application code to read Secrets from mounted secret files, rather than
           from environment variables.
         scored: false
-      
+
       - id: 5.4.2
         text: "Consider external secret storage (Manual)"
         type: "manual"
@@ -256,7 +256,7 @@ groups:
           Refer to the Secrets management options offered by your cloud provider or a third-party
           secrets management solution.
         scored: false
-  
+
   - id: 5.5
     text: "Extensible Admission Control"
     checks:
@@ -266,7 +266,7 @@ groups:
         remediation: |
           Follow the Kubernetes documentation and setup image provenance.
         scored: false
-  
+
   - id: 5.7
     text: "General Policies"
     checks:
@@ -277,7 +277,7 @@ groups:
           Follow the documentation and create namespaces for objects in your deployment as you need
           them.
         scored: false
-      
+
       - id: 5.7.2
         text: "Ensure that the seccomp profile is set to docker/default in your Pod definitions (Manual)"
         type: "manual"
@@ -288,7 +288,7 @@ groups:
               seccompProfile:
                 type: RuntimeDefault
         scored: false
-      
+
       - id: 5.7.3
         text: "Apply SecurityContext to your Pods and Containers (Manual)"
         type: "manual"
@@ -297,7 +297,7 @@ groups:
           suggested list of SecurityContexts, you may refer to the CIS Security Benchmark for Docker
           Containers.
         scored: false
-      
+
       - id: 5.7.4
         text: "The default namespace should not be used (Manual)"
         remediation: |

--- a/package/cfg/k3s-cis-1.8-hardened/policies.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/policies.yaml
@@ -18,12 +18,14 @@ groups:
           clusterrolebinding to the cluster-admin role :
           kubectl delete clusterrolebinding [name]
         scored: false
+      
       - id: 5.1.2
         text: "Minimize access to secrets (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove get, list and watch access to Secret objects in the cluster.
         scored: false
+      
       - id: 5.1.3
         text: "Minimize wildcard use in Roles and ClusterRoles (Manual)"
         type: "manual"
@@ -31,12 +33,14 @@ groups:
           Where possible replace any use of wildcards in clusterroles and roles with specific
           objects or actions.
         scored: false
+      
       - id: 5.1.4
         text: "Minimize access to create pods (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove create access to pod objects in the cluster.
         scored: false
+      
       - id: 5.1.5
         text: "Ensure that default service accounts are not actively used. (Manual)"
         audit: check_for_default_sa.sh
@@ -53,6 +57,7 @@ groups:
           Modify the configuration of each default service account to include this value
           automountServiceAccountToken: false
         scored: false
+      
       - id: 5.1.6
         text: "Ensure that Service Account Tokens are only mounted where necessary (Manual)"
         type: "manual"
@@ -60,48 +65,56 @@ groups:
           Modify the definition of pods and service accounts which do not need to mount service
           account tokens to disable it.
         scored: false
+      
       - id: 5.1.7
         text: "Avoid use of system:masters group (Manual)"
         type: "manual"
         remediation: |
           Remove the system:masters group from all users in the cluster.
         scored: false
+      
       - id: 5.1.8
         text: "Limit use of the Bind, Impersonate and Escalate permissions in the Kubernetes cluster (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove the impersonate, bind and escalate rights from subjects.
         scored: false
+      
       - id: 5.1.9
         text: "Minimize access to create persistent volumes (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove create access to PersistentVolume objects in the cluster.
         scored: false
+      
       - id: 5.1.10
         text: "Minimize access to the proxy sub-resource of nodes (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove access to the proxy sub-resource of node objects.
         scored: false
+      
       - id: 5.1.11
         text: "Minimize access to the approval sub-resource of certificatesigningrequests objects (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove access to the approval sub-resource of certificatesigningrequest objects.
         scored: false
+      
       - id: 5.1.12
         text: "Minimize access to webhook configuration objects (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove access to the validatingwebhookconfigurations or mutatingwebhookconfigurations objects
         scored: false
+      
       - id: 5.1.13
         text: "Minimize access to the service account token creation (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove access to the token sub-resource of serviceaccount objects.
         scored: false
+  
   - id: 5.2
     text: "Pod Security Standards"
     checks:
@@ -112,6 +125,7 @@ groups:
           Ensure that either Pod Security Admission or an external policy control system is in place
           for every namespace which contains user workloads.
         scored: false
+      
       - id: 5.2.2
         text: "Minimize the admission of privileged containers (Manual)"
         type: "manual"
@@ -119,24 +133,28 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of privileged containers.
         scored: false
+      
       - id: 5.2.3
         text: "Minimize the admission of containers wishing to share the host process ID namespace (Automated)"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostPID` containers.
         scored: false
+      
       - id: 5.2.4
         text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostIPC` containers.
         scored: false
+      
       - id: 5.2.5
         text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostNetwork` containers.
         scored: false
+      
       - id: 5.2.6
         text: "Minimize the admission of containers with allowPrivilegeEscalation (Automated)"
         type: "manual"
@@ -144,6 +162,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with `.spec.allowPrivilegeEscalation` set to `true`.
         scored: true
+      
       - id: 5.2.7
         text: "Minimize the admission of root containers (Automated)"
         type: "manual"
@@ -151,6 +170,7 @@ groups:
           Create a policy for each namespace in the cluster, ensuring that either `MustRunAsNonRoot`
           or `MustRunAs` with the range of UIDs not including 0, is set.
         scored: false
+      
       - id: 5.2.8
         text: "Minimize the admission of containers with the NET_RAW capability (Automated)"
         type: "manual"
@@ -158,6 +178,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with the `NET_RAW` capability.
         scored: false
+      
       - id: 5.2.9
         text: "Minimize the admission of containers with added capabilities (Automated)"
         type: "manual"
@@ -165,6 +186,7 @@ groups:
           Ensure that `allowedCapabilities` is not present in policies for the cluster unless
           it is set to an empty array.
         scored: false
+      
       - id: 5.2.10
         text: "Minimize the admission of containers with capabilities assigned (Manual)"
         type: "manual"
@@ -173,6 +195,7 @@ groups:
           contains applicaions which do not require any Linux capabities to operate consider adding
           a PSP which forbids the admission of containers which do not drop all capabilities.
         scored: false
+      
       - id: 5.2.11
         text: "Minimize the admission of Windows HostProcess containers (Manual)"
         type: "manual"
@@ -180,6 +203,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers that have `.securityContext.windowsOptions.hostProcess` set to `true`.
         scored: false
+      
       - id: 5.2.12
         text: "Minimize the admission of HostPath volumes (Manual)"
         type: "manual"
@@ -187,6 +211,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with `hostPath` volumes.
         scored: false
+      
       - id: 5.2.13
         text: "Minimize the admission of containers which use HostPorts (Manual)"
         type: "manual"
@@ -194,6 +219,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers which use `hostPort` sections.
         scored: false
+  
   - id: 5.3
     text: "Network Policies and CNI"
     checks:
@@ -205,11 +231,13 @@ groups:
           making use of a different plugin, or finding an alternate mechanism for restricting traffic
           in the Kubernetes cluster.
         scored: false
+      
       - id: 5.3.2
         text: "Ensure that all Namespaces have NetworkPolicies defined (Manual)"
         remediation: |
           Follow the documentation and create NetworkPolicy objects as you need them.
         scored: false
+  
   - id: 5.4
     text: "Secrets Management"
     checks:
@@ -220,6 +248,7 @@ groups:
           If possible, rewrite application code to read Secrets from mounted secret files, rather than
           from environment variables.
         scored: false
+      
       - id: 5.4.2
         text: "Consider external secret storage (Manual)"
         type: "manual"
@@ -227,6 +256,7 @@ groups:
           Refer to the Secrets management options offered by your cloud provider or a third-party
           secrets management solution.
         scored: false
+  
   - id: 5.5
     text: "Extensible Admission Control"
     checks:
@@ -236,6 +266,7 @@ groups:
         remediation: |
           Follow the Kubernetes documentation and setup image provenance.
         scored: false
+  
   - id: 5.7
     text: "General Policies"
     checks:
@@ -246,6 +277,7 @@ groups:
           Follow the documentation and create namespaces for objects in your deployment as you need
           them.
         scored: false
+      
       - id: 5.7.2
         text: "Ensure that the seccomp profile is set to docker/default in your Pod definitions (Manual)"
         type: "manual"
@@ -256,6 +288,7 @@ groups:
               seccompProfile:
                 type: RuntimeDefault
         scored: false
+      
       - id: 5.7.3
         text: "Apply SecurityContext to your Pods and Containers (Manual)"
         type: "manual"
@@ -264,6 +297,7 @@ groups:
           suggested list of SecurityContexts, you may refer to the CIS Security Benchmark for Docker
           Containers.
         scored: false
+      
       - id: 5.7.4
         text: "The default namespace should not be used (Manual)"
         remediation: |

--- a/package/cfg/k3s-cis-1.8-permissive/controlplane.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/controlplane.yaml
@@ -15,7 +15,7 @@ groups:
           Alternative mechanisms provided by Kubernetes such as the use of OIDC should be
           implemented in place of client certificates.
         scored: false
-      
+
       - id: 3.1.2
         text: "Service account token authentication should not be used for users (Manual)"
         type: "manual"
@@ -23,7 +23,7 @@ groups:
           Alternative mechanisms provided by Kubernetes such as the use of OIDC should be implemented
           in place of service account tokens.
         scored: false
-      
+
       - id: 3.1.3
         text: "Bootstrap token authentication should not be used for users (Manual)"
         type: "manual"
@@ -31,7 +31,7 @@ groups:
           Alternative mechanisms provided by Kubernetes such as the use of OIDC should be implemented
           in place of bootstrap tokens.
         scored: false
-  
+
   - id: 3.2
     text: "Logging"
     checks:
@@ -45,7 +45,7 @@ groups:
         remediation: |
           Create an audit policy file for your cluster.
         scored: false
-      
+
       - id: 3.2.2
         text: "Ensure that the audit policy covers key security concerns (Manual)"
         type: "manual"

--- a/package/cfg/k3s-cis-1.8-permissive/controlplane.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/controlplane.yaml
@@ -15,6 +15,7 @@ groups:
           Alternative mechanisms provided by Kubernetes such as the use of OIDC should be
           implemented in place of client certificates.
         scored: false
+      
       - id: 3.1.2
         text: "Service account token authentication should not be used for users (Manual)"
         type: "manual"
@@ -22,6 +23,7 @@ groups:
           Alternative mechanisms provided by Kubernetes such as the use of OIDC should be implemented
           in place of service account tokens.
         scored: false
+      
       - id: 3.1.3
         text: "Bootstrap token authentication should not be used for users (Manual)"
         type: "manual"
@@ -29,6 +31,7 @@ groups:
           Alternative mechanisms provided by Kubernetes such as the use of OIDC should be implemented
           in place of bootstrap tokens.
         scored: false
+  
   - id: 3.2
     text: "Logging"
     checks:
@@ -42,6 +45,7 @@ groups:
         remediation: |
           Create an audit policy file for your cluster.
         scored: false
+      
       - id: 3.2.2
         text: "Ensure that the audit policy covers key security concerns (Manual)"
         type: "manual"

--- a/package/cfg/k3s-cis-1.8-permissive/etcd.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/etcd.yaml
@@ -27,7 +27,7 @@ groups:
           --cert-file=</path/to/ca-file>
           --key-file=</path/to/key-file>
         scored: true
-      
+
       - id: 2.2
         text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
         audit: "check_for_k3s_etcd.sh 2.2"
@@ -47,7 +47,7 @@ groups:
           node and set the below parameter.
           --client-cert-auth="true"
         scored: true
-      
+
       - id: 2.3
         text: "Ensure that the --auto-tls argument is not set to true (Automated)"
         audit: "check_for_k3s_etcd.sh 2.3"
@@ -67,7 +67,7 @@ groups:
           node and either remove the --auto-tls parameter or set it to false.
             --auto-tls=false
         scored: true
-      
+
       - id: 2.4
         text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
         audit: "check_for_k3s_etcd.sh 2.4"
@@ -88,7 +88,7 @@ groups:
           --peer-client-file=</path/to/peer-cert-file>
           --peer-key-file=</path/to/peer-key-file>
         scored: true
-      
+
       - id: 2.5
         text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
         audit: "check_for_k3s_etcd.sh 2.5"
@@ -108,7 +108,7 @@ groups:
           node and set the below parameter.
           --peer-client-cert-auth=true
         scored: true
-      
+
       - id: 2.6
         text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
         audit: "check_for_k3s_etcd.sh 2.6"
@@ -129,7 +129,7 @@ groups:
           node and either remove the --peer-auto-tls parameter or set it to false.
           --peer-auto-tls=false
         scored: true
-      
+
       - id: 2.7
         text: "Ensure that a unique Certificate Authority is used for etcd (Automated)"
         audit: "check_for_k3s_etcd.sh 2.7"

--- a/package/cfg/k3s-cis-1.8-permissive/etcd.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/etcd.yaml
@@ -27,6 +27,7 @@ groups:
           --cert-file=</path/to/ca-file>
           --key-file=</path/to/key-file>
         scored: true
+      
       - id: 2.2
         text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
         audit: "check_for_k3s_etcd.sh 2.2"
@@ -46,6 +47,7 @@ groups:
           node and set the below parameter.
           --client-cert-auth="true"
         scored: true
+      
       - id: 2.3
         text: "Ensure that the --auto-tls argument is not set to true (Automated)"
         audit: "check_for_k3s_etcd.sh 2.3"
@@ -65,6 +67,7 @@ groups:
           node and either remove the --auto-tls parameter or set it to false.
             --auto-tls=false
         scored: true
+      
       - id: 2.4
         text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
         audit: "check_for_k3s_etcd.sh 2.4"
@@ -85,6 +88,7 @@ groups:
           --peer-client-file=</path/to/peer-cert-file>
           --peer-key-file=</path/to/peer-key-file>
         scored: true
+      
       - id: 2.5
         text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
         audit: "check_for_k3s_etcd.sh 2.5"
@@ -104,6 +108,7 @@ groups:
           node and set the below parameter.
           --peer-client-cert-auth=true
         scored: true
+      
       - id: 2.6
         text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
         audit: "check_for_k3s_etcd.sh 2.6"
@@ -124,6 +129,7 @@ groups:
           node and either remove the --peer-auto-tls parameter or set it to false.
           --peer-auto-tls=false
         scored: true
+      
       - id: 2.7
         text: "Ensure that a unique Certificate Authority is used for etcd (Automated)"
         audit: "check_for_k3s_etcd.sh 2.7"

--- a/package/cfg/k3s-cis-1.8-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/master.yaml
@@ -24,7 +24,7 @@ groups:
           For example, chmod 600 $apiserverconf
           Not Applicable.
         scored: true
-      
+
       - id: 1.1.2
         text: "Ensure that the API server pod specification file ownership is set to root:root (Automated)"
         type: "skip"
@@ -37,7 +37,7 @@ groups:
           For example, chown root:root $apiserverconf
           Not Applicable.
         scored: true
-      
+
       - id: 1.1.3
         text: "Ensure that the controller manager pod specification file permissions are set to 600 or more restrictive (Automated)"
         type: "skip"
@@ -53,7 +53,7 @@ groups:
           For example, chmod 600 $controllermanagerconf
           Not Applicable.
         scored: true
-      
+
       - id: 1.1.4
         text: "Ensure that the controller manager pod specification file ownership is set to root:root (Automated)"
         type: "skip"
@@ -66,7 +66,7 @@ groups:
           For example, chown root:root $controllermanagerconf
           Not Applicable.
         scored: true
-      
+
       - id: 1.1.5
         text: "Ensure that the scheduler pod specification file permissions are set to 600 or more restrictive (Automated)"
         type: "skip"
@@ -82,7 +82,7 @@ groups:
           For example, chmod 600 $schedulerconf
           Not Applicable.
         scored: true
-      
+
       - id: 1.1.6
         text: "Ensure that the scheduler pod specification file ownership is set to root:root (Automated)"
         type: "skip"
@@ -95,7 +95,7 @@ groups:
           For example, chown root:root $schedulerconf
           Not Applicable.
         scored: true
-      
+
       - id: 1.1.7
         text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
         type: "skip"
@@ -113,7 +113,7 @@ groups:
           chmod 600 $etcdconf
           Not Applicable.
         scored: true
-      
+
       - id: 1.1.8
         text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
         type: "skip"
@@ -128,7 +128,7 @@ groups:
           chown root:root $etcdconf
           Not Applicable.
         scored: true
-      
+
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Automated)"
         type: "skip"
@@ -147,7 +147,7 @@ groups:
           For example, chmod 600 <path/to/cni/files>
           Not Applicable.
         scored: false
-      
+
       - id: 1.1.10
         text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
         type: skip
@@ -164,7 +164,7 @@ groups:
           chown root:root <path/to/cni/files>
           Not Applicable.
         scored: false
-      
+
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
         audit: "check_for_k3s_etcd.sh 1.1.11"
@@ -181,7 +181,7 @@ groups:
           Run the below command (based on the etcd data directory found above). For example,
           chmod 700 /var/lib/etcd
         scored: true
-      
+
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
         audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G
@@ -196,7 +196,7 @@ groups:
           For example, chown etcd:etcd /var/lib/etcd
           Not Applicable.
         scored: true
-      
+
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 600 or more restrictive (Automated)"
         audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/admin.kubeconfig'"
@@ -211,7 +211,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chmod 600 /var/lib/rancher/k3s/server/cred/admin.kubeconfig
         scored: true
-      
+
       - id: 1.1.14
         text: "Ensure that the admin.conf file ownership is set to root:root (Automated)"
         audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c %U:%G /var/lib/rancher/k3s/server/cred/admin.kubeconfig; fi'"
@@ -226,7 +226,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chown root:root /etc/kubernetes/admin.conf
         scored: true
-      
+
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 600 or more restrictive (Automated)"
         audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
@@ -241,7 +241,7 @@ groups:
           For example,
           chmod 600 $schedulerkubeconfig
         scored: true
-      
+
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
         audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c %U:%G /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
@@ -253,7 +253,7 @@ groups:
           For example,
           chown root:root $schedulerkubeconfig
         scored: true
-      
+
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 600 or more restrictive (Automated)"
         audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/controller.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/controller.kubeconfig; fi'"
@@ -268,7 +268,7 @@ groups:
           For example,
           chmod 600 $controllermanagerkubeconfig
         scored: true
-      
+
       - id: 1.1.18
         text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
         audit: "stat -c %U:%G /var/lib/rancher/k3s/server/cred/controller.kubeconfig"
@@ -284,7 +284,7 @@ groups:
           For example,
           chown root:root $controllermanagerkubeconfig
         scored: true
-      
+
       - id: 1.1.19
         text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
         audit: "stat -c %U:%G /var/lib/rancher/k3s/server/tls"
@@ -297,7 +297,7 @@ groups:
           For example,
           chown -R root:root /var/lib/rancher/k3s/server/tls
         scored: true
-      
+
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"
         audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' | xargs stat -c permissions=%a"
@@ -313,7 +313,7 @@ groups:
           For example,
           find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 600 {} +
         scored: false
-      
+
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
         audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.key' | xargs stat -c permissions=%a"
@@ -329,7 +329,7 @@ groups:
           For example,
           find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {} +
         scored: false
-  
+
   - id: 1.2
     text: "API Server"
     checks:
@@ -347,7 +347,7 @@ groups:
           on the control plane node and set the below parameter.
           --anonymous-auth=false
         scored: false
-      
+
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -360,7 +360,7 @@ groups:
           edit the API server pod specification file $apiserverconf
           on the control plane node and remove the --token-auth-file=<filename> parameter.
         scored: true
-      
+
       - id: 1.2.3
         text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -379,7 +379,7 @@ groups:
           on the control plane node and remove the `DenyServiceExternalIPs`
           from enabled admission plugins.
         scored: true
-      
+
       - id: 1.2.4
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
@@ -396,7 +396,7 @@ groups:
           --kubelet-client-certificate=<path/to/client-certificate-file>
           --kubelet-client-key=<path/to/client-key-file>
         scored: true
-      
+
       - id: 1.2.5
         text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
         type: "skip"
@@ -412,7 +412,7 @@ groups:
           --kubelet-certificate-authority=<ca-string>
           Permissive - When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
         scored: true
-      
+
       - id: 1.2.6
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
@@ -428,7 +428,7 @@ groups:
           One such example could be as below.
           --authorization-mode=RBAC
         scored: true
-      
+
       - id: 1.2.7
         text: "Ensure that the --authorization-mode argument includes Node (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
@@ -443,7 +443,7 @@ groups:
           on the control plane node and set the --authorization-mode parameter to a value that includes Node.
           --authorization-mode=Node,RBAC
         scored: true
-      
+
       - id: 1.2.8
         text: "Ensure that the --authorization-mode argument includes RBAC (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
@@ -458,7 +458,7 @@ groups:
           on the control plane node and set the --authorization-mode parameter to a value that includes RBAC,
           for example `--authorization-mode=Node,RBAC`.
         scored: true
-      
+
       - id: 1.2.9
         text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
@@ -475,7 +475,7 @@ groups:
           --enable-admission-plugins=...,EventRateLimit,...
           --admission-control-config-file=<path/to/configuration/file>
         scored: false
-      
+
       - id: 1.2.10
         text: "Ensure that the admission control plugin AlwaysAdmit is not set (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
@@ -493,7 +493,7 @@ groups:
           on the control plane node and either remove the --enable-admission-plugins parameter, or set it to a
           value that does not include AlwaysAdmit.
         scored: true
-      
+
       - id: 1.2.11
         text: "Ensure that the admission control plugin AlwaysPullImages is set (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -509,7 +509,7 @@ groups:
           AlwaysPullImages.
           --enable-admission-plugins=...,AlwaysPullImages,...
         scored: false
-      
+
       - id: 1.2.12
         text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)"
         type: "skip"
@@ -532,7 +532,7 @@ groups:
           --enable-admission-plugins=...,SecurityContextDeny,...
           Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
         scored: false
-      
+
       - id: 1.2.13
         text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -551,7 +551,7 @@ groups:
           on the control plane node and ensure that the --disable-admission-plugins parameter is set to a
           value that does not include ServiceAccount.
         scored: true
-      
+
       - id: 1.2.14
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -569,7 +569,7 @@ groups:
           on the control plane node and set the --disable-admission-plugins parameter to
           ensure it does not include NamespaceLifecycle.
         scored: true
-      
+
       - id: 1.2.15
         text: "Ensure that the admission control plugin NodeRestriction is set (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
@@ -586,7 +586,7 @@ groups:
           value that includes NodeRestriction.
           --enable-admission-plugins=...,NodeRestriction,...
         scored: true
-      
+
       - id: 1.2.16
         text: "Ensure that the --profiling argument is set to false (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'profiling'"
@@ -601,7 +601,7 @@ groups:
           on the control plane node and set the below parameter.
           --profiling=false
         scored: true
-      
+
       - id: 1.2.17
         text: "Ensure that the --audit-log-path argument is set (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -616,7 +616,7 @@ groups:
           --audit-log-path=/var/log/apiserver/audit.log
           Permissive.
         scored: true
-      
+
       - id: 1.2.18
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -634,7 +634,7 @@ groups:
           --audit-log-maxage=30
           Permissive.
         scored: true
-      
+
       - id: 1.2.19
         text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -652,7 +652,7 @@ groups:
           --audit-log-maxbackup=10
           Permissive.
         scored: true
-      
+
       - id: 1.2.20
         text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -669,7 +669,7 @@ groups:
           For example, to set it as 100 MB, --audit-log-maxsize=100
           Permissive.
         scored: true
-      
+
       - id: 1.2.21
         text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -683,7 +683,7 @@ groups:
           For example, --request-timeout=300s
           Permissive.
         scored: false
-      
+
       - id: 1.2.22
         text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -703,7 +703,7 @@ groups:
           Alternatively, you can delete the --service-account-lookup parameter from this file so
           that the default takes effect.
         scored: true
-      
+
       - id: 1.2.23
         text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -717,7 +717,7 @@ groups:
           to the public key file for service accounts. For example,
           --service-account-key-file=<filename>
         scored: true
-      
+
       - id: 1.2.24
         text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
         audit: "check_for_k3s_etcd.sh 1.2.29"
@@ -735,7 +735,7 @@ groups:
           --etcd-certfile=<path/to/client-certificate-file>
           --etcd-keyfile=<path/to/client-key-file>
         scored: true
-      
+
       - id: 1.2.25
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal -u k3s | grep -A1 'Running kube-apiserver' | tail -n2"
@@ -753,7 +753,7 @@ groups:
           --tls-cert-file=<path/to/tls-certificate-file>
           --tls-private-key-file=<path/to/tls-key-file>
         scored: true
-      
+
       - id: 1.2.26
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'client-ca-file'"
@@ -766,7 +766,7 @@ groups:
           on the control plane node and set the client certificate authority file.
           --client-ca-file=<path/to/client-ca-file>
         scored: true
-      
+
       - id: 1.2.27
         text: "Ensure that the --etcd-cafile argument is set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-cafile'"
@@ -779,7 +779,7 @@ groups:
           on the control plane node and set the etcd certificate authority file parameter.
           --etcd-cafile=<path/to/ca-file>
         scored: true
-      
+
       - id: 1.2.28
         text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
         type: "skip"
@@ -794,7 +794,7 @@ groups:
           For example, --encryption-provider-config=</path/to/EncryptionConfig/File>
           Permissive - Enabling encryption changes how data can be recovered as data is encrypted.
         scored: false
-      
+
       - id: 1.2.29
         text: "Ensure that encryption providers are appropriately configured (Manual)"
         type: "skip"
@@ -812,7 +812,7 @@ groups:
           In this file, choose aescbc, kms or secretbox as the encryption provider.
           Permissive - Enabling encryption changes how data can be recovered as data is encrypted.
         scored: false
-      
+
       - id: 1.2.30
         text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Automated)"
         audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'tls-cipher-suites'"
@@ -829,7 +829,7 @@ groups:
           kube-apiserver-arg:
           - "tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
         scored: true
-  
+
   - id: 1.3
     text: "Controller Manager"
     checks:
@@ -844,7 +844,7 @@ groups:
           on the control plane node and set the --terminated-pod-gc-threshold to an appropriate threshold,
           for example, --terminated-pod-gc-threshold=10
         scored: false
-      
+
       - id: 1.3.2
         text: "Ensure that the --profiling argument is set to false (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'profiling'"
@@ -859,7 +859,7 @@ groups:
           on the control plane node and set the below parameter.
           --profiling=false
         scored: true
-      
+
       - id: 1.3.3
         text: "Ensure that the --use-service-account-credentials argument is set to true (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'use-service-account-credentials'"
@@ -874,7 +874,7 @@ groups:
           on the control plane node to set the below parameter.
           --use-service-account-credentials=true
         scored: true
-      
+
       - id: 1.3.4
         text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'service-account-private-key-file'"
@@ -887,7 +887,7 @@ groups:
           to the private key file for service accounts.
           --service-account-private-key-file=<filename>
         scored: true
-      
+
       - id: 1.3.5
         text: "Ensure that the --root-ca-file argument is set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'root-ca-file'"
@@ -899,7 +899,7 @@ groups:
           on the control plane node and set the --root-ca-file parameter to the certificate bundle file`.
           --root-ca-file=<path/to/file>
         scored: true
-      
+
       - id: 1.3.6
         text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
         type: "skip"
@@ -920,7 +920,7 @@ groups:
           --feature-gates=RotateKubeletServerCertificate=true
           Not Applicable.
         scored: true
-      
+
       - id: 1.3.7
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
         audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
@@ -938,7 +938,7 @@ groups:
           Edit the Controller Manager pod specification file $controllermanagerconf
           on the control plane node and ensure the correct value for the --bind-address parameter
         scored: true
-  
+
   - id: 1.4
     text: "Scheduler"
     checks:
@@ -957,7 +957,7 @@ groups:
           on the control plane node and set the below parameter.
           --profiling=false
         scored: true
-      
+
       - id: 1.4.2
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'bind-address'"

--- a/package/cfg/k3s-cis-1.8-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/master.yaml
@@ -24,6 +24,7 @@ groups:
           For example, chmod 600 $apiserverconf
           Not Applicable.
         scored: true
+      
       - id: 1.1.2
         text: "Ensure that the API server pod specification file ownership is set to root:root (Automated)"
         type: "skip"
@@ -36,6 +37,7 @@ groups:
           For example, chown root:root $apiserverconf
           Not Applicable.
         scored: true
+      
       - id: 1.1.3
         text: "Ensure that the controller manager pod specification file permissions are set to 600 or more restrictive (Automated)"
         type: "skip"
@@ -51,6 +53,7 @@ groups:
           For example, chmod 600 $controllermanagerconf
           Not Applicable.
         scored: true
+      
       - id: 1.1.4
         text: "Ensure that the controller manager pod specification file ownership is set to root:root (Automated)"
         type: "skip"
@@ -63,6 +66,7 @@ groups:
           For example, chown root:root $controllermanagerconf
           Not Applicable.
         scored: true
+      
       - id: 1.1.5
         text: "Ensure that the scheduler pod specification file permissions are set to 600 or more restrictive (Automated)"
         type: "skip"
@@ -78,6 +82,7 @@ groups:
           For example, chmod 600 $schedulerconf
           Not Applicable.
         scored: true
+      
       - id: 1.1.6
         text: "Ensure that the scheduler pod specification file ownership is set to root:root (Automated)"
         type: "skip"
@@ -90,6 +95,7 @@ groups:
           For example, chown root:root $schedulerconf
           Not Applicable.
         scored: true
+      
       - id: 1.1.7
         text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
         type: "skip"
@@ -107,6 +113,7 @@ groups:
           chmod 600 $etcdconf
           Not Applicable.
         scored: true
+      
       - id: 1.1.8
         text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
         type: "skip"
@@ -121,6 +128,7 @@ groups:
           chown root:root $etcdconf
           Not Applicable.
         scored: true
+      
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Automated)"
         type: "skip"
@@ -139,6 +147,7 @@ groups:
           For example, chmod 600 <path/to/cni/files>
           Not Applicable.
         scored: false
+      
       - id: 1.1.10
         text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
         type: skip
@@ -155,6 +164,7 @@ groups:
           chown root:root <path/to/cni/files>
           Not Applicable.
         scored: false
+      
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
         audit: "check_for_k3s_etcd.sh 1.1.11"
@@ -171,6 +181,7 @@ groups:
           Run the below command (based on the etcd data directory found above). For example,
           chmod 700 /var/lib/etcd
         scored: true
+      
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
         audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G
@@ -185,6 +196,7 @@ groups:
           For example, chown etcd:etcd /var/lib/etcd
           Not Applicable.
         scored: true
+      
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 600 or more restrictive (Automated)"
         audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/admin.kubeconfig'"
@@ -199,6 +211,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chmod 600 /var/lib/rancher/k3s/server/cred/admin.kubeconfig
         scored: true
+      
       - id: 1.1.14
         text: "Ensure that the admin.conf file ownership is set to root:root (Automated)"
         audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c %U:%G /var/lib/rancher/k3s/server/cred/admin.kubeconfig; fi'"
@@ -213,6 +226,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chown root:root /etc/kubernetes/admin.conf
         scored: true
+      
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 600 or more restrictive (Automated)"
         audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
@@ -227,6 +241,7 @@ groups:
           For example,
           chmod 600 $schedulerkubeconfig
         scored: true
+      
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
         audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c %U:%G /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
@@ -238,6 +253,7 @@ groups:
           For example,
           chown root:root $schedulerkubeconfig
         scored: true
+      
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 600 or more restrictive (Automated)"
         audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/controller.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/controller.kubeconfig; fi'"
@@ -252,6 +268,7 @@ groups:
           For example,
           chmod 600 $controllermanagerkubeconfig
         scored: true
+      
       - id: 1.1.18
         text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
         audit: "stat -c %U:%G /var/lib/rancher/k3s/server/cred/controller.kubeconfig"
@@ -267,6 +284,7 @@ groups:
           For example,
           chown root:root $controllermanagerkubeconfig
         scored: true
+      
       - id: 1.1.19
         text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
         audit: "stat -c %U:%G /var/lib/rancher/k3s/server/tls"
@@ -279,6 +297,7 @@ groups:
           For example,
           chown -R root:root /var/lib/rancher/k3s/server/tls
         scored: true
+      
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"
         audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' | xargs stat -c permissions=%a"
@@ -294,6 +313,7 @@ groups:
           For example,
           find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 600 {} +
         scored: false
+      
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
         audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.key' | xargs stat -c permissions=%a"
@@ -309,6 +329,7 @@ groups:
           For example,
           find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {} +
         scored: false
+  
   - id: 1.2
     text: "API Server"
     checks:
@@ -326,6 +347,7 @@ groups:
           on the control plane node and set the below parameter.
           --anonymous-auth=false
         scored: false
+      
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -338,6 +360,7 @@ groups:
           edit the API server pod specification file $apiserverconf
           on the control plane node and remove the --token-auth-file=<filename> parameter.
         scored: true
+      
       - id: 1.2.3
         text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -356,6 +379,7 @@ groups:
           on the control plane node and remove the `DenyServiceExternalIPs`
           from enabled admission plugins.
         scored: true
+      
       - id: 1.2.4
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
@@ -372,6 +396,7 @@ groups:
           --kubelet-client-certificate=<path/to/client-certificate-file>
           --kubelet-client-key=<path/to/client-key-file>
         scored: true
+      
       - id: 1.2.5
         text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
         type: "skip"
@@ -387,6 +412,7 @@ groups:
           --kubelet-certificate-authority=<ca-string>
           Permissive - When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
         scored: true
+      
       - id: 1.2.6
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
@@ -402,6 +428,7 @@ groups:
           One such example could be as below.
           --authorization-mode=RBAC
         scored: true
+      
       - id: 1.2.7
         text: "Ensure that the --authorization-mode argument includes Node (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
@@ -416,6 +443,7 @@ groups:
           on the control plane node and set the --authorization-mode parameter to a value that includes Node.
           --authorization-mode=Node,RBAC
         scored: true
+      
       - id: 1.2.8
         text: "Ensure that the --authorization-mode argument includes RBAC (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
@@ -430,6 +458,7 @@ groups:
           on the control plane node and set the --authorization-mode parameter to a value that includes RBAC,
           for example `--authorization-mode=Node,RBAC`.
         scored: true
+      
       - id: 1.2.9
         text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
@@ -446,6 +475,7 @@ groups:
           --enable-admission-plugins=...,EventRateLimit,...
           --admission-control-config-file=<path/to/configuration/file>
         scored: false
+      
       - id: 1.2.10
         text: "Ensure that the admission control plugin AlwaysAdmit is not set (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
@@ -463,6 +493,7 @@ groups:
           on the control plane node and either remove the --enable-admission-plugins parameter, or set it to a
           value that does not include AlwaysAdmit.
         scored: true
+      
       - id: 1.2.11
         text: "Ensure that the admission control plugin AlwaysPullImages is set (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -478,6 +509,7 @@ groups:
           AlwaysPullImages.
           --enable-admission-plugins=...,AlwaysPullImages,...
         scored: false
+      
       - id: 1.2.12
         text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)"
         type: "skip"
@@ -500,6 +532,7 @@ groups:
           --enable-admission-plugins=...,SecurityContextDeny,...
           Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
         scored: false
+      
       - id: 1.2.13
         text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -518,6 +551,7 @@ groups:
           on the control plane node and ensure that the --disable-admission-plugins parameter is set to a
           value that does not include ServiceAccount.
         scored: true
+      
       - id: 1.2.14
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -535,6 +569,7 @@ groups:
           on the control plane node and set the --disable-admission-plugins parameter to
           ensure it does not include NamespaceLifecycle.
         scored: true
+      
       - id: 1.2.15
         text: "Ensure that the admission control plugin NodeRestriction is set (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
@@ -551,6 +586,7 @@ groups:
           value that includes NodeRestriction.
           --enable-admission-plugins=...,NodeRestriction,...
         scored: true
+      
       - id: 1.2.16
         text: "Ensure that the --profiling argument is set to false (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'profiling'"
@@ -565,6 +601,7 @@ groups:
           on the control plane node and set the below parameter.
           --profiling=false
         scored: true
+      
       - id: 1.2.17
         text: "Ensure that the --audit-log-path argument is set (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -579,6 +616,7 @@ groups:
           --audit-log-path=/var/log/apiserver/audit.log
           Permissive.
         scored: true
+      
       - id: 1.2.18
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -596,6 +634,7 @@ groups:
           --audit-log-maxage=30
           Permissive.
         scored: true
+      
       - id: 1.2.19
         text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -613,6 +652,7 @@ groups:
           --audit-log-maxbackup=10
           Permissive.
         scored: true
+      
       - id: 1.2.20
         text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -629,6 +669,7 @@ groups:
           For example, to set it as 100 MB, --audit-log-maxsize=100
           Permissive.
         scored: true
+      
       - id: 1.2.21
         text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -642,6 +683,7 @@ groups:
           For example, --request-timeout=300s
           Permissive.
         scored: false
+      
       - id: 1.2.22
         text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -661,6 +703,7 @@ groups:
           Alternatively, you can delete the --service-account-lookup parameter from this file so
           that the default takes effect.
         scored: true
+      
       - id: 1.2.23
         text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
@@ -674,6 +717,7 @@ groups:
           to the public key file for service accounts. For example,
           --service-account-key-file=<filename>
         scored: true
+      
       - id: 1.2.24
         text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
         audit: "check_for_k3s_etcd.sh 1.2.29"
@@ -691,6 +735,7 @@ groups:
           --etcd-certfile=<path/to/client-certificate-file>
           --etcd-keyfile=<path/to/client-key-file>
         scored: true
+      
       - id: 1.2.25
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal -u k3s | grep -A1 'Running kube-apiserver' | tail -n2"
@@ -708,6 +753,7 @@ groups:
           --tls-cert-file=<path/to/tls-certificate-file>
           --tls-private-key-file=<path/to/tls-key-file>
         scored: true
+      
       - id: 1.2.26
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'client-ca-file'"
@@ -720,6 +766,7 @@ groups:
           on the control plane node and set the client certificate authority file.
           --client-ca-file=<path/to/client-ca-file>
         scored: true
+      
       - id: 1.2.27
         text: "Ensure that the --etcd-cafile argument is set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-cafile'"
@@ -732,6 +779,7 @@ groups:
           on the control plane node and set the etcd certificate authority file parameter.
           --etcd-cafile=<path/to/ca-file>
         scored: true
+      
       - id: 1.2.28
         text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
         type: "skip"
@@ -746,6 +794,7 @@ groups:
           For example, --encryption-provider-config=</path/to/EncryptionConfig/File>
           Permissive - Enabling encryption changes how data can be recovered as data is encrypted.
         scored: false
+      
       - id: 1.2.29
         text: "Ensure that encryption providers are appropriately configured (Manual)"
         type: "skip"
@@ -763,6 +812,7 @@ groups:
           In this file, choose aescbc, kms or secretbox as the encryption provider.
           Permissive - Enabling encryption changes how data can be recovered as data is encrypted.
         scored: false
+      
       - id: 1.2.30
         text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Automated)"
         audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'tls-cipher-suites'"
@@ -779,6 +829,7 @@ groups:
           kube-apiserver-arg:
           - "tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
         scored: true
+  
   - id: 1.3
     text: "Controller Manager"
     checks:
@@ -793,6 +844,7 @@ groups:
           on the control plane node and set the --terminated-pod-gc-threshold to an appropriate threshold,
           for example, --terminated-pod-gc-threshold=10
         scored: false
+      
       - id: 1.3.2
         text: "Ensure that the --profiling argument is set to false (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'profiling'"
@@ -807,6 +859,7 @@ groups:
           on the control plane node and set the below parameter.
           --profiling=false
         scored: true
+      
       - id: 1.3.3
         text: "Ensure that the --use-service-account-credentials argument is set to true (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'use-service-account-credentials'"
@@ -821,6 +874,7 @@ groups:
           on the control plane node to set the below parameter.
           --use-service-account-credentials=true
         scored: true
+      
       - id: 1.3.4
         text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'service-account-private-key-file'"
@@ -833,6 +887,7 @@ groups:
           to the private key file for service accounts.
           --service-account-private-key-file=<filename>
         scored: true
+      
       - id: 1.3.5
         text: "Ensure that the --root-ca-file argument is set as appropriate (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'root-ca-file'"
@@ -844,6 +899,7 @@ groups:
           on the control plane node and set the --root-ca-file parameter to the certificate bundle file`.
           --root-ca-file=<path/to/file>
         scored: true
+      
       - id: 1.3.6
         text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
         type: "skip"
@@ -864,6 +920,7 @@ groups:
           --feature-gates=RotateKubeletServerCertificate=true
           Not Applicable.
         scored: true
+      
       - id: 1.3.7
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
         audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
@@ -881,6 +938,7 @@ groups:
           Edit the Controller Manager pod specification file $controllermanagerconf
           on the control plane node and ensure the correct value for the --bind-address parameter
         scored: true
+  
   - id: 1.4
     text: "Scheduler"
     checks:
@@ -899,6 +957,7 @@ groups:
           on the control plane node and set the below parameter.
           --profiling=false
         scored: true
+      
       - id: 1.4.2
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'bind-address'"

--- a/package/cfg/k3s-cis-1.8-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/node.yaml
@@ -20,7 +20,7 @@ groups:
                 value: "600"
         remediation: |
           Not Applicable.
-          The kublet is embedded in the k3s process All configuration is passed in as arguments at runtime.
+          The kubelet is embedded in the k3s process All configuration is passed in as arguments at runtime.
         scored: true
 
       - id: 4.1.2
@@ -32,7 +32,7 @@ groups:
             - flag: root:root
         remediation: |
           Not Applicable.
-          The kublet is embedded in the k3s process All configuration is passed in as arguments at runtime.
+          The kubelet is embedded in the k3s process All configuration is passed in as arguments at runtime.
         scored: true
 
       - id: 4.1.3
@@ -160,10 +160,10 @@ groups:
         remediation: |
           By default, K3s sets the --anonymous-auth to false. If you have set this to a different value, you
           should set it back to false. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
-          kublet-arg:
+          kubelet-arg:
           - "anonymous-auth=true"
           If using the command line, edit the K3s service file and remove the below argument.
-          --kublet-arg="anonymous-auth=true"
+          --kubelet-arg="anonymous-auth=true"
           Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
           systemctl restart k3s.service
@@ -183,10 +183,10 @@ groups:
         remediation: |
           By default, K3s does not set the --authorization-mode to AlwaysAllow.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
-          kublet-arg:
+          kubelet-arg:
           - "authorization-mode=AlwaysAllow"
           If using the command line, edit the K3s service file and remove the below argument.
-          --kublet-arg="authorization-mode=AlwaysAllow"
+          --kubelet-arg="authorization-mode=AlwaysAllow"
           Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
           systemctl restart k3s.service
@@ -222,10 +222,10 @@ groups:
         remediation: |
           By default, K3s sets the --read-only-port to 0. If you have set this to a different value, you
           should set it back to 0. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
-          kublet-arg:
+          kubelet-arg:
           - "read-only-port=XXXX"
           If using the command line, edit the K3s service file and remove the below argument.
-          --kublet-arg="read-only-port=XXXX"
+          --kubelet-arg="read-only-port=XXXX"
           Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
           systemctl restart k3s.service
@@ -247,9 +247,9 @@ groups:
           bin_op: or
         remediation: |
           If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
-          kublet-arg:
+          kubelet-arg:
           - "streaming-connection-idle-timeout=5m"
-          If using the command line, run K3s with --kublet-arg="streaming-connection-idle-timeout=5m".
+          If using the command line, run K3s with --kubelet-arg="streaming-connection-idle-timeout=5m".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: false
@@ -271,9 +271,9 @@ groups:
           bin_op: or
         remediation: |
           If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter.
-          kublet-arg:
+          kubelet-arg:
           - "make-iptables-util-chains=true"
-          If using the command line, run K3s with --kublet-arg="make-iptables-util-chains=true".
+          If using the command line, run K3s with --kubelet-arg="make-iptables-util-chains=true".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
           Permissive.
@@ -314,9 +314,9 @@ groups:
         remediation: |
           By default, K3s sets the event-qps to 0. Should you wish to change this,
           If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
-          kublet-arg:
+          kubelet-arg:
           - "event-qps=<value>"
-          If using the command line, run K3s with --kublet-arg="event-qps=<value>".
+          If using the command line, run K3s with --kubelet-arg="event-qps=<value>".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: false
@@ -360,7 +360,7 @@ groups:
         remediation: |
           By default, K3s does not set the --rotate-certificates argument. If you have set this flag with a value of `false`, you should either set it to `true` or completely remove the flag.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any rotate-certificates parameter.
-          If using the command line, remove the K3s flag --kublet-arg="rotate-certificates".
+          If using the command line, remove the K3s flag --kubelet-arg="rotate-certificates".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: false
@@ -384,7 +384,7 @@ groups:
           By default, K3s does not set the RotateKubeletServerCertificate feature gate.
           If you have enabled this feature gate, you should remove it.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any feature-gate=RotateKubeletServerCertificate parameter.
-          If using the command line, remove the K3s flag --kublet-arg="feature-gate=RotateKubeletServerCertificate".
+          If using the command line, remove the K3s flag --kubelet-arg="feature-gate=RotateKubeletServerCertificate".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: true

--- a/package/cfg/k3s-cis-1.8-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/node.yaml
@@ -358,7 +358,7 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          By default, K3s does not set the --rotate-certificates argument. If you have set this to a different value, you should remove it.
+          By default, K3s does not set the --rotate-certificates argument. If you have set this flag with a value of `false`, you should either set it to `true` or completely remove the flag.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any rotate-certificates parameter.
           If using the command line, remove the K3s flag --kublet-arg="rotate-certificates".
           Based on your system, restart the k3s service. For example,
@@ -366,7 +366,7 @@ groups:
         scored: false
 
       - id: 4.2.11
-        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
+        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Automated)"
         audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
@@ -381,14 +381,13 @@ groups:
               path: '{.featureGates.RotateKubeletServerCertificate}'
               set: false
         remediation: |
-          Not Applicable.
           By default, K3s does not set the RotateKubeletServerCertificate feature gate.
           If you have enabled this feature gate, you should remove it.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any feature-gate=RotateKubeletServerCertificate parameter.
           If using the command line, remove the K3s flag --kublet-arg="feature-gate=RotateKubeletServerCertificate".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
-        scored: false
+        scored: true
 
       - id: 4.2.12
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"

--- a/package/cfg/k3s-cis-1.8-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/node.yaml
@@ -37,7 +37,7 @@ groups:
 
       - id: 4.1.3
         text: "If proxy kubeconfig file exists ensure permissions are set to 600 or more restrictive (Manual)"
-        audit: 'stat -c %a /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig'
+        audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c permissions=%a $proxykubeconfig; fi'' '
         tests:
           bin_op: or
           test_items:
@@ -358,7 +358,6 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          Not Applicable.
           By default, K3s does not set the --rotate-certificates argument. If you have set this to a different value, you should remove it.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any rotate-certificates parameter.
           If using the command line, remove the K3s flag --kublet-arg="rotate-certificates".

--- a/package/cfg/k3s-cis-1.8-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/node.yaml
@@ -19,9 +19,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the each worker node.
-          For example, chmod 600 $kubeletsvc
-          Not Applicable - All configuration is passed in as arguments at container run time.
+          Not Applicable.
+          The kublet is embedded in the k3s process All configuration is passed in as arguments at runtime.
         scored: true
       
       - id: 4.1.2
@@ -32,11 +31,8 @@ groups:
           test_items:
             - flag: root:root
         remediation: |
-          Run the below command (based on the file location on your system) on the each worker node.
-          For example,
-          chown root:root $kubeletsvc
           Not Applicable.
-           All configuration is passed in as arguments at container run time.
+          The kublet is embedded in the k3s process All configuration is passed in as arguments at runtime.
         scored: true
       
       - id: 4.1.3
@@ -64,7 +60,8 @@ groups:
             - flag: root:root
         remediation: |
           Run the below command (based on the file location on your system) on the each worker node.
-          For example, chown root:root $proxykubeconfig
+          For example,
+          chown root:root $proxykubeconfig
         scored: false
       
       - id: 4.1.5
@@ -105,7 +102,7 @@ groups:
                 value: "600"
         remediation: |
           Run the following command to modify the file permissions of the
-          --client-ca-file chmod 600 <filename>
+          --client-ca-file chmod 600 $kubeletcafile
         scored: false
       
       - id: 4.1.8
@@ -119,7 +116,7 @@ groups:
                 value: root:root
         remediation: |
           Run the following command to modify the ownership of the --client-ca-file.
-          chown root:root <filename>
+          chown root:root $kubeletcafile
         scored: false
       
       - id: 4.1.9
@@ -161,20 +158,20 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          If using a Kubelet config file, edit the file to set `authentication: anonymous: enabled` to
-          `false`.
-          If using executable arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          `--anonymous-auth=false`
-          Based on your system, restart the kubelet service. For example,
+          By default, K3s sets the --anonymous-auth to false. If you have set this to a different value, you
+          should set it back to false. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
+          kublet-arg:
+          - "anonymous-auth=true"
+          If using the command line, edit the K3s service file and remove the below argument.
+          --kublet-arg="anonymous-auth=true"
+          Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
-          systemctl restart kubelet.service
+          systemctl restart k3s.service
         scored: true
       
       - id: 4.2.2
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
-        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode" | grep -v grep; else echo "--authorization-mode=Webhook"; fi'' '
+        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode"; else echo "--authorization-mode=Webhook"; fi'' '
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -184,38 +181,32 @@ groups:
                 op: nothave
                 value: AlwaysAllow
         remediation: |
-          If using a Kubelet config file, edit the file to set `authorization.mode` to Webhook. If
-          using executable arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_AUTHZ_ARGS variable.
-          --authorization-mode=Webhook
-          Based on your system, restart the kubelet service. For example,
+          By default, K3s does not set the --authorization-mode to AlwaysAllow. 
+          If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
+          kublet-arg:
+          - "authorization-mode=AlwaysAllow"
+          If using the command line, edit the K3s service file and remove the below argument.
+          --kublet-arg="authorization-mode=AlwaysAllow"
+          Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
-          systemctl restart kubelet.service
+          systemctl restart k3s.service
         scored: true
       
       - id: 4.2.3
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
-        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file" | grep -v grep; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
+        audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file"; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
         tests:
           test_items:
             - flag: --client-ca-file
               path: '{.authentication.x509.clientCAFile}'
         remediation: |
-          If using a Kubelet config file, edit the file to set `authentication.x509.clientCAFile` to
-          the location of the client CA file.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_AUTHZ_ARGS variable.
-          --client-ca-file=<path/to/client-ca-file>
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          By default, K3s automatically provides the client ca certificate for the Kubelet.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/client-ca.crt
         scored: true
       
       - id: 4.2.4
         text: "Verify that the --read-only-port argument is set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'read-only-port' "
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           bin_op: or
@@ -229,19 +220,20 @@ groups:
               path: '{.readOnlyPort}'
               set: false
         remediation: |
-          If using a Kubelet config file, edit the file to set `readOnlyPort` to 0.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          --read-only-port=0
-          Based on your system, restart the kubelet service. For example,
+          By default, K3s sets the --read-only-port to 0. If you have set this to a different value, you
+          should set it back to 0. If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
+          kublet-arg:
+          - "read-only-port=XXXX"
+          If using the command line, edit the K3s service file and remove the below argument.
+          --kublet-arg="read-only-port=XXXX"
+          Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
-          systemctl restart kubelet.service
+          systemctl restart k3s.service
         scored: false
       
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'streaming-connection-idle-timeout'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -254,21 +246,18 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          If using a Kubelet config file, edit the file to set `streamingConnectionIdleTimeout` to a
-          value other than 0.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          --streaming-connection-idle-timeout=5m
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
+          kublet-arg:
+          - "streaming-connection-idle-timeout=5m"
+          If using the command line, run K3s with --kublet-arg="streaming-connection-idle-timeout=5m".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
       
       - id: 4.2.6
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
         type: "skip"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'make-iptables-util-chains'"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --make-iptables-util-chains
@@ -281,14 +270,12 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          If using a Kubelet config file, edit the file to set `makeIPTablesUtilChains` to `true`.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          remove the --make-iptables-util-chains argument from the
-          KUBELET_SYSTEM_PODS_ARGS variable.
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter.
+          kublet-arg:
+          - "make-iptables-util-chains=true"
+          If using the command line, run K3s with --kublet-arg="make-iptables-util-chains=true".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
           Permissive.
         scored: true
       
@@ -298,24 +285,20 @@ groups:
         # To check if the property is set as expected, we need to parse the kubelet command
         # instead reading the Kubelet Configuration file.
         type: "skip"
-        audit: "/bin/ps -fC $kubeletbin "
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --hostname-override
               set: false
         remediation: |
-          Edit the kubelet service file $kubeletsvc
-          on each worker node and remove the --hostname-override argument from the
-          KUBELET_SYSTEM_PODS_ARGS variable.
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
           Not Applicable.
+          By default, K3s does set the --hostname-override argument. Per CIS guidelines, this is to comply
+          with cloud providers that require this flag to ensure that hostname matches node names.
         scored: false
       
       - id: 4.2.8
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -329,13 +312,13 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          If using a Kubelet config file, edit the file to set `eventRecordQPS` to an appropriate level.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameter in KUBELET_SYSTEM_PODS_ARGS variable.
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          By default, K3s sets the event-qps to 0. Should you wish to change this,
+          If using the K3s config file /etc/rancher/k3s/config.yaml, set the following parameter to an appropriate value.
+          kublet-arg:
+          - "event-qps=<value>"
+          If using the command line, run K3s with --kublet-arg="event-qps=<value>".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
       
       - id: 4.2.9
@@ -349,23 +332,19 @@ groups:
             - flag: --tls-private-key-file
               path: '/var/lib/rancher/k3s/agent/serving-kubelet.key'
         remediation: |
-          If using a Kubelet config file, edit the file to set `tlsCertFile` to the location
-          of the certificate file to use to identify this Kubelet, and `tlsPrivateKeyFile`
-          to the location of the corresponding private key file.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the below parameters in KUBELET_CERTIFICATE_ARGS variable.
-          --tls-cert-file=<path/to/tls-certificate-file>
-          --tls-private-key-file=<path/to/tls-key-file>
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          By default, K3s automatically provides the TLS certificate and private key for the Kubelet.
+          They are generated and located at /var/lib/rancher/k3s/agent/serving-kubelet.crt and /var/lib/rancher/k3s/agent/serving-kubelet.key
+          If for some reason you need to provide your own certificate and key, you can set the
+          the below parameters in the K3s config file /etc/rancher/k3s/config.yaml.
+          kubelet-arg:
+          - "tls-cert-file=<path/to/tls-cert-file>"
+          - "tls-private-key-file=<path/to/tls-private-key-file>"
           Permissive - When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
         scored: false
       
       - id: 4.2.10
         text: "Ensure that the --rotate-certificates argument is not set to false (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -379,20 +358,17 @@ groups:
               set: false
           bin_op: or
         remediation: |
-          If using a Kubelet config file, edit the file to add the line `rotateCertificates` to `true` or
-          remove it altogether to use the default value.
-          If using command line arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          remove --rotate-certificates=false argument from the KUBELET_CERTIFICATE_ARGS
-          variable.
-          Based on your system, restart the kubelet service. For example,
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          Not Applicable.
+          By default, K3s does not set the --rotate-certificates argument. If you have set this to a different value, you should remove it.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, remove any rotate-certificates parameter.
+          If using the command line, remove the K3s flag --kublet-arg="rotate-certificates".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
       
       - id: 4.2.11
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
           bin_op: or
@@ -406,18 +382,18 @@ groups:
               path: '{.featureGates.RotateKubeletServerCertificate}'
               set: false
         remediation: |
-          Edit the kubelet service file $kubeletsvc
-          on each worker node and set the below parameter in KUBELET_CERTIFICATE_ARGS variable.
-          --feature-gates=RotateKubeletServerCertificate=true
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload
-          systemctl restart kubelet.service
           Not Applicable.
+          By default, K3s does not set the RotateKubeletServerCertificate feature gate. 
+          If you have enabled this feature gate, you should remove it.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, remove any feature-gate=RotateKubeletServerCertificate parameter.
+          If using the command line, remove the K3s flag --kublet-arg="feature-gate=RotateKubeletServerCertificate".
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
       
       - id: 4.2.12
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -427,21 +403,18 @@ groups:
                 op: valid_elements
                 value: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
         remediation: |
-          If using a Kubelet config file, edit the file to set `TLSCipherSuites` to
-          TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
+          If using a K3s config file /etc/rancher/k3s/config.yaml, edit the file to set `TLSCipherSuites` to
+          kubelet-arg:
+          - "tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
           or to a subset of these values.
-          If using executable arguments, edit the kubelet service file
-          $kubeletsvc on each worker node and
-          set the --tls-cipher-suites parameter as follows, or to a subset of these values.
-          --tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_256_GCM_SHA384,TLS_RSA_WITH_AES_128_GCM_SHA256
-          Based on your system, restart the kubelet service. For example:
-          systemctl daemon-reload
-          systemctl restart kubelet.service
+          If using the command line, add the K3s flag --kubelet-arg="tls-cipher-suites=<same values as above>"
+          Based on your system, restart the k3s service. For example,
+          systemctl restart k3s.service
         scored: false
       
       - id: 4.2.13
         text: "Ensure that a limit is set on pod PIDs (Manual)"
-        audit: "/bin/ps -fC $kubeletbin"
+        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.8-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/node.yaml
@@ -23,6 +23,7 @@ groups:
           For example, chmod 600 $kubeletsvc
           Not Applicable - All configuration is passed in as arguments at container run time.
         scored: true
+      
       - id: 4.1.2
         text: "Ensure that the kubelet service file ownership is set to root:root (Automated)"
         type: "skip"
@@ -37,6 +38,7 @@ groups:
           Not Applicable.
            All configuration is passed in as arguments at container run time.
         scored: true
+      
       - id: 4.1.3
         text: "If proxy kubeconfig file exists ensure permissions are set to 600 or more restrictive (Manual)"
         audit: 'stat -c %a /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig'
@@ -52,6 +54,7 @@ groups:
           For example,
           chmod 600 $proxykubeconfig
         scored: false
+      
       - id: 4.1.4
         text: "If proxy kubeconfig file exists ensure ownership is set to root:root (Manual)"
         audit: '/bin/sh -c ''if test -e /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig; then stat -c %U:%G /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig; fi'' '
@@ -63,6 +66,7 @@ groups:
           Run the below command (based on the file location on your system) on the each worker node.
           For example, chown root:root $proxykubeconfig
         scored: false
+      
       - id: 4.1.5
         text: "Ensure that the --kubeconfig kubelet.conf file permissions are set to 600 or more restrictive (Automated)"
         audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c permissions=%a $kubeletkubeconfig; fi'' '
@@ -77,6 +81,7 @@ groups:
           For example,
           chmod 600 $kubeletkubeconfig
         scored: true
+      
       - id: 4.1.6
         text: "Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root (Automated)"
         audit: 'stat -c %U:%G /var/lib/rancher/k3s/agent/kubelet.kubeconfig'
@@ -88,6 +93,7 @@ groups:
           For example,
           chown root:root $kubeletkubeconfig
         scored: true
+      
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Manual)"
         audit: "stat -c permissions=%a $kubeletcafile"
@@ -101,6 +107,7 @@ groups:
           Run the following command to modify the file permissions of the
           --client-ca-file chmod 600 <filename>
         scored: false
+      
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
         audit: "stat -c %U:%G $kubeletcafile"
@@ -114,6 +121,7 @@ groups:
           Run the following command to modify the ownership of the --client-ca-file.
           chown root:root <filename>
         scored: false
+      
       - id: 4.1.9
         text: "Ensure that the kubelet --config configuration file has permissions set to 600 or more restrictive (Automated)"
         audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c permissions=%a $kubeletconf; fi'' '
@@ -127,6 +135,7 @@ groups:
           Run the following command (using the config file location identified in the Audit step)
           chmod 600 $kubeletconf
         scored: true
+      
       - id: 4.1.10
         text: "Ensure that the kubelet --config configuration file ownership is set to root:root (Automated)"
         audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c %U:%G $kubeletconf; fi'' '
@@ -137,6 +146,7 @@ groups:
           Run the following command (using the config file location identified in the Audit step)
           chown root:root $kubeletconf
         scored: true
+  
   - id: 4.2
     text: "Kubelet"
     checks:
@@ -161,6 +171,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: true
+      
       - id: 4.2.2
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
         audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode" | grep -v grep; else echo "--authorization-mode=Webhook"; fi'' '
@@ -182,6 +193,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: true
+      
       - id: 4.2.3
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
         audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file" | grep -v grep; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
@@ -200,6 +212,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: true
+      
       - id: 4.2.4
         text: "Verify that the --read-only-port argument is set to 0 (Manual)"
         audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'read-only-port' "
@@ -225,6 +238,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: false
+      
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
         audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'streaming-connection-idle-timeout'"
@@ -250,6 +264,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: false
+      
       - id: 4.2.6
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
         type: "skip"
@@ -276,6 +291,7 @@ groups:
           systemctl restart kubelet.service
           Permissive.
         scored: true
+      
       - id: 4.2.7
         text: "Ensure that the --hostname-override argument is not set (Manual)"
         # This is one of those properties that can only be set as a command line argument.
@@ -296,6 +312,7 @@ groups:
           systemctl restart kubelet.service
           Not Applicable.
         scored: false
+      
       - id: 4.2.8
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
         audit: "/bin/ps -fC $kubeletbin"
@@ -320,6 +337,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: false
+      
       - id: 4.2.9
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
         type: "skip"
@@ -344,6 +362,7 @@ groups:
           systemctl restart kubelet.service
           Permissive - When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
         scored: false
+      
       - id: 4.2.10
         text: "Ensure that the --rotate-certificates argument is not set to false (Manual)"
         audit: "/bin/ps -fC $kubeletbin"
@@ -370,6 +389,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: false
+      
       - id: 4.2.11
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
         audit: "/bin/ps -fC $kubeletbin"
@@ -394,6 +414,7 @@ groups:
           systemctl restart kubelet.service
           Not Applicable.
         scored: false
+      
       - id: 4.2.12
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
         audit: "/bin/ps -fC $kubeletbin"
@@ -417,6 +438,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: false
+      
       - id: 4.2.13
         text: "Ensure that a limit is set on pod PIDs (Manual)"
         audit: "/bin/ps -fC $kubeletbin"

--- a/package/cfg/k3s-cis-1.8-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/node.yaml
@@ -22,7 +22,7 @@ groups:
           Not Applicable.
           The kublet is embedded in the k3s process All configuration is passed in as arguments at runtime.
         scored: true
-      
+
       - id: 4.1.2
         text: "Ensure that the kubelet service file ownership is set to root:root (Automated)"
         type: "skip"
@@ -34,7 +34,7 @@ groups:
           Not Applicable.
           The kublet is embedded in the k3s process All configuration is passed in as arguments at runtime.
         scored: true
-      
+
       - id: 4.1.3
         text: "If proxy kubeconfig file exists ensure permissions are set to 600 or more restrictive (Manual)"
         audit: 'stat -c %a /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig'
@@ -50,7 +50,7 @@ groups:
           For example,
           chmod 600 $proxykubeconfig
         scored: false
-      
+
       - id: 4.1.4
         text: "If proxy kubeconfig file exists ensure ownership is set to root:root (Manual)"
         audit: '/bin/sh -c ''if test -e /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig; then stat -c %U:%G /var/lib/rancher/k3s/agent/kubeproxy.kubeconfig; fi'' '
@@ -63,7 +63,7 @@ groups:
           For example,
           chown root:root $proxykubeconfig
         scored: false
-      
+
       - id: 4.1.5
         text: "Ensure that the --kubeconfig kubelet.conf file permissions are set to 600 or more restrictive (Automated)"
         audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c permissions=%a $kubeletkubeconfig; fi'' '
@@ -78,7 +78,7 @@ groups:
           For example,
           chmod 600 $kubeletkubeconfig
         scored: true
-      
+
       - id: 4.1.6
         text: "Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root (Automated)"
         audit: 'stat -c %U:%G /var/lib/rancher/k3s/agent/kubelet.kubeconfig'
@@ -90,7 +90,7 @@ groups:
           For example,
           chown root:root $kubeletkubeconfig
         scored: true
-      
+
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Manual)"
         audit: "stat -c permissions=%a $kubeletcafile"
@@ -104,7 +104,7 @@ groups:
           Run the following command to modify the file permissions of the
           --client-ca-file chmod 600 $kubeletcafile
         scored: false
-      
+
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
         audit: "stat -c %U:%G $kubeletcafile"
@@ -118,7 +118,7 @@ groups:
           Run the following command to modify the ownership of the --client-ca-file.
           chown root:root $kubeletcafile
         scored: false
-      
+
       - id: 4.1.9
         text: "Ensure that the kubelet --config configuration file has permissions set to 600 or more restrictive (Automated)"
         audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c permissions=%a $kubeletconf; fi'' '
@@ -132,7 +132,7 @@ groups:
           Run the following command (using the config file location identified in the Audit step)
           chmod 600 $kubeletconf
         scored: true
-      
+
       - id: 4.1.10
         text: "Ensure that the kubelet --config configuration file ownership is set to root:root (Automated)"
         audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c %U:%G $kubeletconf; fi'' '
@@ -143,7 +143,7 @@ groups:
           Run the following command (using the config file location identified in the Audit step)
           chown root:root $kubeletconf
         scored: true
-  
+
   - id: 4.2
     text: "Kubelet"
     checks:
@@ -168,7 +168,7 @@ groups:
           systemctl daemon-reload
           systemctl restart k3s.service
         scored: true
-      
+
       - id: 4.2.2
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
         audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "authorization-mode"; else echo "--authorization-mode=Webhook"; fi'' '
@@ -181,7 +181,7 @@ groups:
                 op: nothave
                 value: AlwaysAllow
         remediation: |
-          By default, K3s does not set the --authorization-mode to AlwaysAllow. 
+          By default, K3s does not set the --authorization-mode to AlwaysAllow.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any lines similar to below.
           kublet-arg:
           - "authorization-mode=AlwaysAllow"
@@ -191,7 +191,7 @@ groups:
           systemctl daemon-reload
           systemctl restart k3s.service
         scored: true
-      
+
       - id: 4.2.3
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
         audit: '/bin/sh -c ''if test $(journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | wc -l) -gt 0; then journalctl -D /var/log/journal -u k3s | grep "Running kube-apiserver" | tail -n1 | grep "client-ca-file"; else echo "--client-ca-file=/var/lib/rancher/k3s/server/tls/request-header-ca.crt"; fi'' '
@@ -203,7 +203,7 @@ groups:
           By default, K3s automatically provides the client ca certificate for the Kubelet.
           It is generated and located at /var/lib/rancher/k3s/server/tls/client-ca.crt
         scored: true
-      
+
       - id: 4.2.4
         text: "Verify that the --read-only-port argument is set to 0 (Manual)"
         audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
@@ -230,7 +230,7 @@ groups:
           systemctl daemon-reload
           systemctl restart k3s.service
         scored: false
-      
+
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
         audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
@@ -253,7 +253,7 @@ groups:
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: false
-      
+
       - id: 4.2.6
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
         type: "skip"
@@ -278,7 +278,7 @@ groups:
           systemctl restart k3s.service
           Permissive.
         scored: true
-      
+
       - id: 4.2.7
         text: "Ensure that the --hostname-override argument is not set (Manual)"
         # This is one of those properties that can only be set as a command line argument.
@@ -295,7 +295,7 @@ groups:
           By default, K3s does set the --hostname-override argument. Per CIS guidelines, this is to comply
           with cloud providers that require this flag to ensure that hostname matches node names.
         scored: false
-      
+
       - id: 4.2.8
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
         audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
@@ -320,7 +320,7 @@ groups:
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: false
-      
+
       - id: 4.2.9
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
         type: "skip"
@@ -341,7 +341,7 @@ groups:
           - "tls-private-key-file=<path/to/tls-private-key-file>"
           Permissive - When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
         scored: false
-      
+
       - id: 4.2.10
         text: "Ensure that the --rotate-certificates argument is not set to false (Manual)"
         audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
@@ -365,7 +365,7 @@ groups:
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: false
-      
+
       - id: 4.2.11
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
         audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
@@ -383,14 +383,14 @@ groups:
               set: false
         remediation: |
           Not Applicable.
-          By default, K3s does not set the RotateKubeletServerCertificate feature gate. 
+          By default, K3s does not set the RotateKubeletServerCertificate feature gate.
           If you have enabled this feature gate, you should remove it.
           If using the K3s config file /etc/rancher/k3s/config.yaml, remove any feature-gate=RotateKubeletServerCertificate parameter.
           If using the command line, remove the K3s flag --kublet-arg="feature-gate=RotateKubeletServerCertificate".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: false
-      
+
       - id: 4.2.12
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
         audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
@@ -411,7 +411,7 @@ groups:
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
         scored: false
-      
+
       - id: 4.2.13
         text: "Ensure that a limit is set on pod PIDs (Manual)"
         audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"

--- a/package/cfg/k3s-cis-1.8-permissive/policies.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/policies.yaml
@@ -18,12 +18,14 @@ groups:
           clusterrolebinding to the cluster-admin role :
           kubectl delete clusterrolebinding [name]
         scored: false
+      
       - id: 5.1.2
         text: "Minimize access to secrets (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove get, list and watch access to Secret objects in the cluster.
         scored: false
+      
       - id: 5.1.3
         text: "Minimize wildcard use in Roles and ClusterRoles (Manual)"
         type: "manual"
@@ -31,12 +33,14 @@ groups:
           Where possible replace any use of wildcards in clusterroles and roles with specific
           objects or actions.
         scored: false
+      
       - id: 5.1.4
         text: "Minimize access to create pods (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove create access to pod objects in the cluster.
         scored: false
+      
       - id: 5.1.5
         text: "Ensure that default service accounts are not actively used. (Manual)"
         type: "skip"
@@ -55,6 +59,7 @@ groups:
           automountServiceAccountToken: false
           Permissive - Kubernetes provides default service accounts to be used.
         scored: false
+      
       - id: 5.1.6
         text: "Ensure that Service Account Tokens are only mounted where necessary (Manual)"
         type: "manual"
@@ -62,48 +67,56 @@ groups:
           Modify the definition of pods and service accounts which do not need to mount service
           account tokens to disable it.
         scored: false
+      
       - id: 5.1.7
         text: "Avoid use of system:masters group (Manual)"
         type: "manual"
         remediation: |
           Remove the system:masters group from all users in the cluster.
         scored: false
+      
       - id: 5.1.8
         text: "Limit use of the Bind, Impersonate and Escalate permissions in the Kubernetes cluster (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove the impersonate, bind and escalate rights from subjects.
         scored: false
+      
       - id: 5.1.9
         text: "Minimize access to create persistent volumes (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove create access to PersistentVolume objects in the cluster.
         scored: false
+      
       - id: 5.1.10
         text: "Minimize access to the proxy sub-resource of nodes (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove access to the proxy sub-resource of node objects.
         scored: false
+      
       - id: 5.1.11
         text: "Minimize access to the approval sub-resource of certificatesigningrequests objects (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove access to the approval sub-resource of certificatesigningrequest objects.
         scored: false
+      
       - id: 5.1.12
         text: "Minimize access to webhook configuration objects (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove access to the validatingwebhookconfigurations or mutatingwebhookconfigurations objects
         scored: false
+      
       - id: 5.1.13
         text: "Minimize access to the service account token creation (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove access to the token sub-resource of serviceaccount objects.
         scored: false
+  
   - id: 5.2
     text: "Pod Security Standards"
     checks:
@@ -114,6 +127,7 @@ groups:
           Ensure that either Pod Security Admission or an external policy control system is in place
           for every namespace which contains user workloads.
         scored: false
+      
       - id: 5.2.2
         text: "Minimize the admission of privileged containers (Manual)"
         type: "manual"
@@ -121,6 +135,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of privileged containers.
         scored: false
+      
       - id: 5.2.3
         text: "Minimize the admission of containers wishing to share the host process ID namespace (Automated)"
         type: "skip"
@@ -129,6 +144,7 @@ groups:
           admission of `hostPID` containers.
           Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
         scored: false
+      
       - id: 5.2.4
         text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
         type: "skip"
@@ -137,6 +153,7 @@ groups:
           admission of `hostIPC` containers.
           Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
         scored: false
+      
       - id: 5.2.5
         text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
         type: "skip"
@@ -145,6 +162,7 @@ groups:
           admission of `hostNetwork` containers.
           Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
         scored: false
+      
       - id: 5.2.6
         text: "Minimize the admission of containers with allowPrivilegeEscalation (Automated)"
         type: "manual"
@@ -152,6 +170,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with `.spec.allowPrivilegeEscalation` set to `true`.
         scored: true
+      
       - id: 5.2.7
         text: "Minimize the admission of root containers (Automated)"
         type: "manual"
@@ -159,6 +178,7 @@ groups:
           Create a policy for each namespace in the cluster, ensuring that either `MustRunAsNonRoot`
           or `MustRunAs` with the range of UIDs not including 0, is set.
         scored: false
+      
       - id: 5.2.8
         text: "Minimize the admission of containers with the NET_RAW capability (Automated)"
         type: "manual"
@@ -166,6 +186,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with the `NET_RAW` capability.
         scored: false
+      
       - id: 5.2.9
         text: "Minimize the admission of containers with added capabilities (Automated)"
         type: "manual"
@@ -173,6 +194,7 @@ groups:
           Ensure that `allowedCapabilities` is not present in policies for the cluster unless
           it is set to an empty array.
         scored: false
+      
       - id: 5.2.10
         text: "Minimize the admission of containers with capabilities assigned (Manual)"
         type: "manual"
@@ -181,6 +203,7 @@ groups:
           contains applicaions which do not require any Linux capabities to operate consider adding
           a PSP which forbids the admission of containers which do not drop all capabilities.
         scored: false
+      
       - id: 5.2.11
         text: "Minimize the admission of Windows HostProcess containers (Manual)"
         type: "manual"
@@ -188,6 +211,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers that have `.securityContext.windowsOptions.hostProcess` set to `true`.
         scored: false
+      
       - id: 5.2.12
         text: "Minimize the admission of HostPath volumes (Manual)"
         type: "manual"
@@ -195,6 +219,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with `hostPath` volumes.
         scored: false
+      
       - id: 5.2.13
         text: "Minimize the admission of containers which use HostPorts (Manual)"
         type: "manual"
@@ -202,6 +227,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers which use `hostPort` sections.
         scored: false
+  
   - id: 5.3
     text: "Network Policies and CNI"
     checks:
@@ -213,6 +239,7 @@ groups:
           making use of a different plugin, or finding an alternate mechanism for restricting traffic
           in the Kubernetes cluster.
         scored: false
+      
       - id: 5.3.2
         text: "Ensure that all Namespaces have NetworkPolicies defined (Manual)"
         type: "skip"
@@ -220,6 +247,7 @@ groups:
           Follow the documentation and create NetworkPolicy objects as you need them.
           Permissive - Enabling Network Policies can prevent certain applications from communicating with each other.
         scored: false
+  
   - id: 5.4
     text: "Secrets Management"
     checks:
@@ -230,6 +258,7 @@ groups:
           If possible, rewrite application code to read Secrets from mounted secret files, rather than
           from environment variables.
         scored: false
+      
       - id: 5.4.2
         text: "Consider external secret storage (Manual)"
         type: "manual"
@@ -237,6 +266,7 @@ groups:
           Refer to the Secrets management options offered by your cloud provider or a third-party
           secrets management solution.
         scored: false
+  
   - id: 5.5
     text: "Extensible Admission Control"
     checks:
@@ -246,6 +276,7 @@ groups:
         remediation: |
           Follow the Kubernetes documentation and setup image provenance.
         scored: false
+  
   - id: 5.7
     text: "General Policies"
     checks:
@@ -256,6 +287,7 @@ groups:
           Follow the documentation and create namespaces for objects in your deployment as you need
           them.
         scored: false
+      
       - id: 5.7.2
         text: "Ensure that the seccomp profile is set to docker/default in your Pod definitions (Manual)"
         type: "manual"
@@ -266,6 +298,7 @@ groups:
               seccompProfile:
                 type: RuntimeDefault
         scored: false
+      
       - id: 5.7.3
         text: "Apply SecurityContext to your Pods and Containers (Manual)"
         type: "manual"
@@ -274,6 +307,7 @@ groups:
           suggested list of SecurityContexts, you may refer to the CIS Security Benchmark for Docker
           Containers.
         scored: false
+      
       - id: 5.7.4
         text: "The default namespace should not be used (Manual)"
         type: "skip"

--- a/package/cfg/k3s-cis-1.8-permissive/policies.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/policies.yaml
@@ -18,14 +18,14 @@ groups:
           clusterrolebinding to the cluster-admin role :
           kubectl delete clusterrolebinding [name]
         scored: false
-      
+
       - id: 5.1.2
         text: "Minimize access to secrets (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove get, list and watch access to Secret objects in the cluster.
         scored: false
-      
+
       - id: 5.1.3
         text: "Minimize wildcard use in Roles and ClusterRoles (Manual)"
         type: "manual"
@@ -33,14 +33,14 @@ groups:
           Where possible replace any use of wildcards in clusterroles and roles with specific
           objects or actions.
         scored: false
-      
+
       - id: 5.1.4
         text: "Minimize access to create pods (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove create access to pod objects in the cluster.
         scored: false
-      
+
       - id: 5.1.5
         text: "Ensure that default service accounts are not actively used. (Manual)"
         type: "skip"
@@ -59,7 +59,7 @@ groups:
           automountServiceAccountToken: false
           Permissive - Kubernetes provides default service accounts to be used.
         scored: false
-      
+
       - id: 5.1.6
         text: "Ensure that Service Account Tokens are only mounted where necessary (Manual)"
         type: "manual"
@@ -67,56 +67,56 @@ groups:
           Modify the definition of pods and service accounts which do not need to mount service
           account tokens to disable it.
         scored: false
-      
+
       - id: 5.1.7
         text: "Avoid use of system:masters group (Manual)"
         type: "manual"
         remediation: |
           Remove the system:masters group from all users in the cluster.
         scored: false
-      
+
       - id: 5.1.8
         text: "Limit use of the Bind, Impersonate and Escalate permissions in the Kubernetes cluster (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove the impersonate, bind and escalate rights from subjects.
         scored: false
-      
+
       - id: 5.1.9
         text: "Minimize access to create persistent volumes (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove create access to PersistentVolume objects in the cluster.
         scored: false
-      
+
       - id: 5.1.10
         text: "Minimize access to the proxy sub-resource of nodes (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove access to the proxy sub-resource of node objects.
         scored: false
-      
+
       - id: 5.1.11
         text: "Minimize access to the approval sub-resource of certificatesigningrequests objects (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove access to the approval sub-resource of certificatesigningrequest objects.
         scored: false
-      
+
       - id: 5.1.12
         text: "Minimize access to webhook configuration objects (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove access to the validatingwebhookconfigurations or mutatingwebhookconfigurations objects
         scored: false
-      
+
       - id: 5.1.13
         text: "Minimize access to the service account token creation (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove access to the token sub-resource of serviceaccount objects.
         scored: false
-  
+
   - id: 5.2
     text: "Pod Security Standards"
     checks:
@@ -127,7 +127,7 @@ groups:
           Ensure that either Pod Security Admission or an external policy control system is in place
           for every namespace which contains user workloads.
         scored: false
-      
+
       - id: 5.2.2
         text: "Minimize the admission of privileged containers (Manual)"
         type: "manual"
@@ -135,7 +135,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of privileged containers.
         scored: false
-      
+
       - id: 5.2.3
         text: "Minimize the admission of containers wishing to share the host process ID namespace (Automated)"
         type: "skip"
@@ -144,7 +144,7 @@ groups:
           admission of `hostPID` containers.
           Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
         scored: false
-      
+
       - id: 5.2.4
         text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
         type: "skip"
@@ -153,7 +153,7 @@ groups:
           admission of `hostIPC` containers.
           Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
         scored: false
-      
+
       - id: 5.2.5
         text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
         type: "skip"
@@ -162,7 +162,7 @@ groups:
           admission of `hostNetwork` containers.
           Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
         scored: false
-      
+
       - id: 5.2.6
         text: "Minimize the admission of containers with allowPrivilegeEscalation (Automated)"
         type: "manual"
@@ -170,7 +170,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with `.spec.allowPrivilegeEscalation` set to `true`.
         scored: true
-      
+
       - id: 5.2.7
         text: "Minimize the admission of root containers (Automated)"
         type: "manual"
@@ -178,7 +178,7 @@ groups:
           Create a policy for each namespace in the cluster, ensuring that either `MustRunAsNonRoot`
           or `MustRunAs` with the range of UIDs not including 0, is set.
         scored: false
-      
+
       - id: 5.2.8
         text: "Minimize the admission of containers with the NET_RAW capability (Automated)"
         type: "manual"
@@ -186,7 +186,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with the `NET_RAW` capability.
         scored: false
-      
+
       - id: 5.2.9
         text: "Minimize the admission of containers with added capabilities (Automated)"
         type: "manual"
@@ -194,7 +194,7 @@ groups:
           Ensure that `allowedCapabilities` is not present in policies for the cluster unless
           it is set to an empty array.
         scored: false
-      
+
       - id: 5.2.10
         text: "Minimize the admission of containers with capabilities assigned (Manual)"
         type: "manual"
@@ -203,7 +203,7 @@ groups:
           contains applicaions which do not require any Linux capabities to operate consider adding
           a PSP which forbids the admission of containers which do not drop all capabilities.
         scored: false
-      
+
       - id: 5.2.11
         text: "Minimize the admission of Windows HostProcess containers (Manual)"
         type: "manual"
@@ -211,7 +211,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers that have `.securityContext.windowsOptions.hostProcess` set to `true`.
         scored: false
-      
+
       - id: 5.2.12
         text: "Minimize the admission of HostPath volumes (Manual)"
         type: "manual"
@@ -219,7 +219,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with `hostPath` volumes.
         scored: false
-      
+
       - id: 5.2.13
         text: "Minimize the admission of containers which use HostPorts (Manual)"
         type: "manual"
@@ -227,7 +227,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers which use `hostPort` sections.
         scored: false
-  
+
   - id: 5.3
     text: "Network Policies and CNI"
     checks:
@@ -239,7 +239,7 @@ groups:
           making use of a different plugin, or finding an alternate mechanism for restricting traffic
           in the Kubernetes cluster.
         scored: false
-      
+
       - id: 5.3.2
         text: "Ensure that all Namespaces have NetworkPolicies defined (Manual)"
         type: "skip"
@@ -247,7 +247,7 @@ groups:
           Follow the documentation and create NetworkPolicy objects as you need them.
           Permissive - Enabling Network Policies can prevent certain applications from communicating with each other.
         scored: false
-  
+
   - id: 5.4
     text: "Secrets Management"
     checks:
@@ -258,7 +258,7 @@ groups:
           If possible, rewrite application code to read Secrets from mounted secret files, rather than
           from environment variables.
         scored: false
-      
+
       - id: 5.4.2
         text: "Consider external secret storage (Manual)"
         type: "manual"
@@ -266,7 +266,7 @@ groups:
           Refer to the Secrets management options offered by your cloud provider or a third-party
           secrets management solution.
         scored: false
-  
+
   - id: 5.5
     text: "Extensible Admission Control"
     checks:
@@ -276,7 +276,7 @@ groups:
         remediation: |
           Follow the Kubernetes documentation and setup image provenance.
         scored: false
-  
+
   - id: 5.7
     text: "General Policies"
     checks:
@@ -287,7 +287,7 @@ groups:
           Follow the documentation and create namespaces for objects in your deployment as you need
           them.
         scored: false
-      
+
       - id: 5.7.2
         text: "Ensure that the seccomp profile is set to docker/default in your Pod definitions (Manual)"
         type: "manual"
@@ -298,7 +298,7 @@ groups:
               seccompProfile:
                 type: RuntimeDefault
         scored: false
-      
+
       - id: 5.7.3
         text: "Apply SecurityContext to your Pods and Containers (Manual)"
         type: "manual"
@@ -307,7 +307,7 @@ groups:
           suggested list of SecurityContexts, you may refer to the CIS Security Benchmark for Docker
           Containers.
         scored: false
-      
+
       - id: 5.7.4
         text: "The default namespace should not be used (Manual)"
         type: "skip"


### PR DESCRIPTION
## Changes
- Fix newline spacing issues in k3s cis-1.8 versions.
- Add missing "permissions=" output expected for 4.1.3 and 4.1.5
- Add remediation for 4.2.XX sections of the K3s scans
  - Fixes incorrect audit, remove grep for specific flags when it is valid for the flag to not exist
  - Remove "skips" for 4.2.9 in hardened versions, we are skipping checks that we pass and comply with
  - Add K3s specific remediation info for most of the sections.
  
  
 ## Verification (Section 4 Only)
 
 Config for k3s (Note the last line is different for psa vs psp)
 ```
cluster-init: true
protect-kernel-defaults: true
secrets-encryption: true
kube-controller-manager-arg:
  - 'terminated-pod-gc-threshold=10'
  - 'use-service-account-credentials=true'
kubelet-arg:
  - 'streaming-connection-idle-timeout=5m'
  - 'make-iptables-util-chains=true'
  - 'event-qps=0'
  - "tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
kube-apiserver-arg:
  - 'audit-log-path=/var/lib/rancher/k3s/server/logs/audit.log'
  - 'audit-policy-file=/var/lib/rancher/k3s/server/audit.yaml'
  - 'audit-log-maxage=30'
  - 'audit-log-maxbackup=10'
  - 'audit-log-maxsize=100'
  - 'enable-admission-plugins=NodeRestriction,NamespaceLifecycle,ServiceAccount,PodSecurityPolicy'
```
 
 K3s-cis-1.24-hardened (v1.24.17+k3s1)
| old | new |
| - | - |
| ![image](https://github.com/user-attachments/assets/49dae52c-711e-4ddf-851f-7ed70c4f8ec3) | ![image](https://github.com/user-attachments/assets/764a0e9a-74a8-4772-9176-6369400937dd) |
  
 K3s-cis-1.7-hardened (v1.25.16+k3s4)
| old | new |
| - | - |
| ![image](https://github.com/user-attachments/assets/15afe10f-e34f-49d3-9daa-4a77a5eda1d7) |  ![image](https://github.com/user-attachments/assets/1dc3060e-2dd2-40a2-95aa-5d5c0f282355) |
 
 K3s-cis-1.8-hardened (v1.28.11+k3s1)
| old | new |
| - | - |
| ![image](https://github.com/user-attachments/assets/7d22da47-6aa0-4d4e-82b0-01bf4a72d50a) | ![image](https://github.com/user-attachments/assets/440d592e-2171-404a-b892-380e884a4428) |
   