### PR TITLE
Add proper remediation info for K3s Master 1.X.XX sections

### DIFF
--- a/package/cfg/config.yaml
+++ b/package/cfg/config.yaml
@@ -46,6 +46,7 @@ master:
       - /var/snap/kube-scheduler/current/args
       - /var/lib/rancher/rke2/agent/pod-manifests/kube-scheduler.yaml
     kubeconfig:
+      - /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig
       - /var/lib/rancher/rke2/server/cred/scheduler.kubeconfig
     defaultconf: /etc/kubernetes/manifests/kube-scheduler.yaml
 
@@ -63,6 +64,7 @@ master:
       - /var/snap/kube-controller-manager/current/args
       - /var/lib/rancher/rke2/agent/pod-manifests/kube-controller-manager.yaml
     kubeconfig:
+      - /var/lib/rancher/k3s/server/cred/controller.kubeconfig
       - /var/lib/rancher/rke2/server/cred/controller.kubeconfig
     defaultconf: /etc/kubernetes/manifests/kube-controller-manager.yaml
 

--- a/package/cfg/k3s-cis-1.23-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.23-hardened/master.yaml
@@ -155,7 +155,12 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: "check_for_k3s_etcd.sh 1.1.11"
+        audit: |
+          if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
+            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
+          else
+            echo "permissions=700"
+          fi
         tests:
           test_items:
             - flag: "permissions"
@@ -731,7 +736,12 @@ groups:
 
       - id: 1.2.26
         text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
-        audit: "check_for_k3s_etcd.sh 1.2.29"
+        audit: |
+          if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
+            journalctl -D /var/log/journal -u k3s | grep -m1 'Running kube-apiserver' | tail -n1
+          else
+            echo "--etcd-certfile AND --etcd-keyfile"
+          fi
         tests:
           bin_op: and
           test_items:

--- a/package/cfg/k3s-cis-1.23-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.23-hardened/master.yaml
@@ -185,7 +185,7 @@ groups:
 
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/admin.kubeconfig'"
+        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/admin.kubeconfig; fi'"
         type: "skip"
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.23-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.23-hardened/master.yaml
@@ -158,11 +158,10 @@ groups:
         audit: "check_for_k3s_etcd.sh 1.1.11"
         tests:
           test_items:
-            - flag: "700"
+            - flag: "permissions"
               compare:
-                op: eq
+                op: bitmask
                 value: "700"
-              set: true
         remediation: |
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.

--- a/package/cfg/k3s-cis-1.23-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.23-permissive/master.yaml
@@ -155,7 +155,12 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: "check_for_k3s_etcd.sh 1.1.11"
+        audit: |
+          if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
+            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
+          else
+            echo "permissions=700"
+          fi
         tests:
           test_items:
             - flag: "permissions"
@@ -735,7 +740,12 @@ groups:
 
       - id: 1.2.26
         text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
-        audit: "check_for_k3s_etcd.sh 1.2.29"
+        audit: |
+          if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
+            journalctl -D /var/log/journal -u k3s | grep -m1 'Running kube-apiserver' | tail -n1
+          else
+            echo "--etcd-certfile AND --etcd-keyfile"
+          fi
         tests:
           bin_op: and
           test_items:

--- a/package/cfg/k3s-cis-1.23-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.23-permissive/master.yaml
@@ -185,7 +185,7 @@ groups:
 
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/admin.kubeconfig'"
+        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/admin.kubeconfig; fi'"
         type: "skip"
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.23-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.23-permissive/master.yaml
@@ -158,11 +158,10 @@ groups:
         audit: "check_for_k3s_etcd.sh 1.1.11"
         tests:
           test_items:
-            - flag: "700"
+            - flag: "permissions"
               compare:
-                op: eq
+                op: bitmask
                 value: "700"
-              set: true
         remediation: |
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.

--- a/package/cfg/k3s-cis-1.24-hardened/config.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/config.yaml
@@ -16,10 +16,15 @@ master:
   scheduler:
     bins:
       - containerd
+    kubeconfig:
+      - /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig
 
   controllermanager:
     bins:
       - containerd
+    kubeconfig:
+      - /var/lib/rancher/k3s/server/cred/controller.kubeconfig
+
 
   etcd:
     bins:

--- a/package/cfg/k3s-cis-1.24-hardened/controlplane.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/controlplane.yaml
@@ -21,7 +21,7 @@ groups:
     checks:
       - id: 3.2.1
         text: "Ensure that a minimal audit policy is created (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-policy-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-policy-file'"
         type: "manual"
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.24-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/master.yaml
@@ -20,7 +20,7 @@ groups:
                 value: "644"
         remediation: |
           Not Applicable.
-          K3s embeds the api server within the k3s process. There is no API server pod specification file.
+          By default, K3s embeds the api server within the k3s process. There is no API server pod specification file.
         scored: true
 
       - id: 1.1.2
@@ -32,7 +32,7 @@ groups:
             - flag: "root:root"
         remediation: |
           Not Applicable.
-          K3s embeds the api server within the k3s process. There is no API server pod specification file.
+          By default, K3s embeds the api server within the k3s process. There is no API server pod specification file.
         scored: true
 
       - id: 1.1.3
@@ -47,7 +47,7 @@ groups:
                 value: "600"
         remediation: |
           Not Applicable.
-          K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
+          By default, K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
         scored: true
 
       - id: 1.1.4
@@ -59,7 +59,7 @@ groups:
             - flag: "root:root"
         remediation: |
           Not Applicable.
-          K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
+          By default, K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
         scored: true
 
       - id: 1.1.5
@@ -74,7 +74,7 @@ groups:
                 value: "600"
         remediation: |
           Not Applicable.
-          K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
+          By default, K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
         scored: true
 
       - id: 1.1.6
@@ -86,7 +86,7 @@ groups:
             - flag: "root:root"
         remediation: |
           Not Applicable.
-          K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
+          By default, K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
         scored: true
 
       - id: 1.1.7
@@ -101,7 +101,7 @@ groups:
                 value: "600"
         remediation: |
           Not Applicable.
-          K3s embeds etcd within the k3s process. There is no etcd pod specification file.
+          By default, K3s embeds etcd within the k3s process. There is no etcd pod specification file.
         scored: true
 
       - id: 1.1.8
@@ -113,7 +113,7 @@ groups:
             - flag: "root:root"
         remediation: |
           Not Applicable.
-          K3s embeds etcd within the k3s process. There is no etcd pod specification file.
+          By default, K3s embeds etcd within the k3s process. There is no etcd pod specification file.
         scored: true
 
       - id: 1.1.9
@@ -321,9 +321,8 @@ groups:
     text: "API Server"
     checks:
       - id: 1.2.1
-        text: "Ensure that the --anonymous-auth argument is set to false (Manual)"
+        text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
         audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth'"
-        type: manual
         tests:
           test_items:
             - flag: "--anonymous-auth"

--- a/package/cfg/k3s-cis-1.24-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/master.yaml
@@ -117,11 +117,8 @@ groups:
         scored: true
 
       - id: 1.1.9
-        text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Manual)"
-        type: "skip"
-        audit: |
-          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
-          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
+        text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Automated)"
+        audit: find /var/lib/cni/networks -type f ! -name lock 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
         use_multiple_values: true
         tests:
           test_items:
@@ -130,8 +127,10 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 <path/to/cni/files>
+          By default, K3s sets the CNI file permissions to 600.
+          Note that for many CNIs, a lock file is created with permissions 750. This is expected and can be ignored.
+          If you modify your CNI configuration, ensure that the permissions are set to 600.
+          For example, chmod 600 /var/lib/cni/networks/<filename>
         scored: false
 
       - id: 1.1.10

--- a/package/cfg/k3s-cis-1.24-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/master.yaml
@@ -19,9 +19,8 @@ groups:
                 op: bitmask
                 value: "644"
         remediation: |
-          Run the below command (based on the file location on your system) on the
-          control plane node.
-          For example, chmod 644 $apiserverconf
+          Not Applicable.
+          K3s embeds the api server within the k3s process. There is no API server pod specification file.
         scored: true
 
       - id: 1.1.2
@@ -32,8 +31,8 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root $apiserverconf
+          Not Applicable.
+          K3s embeds the api server within the k3s process. There is no API server pod specification file.
         scored: true
 
       - id: 1.1.3
@@ -47,8 +46,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 $controllermanagerconf
+          Not Applicable.
+          K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
         scored: true
 
       - id: 1.1.4
@@ -59,8 +58,8 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root $controllermanagerconf
+          Not Applicable.
+          K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
         scored: true
 
       - id: 1.1.5
@@ -74,8 +73,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 $schedulerconf
+          Not Applicable.
+          K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
         scored: true
 
       - id: 1.1.6
@@ -86,8 +85,8 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root $schedulerconf
+          Not Applicable.
+          K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
         scored: true
 
       - id: 1.1.7
@@ -101,9 +100,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chmod 600 $etcdconf
+          Not Applicable.
+          K3s embeds etcd within the k3s process. There is no etcd pod specification file.
         scored: true
 
       - id: 1.1.8
@@ -114,9 +112,8 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chown root:root $etcdconf
+          Not Applicable.
+          K3s embeds etcd within the k3s process. There is no etcd pod specification file.
         scored: true
 
       - id: 1.1.9
@@ -158,11 +155,10 @@ groups:
         audit: "check_for_k3s_etcd.sh 1.1.11"
         tests:
           test_items:
-            - flag: "700"
+            - flag: "permissions"
               compare:
-                op: eq
+                op: bitmask
                 value: "700"
-              set: true
         remediation: |
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.
@@ -178,10 +174,9 @@ groups:
           test_items:
             - flag: "etcd:etcd"
         remediation: |
-          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-          from the command 'ps -ef | grep etcd'.
-          Run the below command (based on the etcd data directory found above).
-          For example, chown etcd:etcd /var/lib/etcd
+          Not Applicable.
+          For K3s, etcd is embedded within the k3s process. There is no separate etcd process.
+          Therefore the etcd data directory ownership is managed by the k3s process and should be root:root.
         scored: true
 
       - id: 1.1.13
@@ -212,12 +207,12 @@ groups:
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root /etc/kubernetes/admin.conf
+          For example, chown root:root /var/lib/rancher/k3s/server/cred/admin.kubeconfig
         scored: true
 
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c permissions=%a $schedulerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -232,7 +227,7 @@ groups:
 
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c %U:%G /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c %U:%G $schedulerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "root:root"
@@ -244,7 +239,7 @@ groups:
 
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/controller.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/controller.kubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c permissions=%a $controllermanagerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -288,7 +283,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"
-        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' | xargs stat -c permissions=%a"
+        audit: "/bin/sh -c 'stat -c permissions=%a /var/lib/rancher/k3s/server/tls/*.crt'"
         use_multiple_values: true
         tests:
           test_items:
@@ -299,12 +294,12 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 600 {} +
+          chmod -R 600 /var/lib/rancher/k3s/server/tls/*.crt
         scored: false
 
       - id: 1.1.21
-        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.key' | xargs stat -c permissions=%a"
+        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Automated)"
+        audit: "/bin/sh -c 'stat -c permissions=%a /var/lib/rancher/k3s/server/tls/*.key'"
         use_multiple_values: true
         tests:
           test_items:
@@ -315,7 +310,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {} +
+          chmod -R 600 /var/lib/rancher/k3s/server/tls/*.key
         scored: false
 
   - id: 1.2

--- a/package/cfg/k3s-cis-1.24-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/master.yaml
@@ -155,7 +155,7 @@ groups:
         audit: |
           if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
             stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
-          else 
+          else
             echo "permissions=700"
           fi
         tests:
@@ -448,7 +448,7 @@ groups:
                 value: "Node"
         remediation: |
           By default, K3s sets the --authorization-mode to Node and RBAC.
-          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, 
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml,
           ensure that you are not overriding authorization-mode.
         scored: true
 
@@ -613,8 +613,7 @@ groups:
               set: false
         remediation: |
           By default, K3s sets the secure port to 6444.
-          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml 
-          and remove any lines like below.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
           kube-apiserver-arg:
           - "secure-port=<PORT>"
         scored: true
@@ -674,7 +673,7 @@ groups:
                 op: gte
                 value: 10
         remediation: |
-          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and 
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and
           set the audit-log-maxbackup parameter to 10 or to an appropriate value. For example,
           kube-apiserver-arg:
           - "audit-log-maxbackup=10"
@@ -690,7 +689,7 @@ groups:
                 op: gte
                 value: 100
         remediation: |
-          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and 
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and
           set the audit-log-maxsize parameter to an appropriate size in MB. For example,
           kube-apiserver-arg:
           - "audit-log-maxsize=100"
@@ -706,7 +705,7 @@ groups:
               set: false
             - flag: "--request-timeout"
         remediation: |
-          Permissive, per CIS guidelines, 
+          Permissive, per CIS guidelines,
           "it is recommended to set this limit as appropriate and change the default limit of 60 seconds only if needed".
           Edit the K3s config file /etc/rancher/k3s/config.yaml
           and set the below parameter if needed. For example,
@@ -754,7 +753,7 @@ groups:
         audit: |
           if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
             journalctl -D /var/log/journal -u k3s | grep -m1 'Running kube-apiserver' | tail -n1
-          else 
+          else
             echo "--etcd-certfile AND --etcd-keyfile"
           fi
         tests:
@@ -880,9 +879,10 @@ groups:
           test_items:
             - flag: "--terminated-pod-gc-threshold"
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --terminated-pod-gc-threshold to an appropriate threshold,
-          for example, --terminated-pod-gc-threshold=10
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node
+          and set the --terminated-pod-gc-threshold to an appropriate threshold,
+          kube-controller-manager-arg:
+          - "terminated-pod-gc-threshold=10"
         scored: false
 
       - id: 1.3.2
@@ -895,9 +895,10 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the below parameter.
-          --profiling=false
+          By default, K3s sets the --profiling argument to false.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+          - "profiling=true"
         scored: true
 
       - id: 1.3.3
@@ -910,9 +911,10 @@ groups:
                 op: noteq
                 value: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node to set the below parameter.
-          --use-service-account-credentials=true
+          By default, K3s sets the --use-service-account-credentials argument to true.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+          - "use-service-account-credentials=false"
         scored: true
 
       - id: 1.3.4
@@ -922,10 +924,11 @@ groups:
           test_items:
             - flag: "--service-account-private-key-file"
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --service-account-private-key-file parameter
-          to the private key file for service accounts.
-          --service-account-private-key-file=<filename>
+          By default, K3s automatically provides the service account private key file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/service.current.key.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+          - "service-account-private-key-file=<path>"
         scored: true
 
       - id: 1.3.5
@@ -935,15 +938,16 @@ groups:
           test_items:
             - flag: "--root-ca-file"
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --root-ca-file parameter to the certificate bundle file`.
-          --root-ca-file=<path/to/file>
+          By default, K3s automatically provides the root CA file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/server-ca.crt.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+          - "root-ca-file=<path>"
         scored: true
 
       - id: 1.3.6
         text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'RotateKubeletServerCertificate'"
-        type: "skip"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -955,9 +959,11 @@ groups:
             - flag: "--feature-gates"
               set: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --feature-gates parameter to include RotateKubeletServerCertificate=true.
-          --feature-gates=RotateKubeletServerCertificate=true
+          By default, K3s does not set the RotateKubeletServerCertificate feature gate.
+          If you have enabled this feature gate, you should remove it.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-controller-manager-arg:
+          - "feature-gate=RotateKubeletServerCertificate"
         scored: true
 
       - id: 1.3.7
@@ -974,8 +980,10 @@ groups:
             - flag: "--bind-address"
               set: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and ensure the correct value for the --bind-address parameter
+          By default, K3s sets the --bind-address argument to 127.0.0.1
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+          - "bind-address=<IP>"
         scored: true
 
   - id: 1.4
@@ -992,9 +1000,10 @@ groups:
                 value: false
               set: true
         remediation: |
-          Edit the Scheduler pod specification file $schedulerconf file
-          on the control plane node and set the below parameter.
-          --profiling=false
+          By default, K3s sets the --profiling argument to false.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-scheduler-arg:
+          - "profiling=true"
         scored: true
 
       - id: 1.4.2
@@ -1011,6 +1020,8 @@ groups:
             - flag: "--bind-address"
               set: false
         remediation: |
-          Edit the Scheduler pod specification file $schedulerconf
-          on the control plane node and ensure the correct value for the --bind-address parameter
+          By default, K3s sets the --bind-address argument to 127.0.0.1
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-scheduler-arg:
+          - "bind-address=<IP>"
         scored: true

--- a/package/cfg/k3s-cis-1.24-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/master.yaml
@@ -152,7 +152,12 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: "check_for_k3s_etcd.sh 1.1.11"
+        audit: |
+          if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
+            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
+          else 
+            echo "permissions=700"
+          fi
         tests:
           test_items:
             - flag: "permissions"
@@ -746,7 +751,12 @@ groups:
 
       - id: 1.2.26
         text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
-        audit: "check_for_k3s_etcd.sh 1.2.29"
+        audit: |
+          if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
+            journalctl -D /var/log/journal -u k3s | grep -m1 'Running kube-apiserver' | tail -n1
+          else 
+            echo "--etcd-certfile AND --etcd-keyfile"
+          fi
         tests:
           bin_op: and
           test_items:

--- a/package/cfg/k3s-cis-1.24-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/master.yaml
@@ -181,7 +181,7 @@ groups:
 
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/admin.kubeconfig'"
+        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/admin.kubeconfig; fi'"
         type: "skip"
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.24-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/master.yaml
@@ -327,27 +327,29 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the below parameter.
-          --anonymous-auth=false
+          By default, K3s sets the --anonymous-auth argument to false. If it is set to true,
+          edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
+          kube-apiserver-arg:
+            - "anonymous-auth=true"
         scored: false
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--token-auth-file"
               set: false
         remediation: |
-          Follow the documentation and configure alternate mechanisms for authentication. Then,
-          edit the API server pod specification file $apiserverconf
-          on the control plane node and remove the --token-auth-file=<filename> parameter.
+          Follow the documentation and configure alternate mechanisms for authentication.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
+          kube-apiserver-arg:
+          - "token-auth-file=<path>".
         scored: true
 
       - id: 1.2.3
         text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -358,14 +360,15 @@ groups:
             - flag: "--enable-admission-plugins"
               set: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and remove the `DenyServiceExternalIPs`
-          from enabled admission plugins.
+          By default, K3s does not set DenyServiceExternalIPs.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-apiserver-arg:
+          - "enable-admission-plugins=DenyServiceExternalIPs"
         scored: true
 
       - id: 1.2.4
         text: "Ensure that the --kubelet-https argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-https'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           bin_op: or
@@ -390,12 +393,13 @@ groups:
             - flag: "--kubelet-client-certificate"
             - flag: "--kubelet-client-key"
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection between the
-          apiserver and kubelets. Then, edit API server pod specification file
-          $apiserverconf on the control plane node and set the
-          kubelet client certificate and key parameters as below.
-          --kubelet-client-certificate=<path/to/client-certificate-file>
-          --kubelet-client-key=<path/to/client-key-file>
+          By default, K3s automatically provides the kubelet client certificate and key.
+          They are generated and located at /var/lib/rancher/k3s/server/tls/client-kube-apiserver.crt and /var/lib/rancher/k3s/server/tls/client-kube-apiserver.key
+          If for some reason you need to provide your own certificate and key, you can set the
+          the below parameters in the K3s config file /etc/rancher/k3s/config.yaml.
+          kube-apiserver-arg:
+          - "kubelet-client-certificate=<path/to/client-cert-file>"
+          - "kubelet-client-key=<path/to/client-key-file>"
         scored: true
 
       - id: 1.2.6
@@ -422,10 +426,10 @@ groups:
                 op: nothave
                 value: "AlwaysAllow"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --authorization-mode parameter to values other than AlwaysAllow.
-          One such example could be as below.
-          --authorization-mode=RBAC
+          By default, K3s does not set the --authorization-mode to AlwaysAllow.
+          If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-apiserver-arg:
+          - "authorization-mode=AlwaysAllow"
         scored: true
 
       - id: 1.2.8
@@ -438,9 +442,9 @@ groups:
                 op: has
                 value: "Node"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --authorization-mode parameter to a value that includes Node.
-          --authorization-mode=Node,RBAC
+          By default, K3s sets the --authorization-mode to Node and RBAC.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, 
+          ensure that you are not overriding authorization-mode.
         scored: true
 
       - id: 1.2.9
@@ -453,9 +457,9 @@ groups:
                 op: has
                 value: "RBAC"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --authorization-mode parameter to a value that includes RBAC,
-          for example `--authorization-mode=Node,RBAC`.
+          By default, K3s sets the --authorization-mode to Node and RBAC.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml,
+          ensure that you are not overriding authorization-mode.
         scored: true
 
       - id: 1.2.10
@@ -469,10 +473,10 @@ groups:
                 value: "EventRateLimit"
         remediation: |
           Follow the Kubernetes documentation and set the desired limits in a configuration file.
-          Then, edit the API server pod specification file $apiserverconf
-          and set the below parameters.
-          --enable-admission-plugins=...,EventRateLimit,...
-          --admission-control-config-file=<path/to/configuration/file>
+          Then, edit the K3s config file /etc/rancher/k3s/config.yaml and set the below parameters.
+          kube-apiserver-arg:
+          - "enable-admission-plugins=...,EventRateLimit,..."
+          - "admission-control-config-file=<path/to/configuration/file>"
         scored: false
 
       - id: 1.2.11
@@ -488,9 +492,10 @@ groups:
             - flag: "--enable-admission-plugins"
               set: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and either remove the --enable-admission-plugins parameter, or set it to a
-          value that does not include AlwaysAdmit.
+          By default, K3s does not set the --enable-admission-plugins to AlwaysAdmit.
+          If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-apiserver-arg:
+          - "enable-admission-plugins=AlwaysAdmit"
         scored: true
 
       - id: 1.2.12
@@ -503,10 +508,13 @@ groups:
                 op: has
                 value: "AlwaysPullImages"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --enable-admission-plugins parameter to include
-          AlwaysPullImages.
-          --enable-admission-plugins=...,AlwaysPullImages,...
+          Permissive, per CIS guidelines,
+          "This setting could impact offline or isolated clusters, which have images pre-loaded and
+          do not have access to a registry to pull in-use images. This setting is not appropriate for
+          clusters which use this configuration."
+          Edit the K3s config file /etc/rancher/k3s/config.yaml and set the below parameter.
+          kube-apiserver-arg:
+          - "enable-admission-plugins=...,AlwaysPullImages,..."
         scored: false
 
       - id: 1.2.13
@@ -543,15 +551,16 @@ groups:
             - flag: "--disable-admission-plugins"
               set: false
         remediation: |
+          By default, K3s does not set the --disable-admission-plugins to anything.
           Follow the documentation and create ServiceAccount objects as per your environment.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and ensure that the --disable-admission-plugins parameter is set to a
-          value that does not include ServiceAccount.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "disable-admission-plugins=ServiceAccount"
         scored: true
 
       - id: 1.2.15
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -562,9 +571,10 @@ groups:
             - flag: "--disable-admission-plugins"
               set: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --disable-admission-plugins parameter to
-          ensure it does not include NamespaceLifecycle.
+          By default, K3s does not set the --disable-admission-plugins to anything.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "disable-admission-plugins=...,NamespaceLifecycle,..."
         scored: true
 
       - id: 1.2.16
@@ -577,11 +587,11 @@ groups:
                 op: has
                 value: "NodeRestriction"
         remediation: |
-          Follow the Kubernetes documentation and configure NodeRestriction plug-in on kubelets.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --enable-admission-plugins parameter to a
-          value that includes NodeRestriction.
-          --enable-admission-plugins=...,NodeRestriction,...
+          By default, K3s sets the --enable-admission-plugins to NodeRestriction.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, check that you are not overriding the admission plugins.
+          If you are, include NodeRestriction in the list.
+          kube-apiserver-arg:
+          - "enable-admission-plugins=...,NodeRestriction,..."
         scored: true
 
       - id: 1.2.17
@@ -597,9 +607,11 @@ groups:
             - flag: "--secure-port"
               set: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and either remove the --secure-port parameter or
-          set it to a different (non-zero) desired port.
+          By default, K3s sets the secure port to 6444.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml 
+          and remove any lines like below.
+          kube-apiserver-arg:
+          - "secure-port=<PORT>"
         scored: true
 
       - id: 1.2.18
@@ -612,22 +624,23 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the below parameter.
-          --profiling=false
+          By default, K3s sets the --profiling argument to false.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "profiling=true"
         scored: true
 
       - id: 1.2.19
-        text: "Ensure that the --audit-log-path argument is set (Automated)"
+        text: "Ensure that the --audit-log-path argument is set (Manual)"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-path'"
         tests:
           test_items:
             - flag: "--audit-log-path"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-path parameter to a suitable path and
+          Edit the K3s config file /etc/rancher/k3s/config.yaml and set the audit-log-path parameter to a suitable path and
           file where you would like audit logs to be written, for example,
-          --audit-log-path=/var/log/apiserver/audit.log
+          kube-apiserver-arg:
+          - "audit-log-path=/var/lib/rancher/k3s/server/logs/audit.log"
         scored: true
 
       - id: 1.2.20
@@ -640,10 +653,10 @@ groups:
                 op: gte
                 value: 30
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-maxage parameter to 30
-          or as an appropriate number of days, for example,
-          --audit-log-maxage=30
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and
+          set the audit-log-maxage parameter to 30 or as an appropriate number of days, for example,
+          kube-apiserver-arg:
+          - "audit-log-maxage=30"
         scored: true
 
       - id: 1.2.21
@@ -656,10 +669,10 @@ groups:
                 op: gte
                 value: 10
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-maxbackup parameter to 10 or to an appropriate
-          value. For example,
-          --audit-log-maxbackup=10
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and 
+          set the audit-log-maxbackup parameter to 10 or to an appropriate value. For example,
+          kube-apiserver-arg:
+          - "audit-log-maxbackup=10"
         scored: true
 
       - id: 1.2.22
@@ -672,9 +685,10 @@ groups:
                 op: gte
                 value: 100
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-maxsize parameter to an appropriate size in MB.
-          For example, to set it as 100 MB, --audit-log-maxsize=100
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and 
+          set the audit-log-maxsize parameter to an appropriate size in MB. For example,
+          kube-apiserver-arg:
+          - "audit-log-maxsize=100"
         scored: true
 
       - id: 1.2.23
@@ -687,14 +701,17 @@ groups:
               set: false
             - flag: "--request-timeout"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          and set the below parameter as appropriate and if needed.
-          For example, --request-timeout=300s
-        scored: true
+          Permissive, per CIS guidelines, 
+          "it is recommended to set this limit as appropriate and change the default limit of 60 seconds only if needed".
+          Edit the K3s config file /etc/rancher/k3s/config.yaml
+          and set the below parameter if needed. For example,
+          kube-apiserver-arg:
+          - "request-timeout=300s"
+        scored: false
 
       - id: 1.2.24
         text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'service-account-lookup'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -705,10 +722,11 @@ groups:
                 op: eq
                 value: true
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the below parameter.
-          --service-account-lookup=true
-          Alternatively, you can delete the --service-account-lookup parameter from this file so
+          By default, K3s does not set the --service-account-lookup argument.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml and set the service-account-lookup. For example,
+          kube-apiserver-arg:
+          - "service-account-lookup=true"
+          Alternatively, you can delete the service-account-lookup parameter from this file so
           that the default takes effect.
         scored: true
 
@@ -719,10 +737,11 @@ groups:
           test_items:
             - flag: "--service-account-key-file"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --service-account-key-file parameter
-          to the public key file for service accounts. For example,
-          --service-account-key-file=<filename>
+          K3s automatically generates and sets the service account key file.
+          It is located at /var/lib/rancher/k3s/server/tls/service.key.
+          If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "service-account-key-file=<path>"
         scored: true
 
       - id: 1.2.26
@@ -736,11 +755,12 @@ groups:
             - flag: "--etcd-keyfile"
               set: true
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the etcd certificate and key file parameters.
-          --etcd-certfile=<path/to/client-certificate-file>
-          --etcd-keyfile=<path/to/client-key-file>
+          K3s automatically generates and sets the etcd certificate and key files.
+          They are located at /var/lib/rancher/k3s/server/tls/etcd/client.crt and /var/lib/rancher/k3s/server/tls/etcd/client.key.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "etcd-certfile=<path>"
+          - "etcd-keyfile=<path>"
         scored: true
 
       - id: 1.2.27
@@ -754,11 +774,12 @@ groups:
             - flag: "--tls-private-key-file"
               set: true
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the TLS certificate and private key file parameters.
-          --tls-cert-file=<path/to/tls-certificate-file>
-          --tls-private-key-file=<path/to/tls-key-file>
+          By default, K3s automatically generates and provides the TLS certificate and private key for the apiserver.
+          They are generated and located at /var/lib/rancher/k3s/server/tls/serving-kube-apiserver.crt and /var/lib/rancher/k3s/server/tls/serving-kube-apiserver.key
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "tls-cert-file=<path>"
+          - "tls-private-key-file=<path>"
         scored: true
 
       - id: 1.2.28
@@ -768,10 +789,11 @@ groups:
           test_items:
             - flag: "--client-ca-file"
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the client certificate authority file.
-          --client-ca-file=<path/to/client-ca-file>
+          By default, K3s automatically provides the client certificate authority file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/client-ca.crt.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "client-ca-file=<path>"
         scored: true
 
       - id: 1.2.29
@@ -781,10 +803,11 @@ groups:
           test_items:
             - flag: "--etcd-cafile"
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the etcd certificate authority file parameter.
-          --etcd-cafile=<path/to/ca-file>
+          By default, K3s automatically provides the etcd certificate authority file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/client-ca.crt.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "etcd-cafile=<path>"
         scored: true
 
       - id: 1.2.30
@@ -794,19 +817,30 @@ groups:
           test_items:
             - flag: "--encryption-provider-config"
         remediation: |
-          Follow the Kubernetes documentation and configure a EncryptionConfig file.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --encryption-provider-config parameter to the path of that file.
-          For example, --encryption-provider-config=</path/to/EncryptionConfig/File>
+          K3s can be configured to use encryption providers to encrypt secrets at rest.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and set the below parameter.
+          secrets-encryption: true
+          Secrets encryption can then be managed with the k3s secrets-encrypt command line tool.
+          If needed, you can find the generated encryption config at /var/lib/rancher/k3s/server/cred/encryption-config.json.
         scored: false
 
       - id: 1.2.31
         text: "Ensure that encryption providers are appropriately configured (Manual)"
-        audit: "grep aescbc /path/to/encryption-config.json"
-        type: "manual"
+        audit: |
+          ENCRYPTION_PROVIDER_CONFIG=$(journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
+          if test -e $ENCRYPTION_PROVIDER_CONFIG; then grep -o 'providers\"\:\[.*\]' $ENCRYPTION_PROVIDER_CONFIG | grep -o "[A-Za-z]*" | head -2 | tail -1  | sed 's/^/provider=/'; fi
+        tests:
+          test_items:
+            - flag: "provider"
+              compare:
+                op: valid_elements
+                value: "aescbc,kms,secretbox"
         remediation: |
-          Follow the Kubernetes documentation and configure a EncryptionConfig file.
-          In this file, choose aescbc, kms or secretbox as the encryption provider.
+          K3s can be configured to use encryption providers to encrypt secrets at rest. K3s will utilize the aescbc provider.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and set the below parameter.
+          secrets-encryption: true
+          Secrets encryption can then be managed with the k3s secrets-encrypt command line tool.
+          If needed, you can find the generated encryption config at /var/lib/rancher/k3s/server/cred/encryption-config.json
         scored: false
 
       - id: 1.2.32

--- a/package/cfg/k3s-cis-1.24-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/master.yaml
@@ -323,7 +323,7 @@ groups:
     checks:
       - id: 1.2.1
         text: "Ensure that the --anonymous-auth argument is set to false (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth'"
         type: manual
         tests:
           test_items:
@@ -340,7 +340,7 @@ groups:
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--token-auth-file"
@@ -354,7 +354,7 @@ groups:
 
       - id: 1.2.3
         text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -373,7 +373,7 @@ groups:
 
       - id: 1.2.4
         text: "Ensure that the --kubelet-https argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           bin_op: or
@@ -391,7 +391,7 @@ groups:
 
       - id: 1.2.5
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
         tests:
           bin_op: and
           test_items:
@@ -409,7 +409,7 @@ groups:
 
       - id: 1.2.6
         text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
         tests:
           test_items:
             - flag: "--kubelet-certificate-authority"
@@ -423,7 +423,7 @@ groups:
 
       - id: 1.2.7
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -439,7 +439,7 @@ groups:
 
       - id: 1.2.8
         text: "Ensure that the --authorization-mode argument includes Node (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -454,7 +454,7 @@ groups:
 
       - id: 1.2.9
         text: "Ensure that the --authorization-mode argument includes RBAC (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -469,7 +469,7 @@ groups:
 
       - id: 1.2.10
         text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -486,7 +486,7 @@ groups:
 
       - id: 1.2.11
         text: "Ensure that the admission control plugin AlwaysAdmit is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           bin_op: or
           test_items:
@@ -505,7 +505,7 @@ groups:
 
       - id: 1.2.12
         text: "Ensure that the admission control plugin AlwaysPullImages is set (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -524,7 +524,7 @@ groups:
 
       - id: 1.2.13
         text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           bin_op: or
           test_items:
@@ -545,7 +545,7 @@ groups:
 
       - id: 1.2.14
         text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'ServiceAccount'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'ServiceAccount'"
         tests:
           bin_op: or
           test_items:
@@ -565,7 +565,7 @@ groups:
 
       - id: 1.2.15
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -584,7 +584,7 @@ groups:
 
       - id: 1.2.16
         text: "Ensure that the admission control plugin NodeRestriction is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -601,7 +601,7 @@ groups:
 
       - id: 1.2.17
         text: "Ensure that the --secure-port argument is not set to 0 (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'secure-port'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'secure-port'"
         tests:
           bin_op: or
           test_items:
@@ -620,7 +620,7 @@ groups:
 
       - id: 1.2.18
         text: "Ensure that the --profiling argument is set to false (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'profiling'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'profiling'"
         tests:
           test_items:
             - flag: "--profiling"
@@ -636,7 +636,7 @@ groups:
 
       - id: 1.2.19
         text: "Ensure that the --audit-log-path argument is set (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-path'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-path'"
         tests:
           test_items:
             - flag: "--audit-log-path"
@@ -649,7 +649,7 @@ groups:
 
       - id: 1.2.20
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-maxage'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-maxage'"
         tests:
           test_items:
             - flag: "--audit-log-maxage"
@@ -665,7 +665,7 @@ groups:
 
       - id: 1.2.21
         text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-maxbackup'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-maxbackup'"
         tests:
           test_items:
             - flag: "--audit-log-maxbackup"
@@ -681,7 +681,7 @@ groups:
 
       - id: 1.2.22
         text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-maxsize'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-log-maxsize'"
         tests:
           test_items:
             - flag: "--audit-log-maxsize"
@@ -697,7 +697,7 @@ groups:
 
       - id: 1.2.23
         text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'request-timeout'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'request-timeout'"
         tests:
           bin_op: or
           test_items:
@@ -715,7 +715,7 @@ groups:
 
       - id: 1.2.24
         text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -736,7 +736,7 @@ groups:
 
       - id: 1.2.25
         text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'service-account-key-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'service-account-key-file'"
         tests:
           test_items:
             - flag: "--service-account-key-file"
@@ -793,7 +793,7 @@ groups:
 
       - id: 1.2.28
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'client-ca-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'client-ca-file'"
         tests:
           test_items:
             - flag: "--client-ca-file"
@@ -807,7 +807,7 @@ groups:
 
       - id: 1.2.29
         text: "Ensure that the --etcd-cafile argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-cafile'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-cafile'"
         tests:
           test_items:
             - flag: "--etcd-cafile"
@@ -821,7 +821,7 @@ groups:
 
       - id: 1.2.30
         text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'encryption-provider-config'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'encryption-provider-config'"
         tests:
           test_items:
             - flag: "--encryption-provider-config"
@@ -874,7 +874,7 @@ groups:
     checks:
       - id: 1.3.1
         text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'terminated-pod-gc-threshold'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'terminated-pod-gc-threshold'"
         tests:
           test_items:
             - flag: "--terminated-pod-gc-threshold"
@@ -887,7 +887,7 @@ groups:
 
       - id: 1.3.2
         text: "Ensure that the --profiling argument is set to false (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'profiling'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'profiling'"
         tests:
           test_items:
             - flag: "--profiling"
@@ -903,7 +903,7 @@ groups:
 
       - id: 1.3.3
         text: "Ensure that the --use-service-account-credentials argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'use-service-account-credentials'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'use-service-account-credentials'"
         tests:
           test_items:
             - flag: "--use-service-account-credentials"
@@ -919,7 +919,7 @@ groups:
 
       - id: 1.3.4
         text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'service-account-private-key-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'service-account-private-key-file'"
         tests:
           test_items:
             - flag: "--service-account-private-key-file"
@@ -933,7 +933,7 @@ groups:
 
       - id: 1.3.5
         text: "Ensure that the --root-ca-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'root-ca-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'root-ca-file'"
         tests:
           test_items:
             - flag: "--root-ca-file"
@@ -947,7 +947,7 @@ groups:
 
       - id: 1.3.6
         text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -968,7 +968,7 @@ groups:
 
       - id: 1.3.7
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'bind-address'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'bind-address'"
         tests:
           bin_op: or
           test_items:
@@ -1008,7 +1008,7 @@ groups:
 
       - id: 1.4.2
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'bind-address'"
+        audit: "journalctl -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'bind-address'"
         tests:
           bin_op: or
           test_items:

--- a/package/cfg/k3s-cis-1.24-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/node.yaml
@@ -216,7 +216,7 @@ groups:
 
       - id: 4.2.4
         text: "Verify that the --read-only-port argument is set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -242,7 +242,7 @@ groups:
 
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -265,7 +265,7 @@ groups:
 
       - id: 4.2.6
         text: "Ensure that the --protect-kernel-defaults argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --protect-kernel-defaults
@@ -284,7 +284,7 @@ groups:
 
       - id: 4.2.7
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --make-iptables-util-chains
@@ -309,7 +309,7 @@ groups:
       - id: 4.2.8
         text: "Ensure that the --hostname-override argument is not set (Manual)"
         type: "skip"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --hostname-override
@@ -322,7 +322,7 @@ groups:
 
       - id: 4.2.9
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
           test_items:
@@ -343,7 +343,7 @@ groups:
 
       - id: 4.2.10
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --tls-cert-file
@@ -362,7 +362,7 @@ groups:
 
       - id: 4.2.11
         text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -385,7 +385,7 @@ groups:
 
       - id: 4.2.12
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -408,7 +408,7 @@ groups:
 
       - id: 4.2.13
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.24-permissive/config.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/config.yaml
@@ -16,10 +16,15 @@ master:
   scheduler:
     bins:
       - containerd
+    kubeconfig:
+      - /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig
 
   controllermanager:
     bins:
       - containerd
+    kubeconfig:
+      - /var/lib/rancher/k3s/server/cred/controller.kubeconfig
+
 
   etcd:
     bins:

--- a/package/cfg/k3s-cis-1.24-permissive/controlplane.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/controlplane.yaml
@@ -21,7 +21,7 @@ groups:
     checks:
       - id: 3.2.1
         text: "Ensure that a minimal audit policy is created (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-policy-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-policy-file'"
         tests:
           test_items:
             - flag: "--audit-policy-file"

--- a/package/cfg/k3s-cis-1.24-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/master.yaml
@@ -118,10 +118,7 @@ groups:
 
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Automated)"
-        type: "skip"
-        audit: |
-          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
-          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
+        audit: find /var/lib/cni/networks -type f ! -name lock 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
         use_multiple_values: true
         tests:
           test_items:
@@ -130,8 +127,10 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 <path/to/cni/files>
+          By default, K3s sets the CNI file permissions to 600.
+          Note that for many CNIs, a lock file is created with permissions 750. This is expected and can be ignored.
+          If you modify your CNI configuration, ensure that the permissions are set to 600.
+          For example, chmod 600 /var/lib/cni/networks/<filename>
         scored: false
 
       - id: 1.1.10

--- a/package/cfg/k3s-cis-1.24-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/master.yaml
@@ -323,7 +323,7 @@ groups:
     checks:
       - id: 1.2.1
         text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth'"
         tests:
           test_items:
             - flag: "--anonymous-auth"
@@ -339,7 +339,7 @@ groups:
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--token-auth-file"
@@ -353,7 +353,7 @@ groups:
 
       - id: 1.2.3
         text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -373,7 +373,7 @@ groups:
 
       - id: 1.2.4
         text: "Ensure that the --kubelet-https argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-https'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-https'"
         type: "skip"
         tests:
           bin_op: or
@@ -391,7 +391,7 @@ groups:
 
       - id: 1.2.5
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
         tests:
           bin_op: and
           test_items:
@@ -409,7 +409,7 @@ groups:
 
       - id: 1.2.6
         text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
         tests:
           test_items:
             - flag: "--kubelet-certificate-authority"
@@ -423,7 +423,7 @@ groups:
 
       - id: 1.2.7
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -439,7 +439,7 @@ groups:
 
       - id: 1.2.8
         text: "Ensure that the --authorization-mode argument includes Node (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -454,7 +454,7 @@ groups:
 
       - id: 1.2.9
         text: "Ensure that the --authorization-mode argument includes RBAC (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -469,7 +469,7 @@ groups:
 
       - id: 1.2.10
         text: "Ensure that the admission control plugin EventRateLimit is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -486,7 +486,7 @@ groups:
 
       - id: 1.2.11
         text: "Ensure that the admission control plugin AlwaysAdmit is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           bin_op: or
           test_items:
@@ -524,7 +524,7 @@ groups:
 
       - id: 1.2.13
         text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           bin_op: or
           test_items:
@@ -545,7 +545,7 @@ groups:
 
       - id: 1.2.14
         text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -565,7 +565,7 @@ groups:
 
       - id: 1.2.15
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -584,7 +584,7 @@ groups:
 
       - id: 1.2.16
         text: "Ensure that the admission control plugin NodeRestriction is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -601,7 +601,7 @@ groups:
 
       - id: 1.2.17
         text: "Ensure that the --secure-port argument is not set to 0 (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'secure-port'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'secure-port'"
         tests:
           bin_op: or
           test_items:
@@ -620,7 +620,7 @@ groups:
 
       - id: 1.2.18
         text: "Ensure that the --profiling argument is set to false (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'profiling'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'profiling'"
         tests:
           test_items:
             - flag: "--profiling"
@@ -636,7 +636,7 @@ groups:
 
       - id: 1.2.19
         text: "Ensure that the --audit-log-path argument is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -650,7 +650,7 @@ groups:
 
       - id: 1.2.20
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -667,7 +667,7 @@ groups:
 
       - id: 1.2.21
         text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -684,7 +684,7 @@ groups:
 
       - id: 1.2.22
         text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -701,7 +701,7 @@ groups:
 
       - id: 1.2.23
         text: "Ensure that the --request-timeout argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -717,7 +717,7 @@ groups:
 
       - id: 1.2.24
         text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -738,7 +738,7 @@ groups:
 
       - id: 1.2.25
         text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -796,7 +796,7 @@ groups:
 
       - id: 1.2.28
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'client-ca-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'client-ca-file'"
         tests:
           test_items:
             - flag: "--client-ca-file"
@@ -810,7 +810,7 @@ groups:
 
       - id: 1.2.29
         text: "Ensure that the --etcd-cafile argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-cafile'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-cafile'"
         tests:
           test_items:
             - flag: "--etcd-cafile"
@@ -824,7 +824,7 @@ groups:
 
       - id: 1.2.30
         text: "Ensure that the --encryption-provider-config argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'encryption-provider-config'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'encryption-provider-config'"
         tests:
           test_items:
             - flag: "--encryption-provider-config"
@@ -877,7 +877,7 @@ groups:
     checks:
       - id: 1.3.1
         text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'terminated-pod-gc-threshold'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'terminated-pod-gc-threshold'"
         tests:
           test_items:
             - flag: "--terminated-pod-gc-threshold"
@@ -890,7 +890,7 @@ groups:
 
       - id: 1.3.2
         text: "Ensure that the --profiling argument is set to false (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'profiling'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'profiling'"
         tests:
           test_items:
             - flag: "--profiling"
@@ -906,7 +906,7 @@ groups:
 
       - id: 1.3.3
         text: "Ensure that the --use-service-account-credentials argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'use-service-account-credentials'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'use-service-account-credentials'"
         tests:
           test_items:
             - flag: "--use-service-account-credentials"
@@ -922,7 +922,7 @@ groups:
 
       - id: 1.3.4
         text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'service-account-private-key-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'service-account-private-key-file'"
         tests:
           test_items:
             - flag: "--service-account-private-key-file"
@@ -936,7 +936,7 @@ groups:
 
       - id: 1.3.5
         text: "Ensure that the --root-ca-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'root-ca-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'root-ca-file'"
         tests:
           test_items:
             - flag: "--root-ca-file"
@@ -950,7 +950,7 @@ groups:
 
       - id: 1.3.6
         text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -1011,7 +1011,7 @@ groups:
 
       - id: 1.4.2
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'bind-address'"
+        audit: "journalctl -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'bind-address'"
         tests:
           bin_op: or
           test_items:

--- a/package/cfg/k3s-cis-1.24-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/master.yaml
@@ -20,7 +20,7 @@ groups:
                 value: "644"
         remediation: |
           Not Applicable.
-          K3s embeds the api server within the k3s process. There is no API server pod specification file.
+          By default, K3s embeds the api server within the k3s process. There is no API server pod specification file.
         scored: true
 
       - id: 1.1.2
@@ -32,7 +32,7 @@ groups:
             - flag: "root:root"
         remediation: |
           Not Applicable.
-          K3s embeds the api server within the k3s process. There is no API server pod specification file.
+          By default, K3s embeds the api server within the k3s process. There is no API server pod specification file.
         scored: true
 
       - id: 1.1.3
@@ -47,7 +47,7 @@ groups:
                 value: "600"
         remediation: |
           Not Applicable.
-          K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
+          By default, K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
         scored: true
 
       - id: 1.1.4
@@ -59,7 +59,7 @@ groups:
             - flag: "root:root"
         remediation: |
           Not Applicable.
-          K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
+          By default, K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
         scored: true
 
       - id: 1.1.5
@@ -74,7 +74,7 @@ groups:
                 value: "600"
         remediation: |
           Not Applicable.
-          K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
+          By default, K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
         scored: true
 
       - id: 1.1.6
@@ -86,7 +86,7 @@ groups:
             - flag: "root:root"
         remediation: |
           Not Applicable.
-          K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
+          By default, K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
         scored: true
 
       - id: 1.1.7
@@ -101,7 +101,7 @@ groups:
                 value: "600"
         remediation: |
           Not Applicable.
-          K3s embeds etcd within the k3s process. There is no etcd pod specification file.
+          By default, K3s embeds etcd within the k3s process. There is no etcd pod specification file.
         scored: true
 
       - id: 1.1.8
@@ -113,7 +113,7 @@ groups:
             - flag: "root:root"
         remediation: |
           Not Applicable.
-          K3s embeds etcd within the k3s process. There is no etcd pod specification file.
+          By default, K3s embeds etcd within the k3s process. There is no etcd pod specification file.
         scored: true
 
       - id: 1.1.9

--- a/package/cfg/k3s-cis-1.24-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/master.yaml
@@ -152,7 +152,12 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: "check_for_k3s_etcd.sh 1.1.11"
+        audit: |
+          if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
+            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
+          else 
+            echo "permissions=700"
+          fi
         tests:
           test_items:
             - flag: "permissions"
@@ -749,7 +754,12 @@ groups:
 
       - id: 1.2.26
         text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
-        audit: "check_for_k3s_etcd.sh 1.2.29"
+        audit: |
+          if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
+            journalctl -D /var/log/journal -u k3s | grep -m1 'Running kube-apiserver' | tail -n1
+          else 
+            echo "--etcd-certfile AND --etcd-keyfile"
+          fi
         tests:
           bin_op: and
           test_items:

--- a/package/cfg/k3s-cis-1.24-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/master.yaml
@@ -181,7 +181,7 @@ groups:
 
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/admin.kubeconfig'"
+        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/admin.kubeconfig; fi'"
         type: "skip"
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.24-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/master.yaml
@@ -326,27 +326,29 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the below parameter.
-          --anonymous-auth=false
+          By default, K3s sets the --anonymous-auth argument to false. If it is set to true,
+          edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
+          kube-apiserver-arg:
+            - "anonymous-auth=true"
         scored: false
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--token-auth-file"
               set: false
         remediation: |
-          Follow the documentation and configure alternate mechanisms for authentication. Then,
-          edit the API server pod specification file $apiserverconf
-          on the control plane node and remove the --token-auth-file=<filename> parameter.
+          Follow the documentation and configure alternate mechanisms for authentication.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
+          kube-apiserver-arg:
+          - "token-auth-file=<path>".
         scored: true
 
       - id: 1.2.3
         text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -358,9 +360,10 @@ groups:
             - flag: "--enable-admission-plugins"
               set: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and remove the `DenyServiceExternalIPs`
-          from enabled admission plugins.
+          By default, K3s does not set DenyServiceExternalIPs.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-apiserver-arg:
+          - "enable-admission-plugins=DenyServiceExternalIPs"
         scored: true
 
       - id: 1.2.4
@@ -390,12 +393,13 @@ groups:
             - flag: "--kubelet-client-certificate"
             - flag: "--kubelet-client-key"
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection between the
-          apiserver and kubelets. Then, edit API server pod specification file
-          $apiserverconf on the control plane node and set the
-          kubelet client certificate and key parameters as below.
-          --kubelet-client-certificate=<path/to/client-certificate-file>
-          --kubelet-client-key=<path/to/client-key-file>
+          By default, K3s automatically provides the kubelet client certificate and key.
+          They are generated and located at /var/lib/rancher/k3s/server/tls/client-kube-apiserver.crt and /var/lib/rancher/k3s/server/tls/client-kube-apiserver.key
+          If for some reason you need to provide your own certificate and key, you can set the
+          the below parameters in the K3s config file /etc/rancher/k3s/config.yaml.
+          kube-apiserver-arg:
+          - "kubelet-client-certificate=<path/to/client-cert-file>"
+          - "kubelet-client-key=<path/to/client-key-file>"
         scored: true
 
       - id: 1.2.6
@@ -422,10 +426,10 @@ groups:
                 op: nothave
                 value: "AlwaysAllow"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --authorization-mode parameter to values other than AlwaysAllow.
-          One such example could be as below.
-          --authorization-mode=RBAC
+          By default, K3s does not set the --authorization-mode to AlwaysAllow.
+          If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-apiserver-arg:
+          - "authorization-mode=AlwaysAllow"
         scored: true
 
       - id: 1.2.8
@@ -438,9 +442,9 @@ groups:
                 op: has
                 value: "Node"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --authorization-mode parameter to a value that includes Node.
-          --authorization-mode=Node,RBAC
+          By default, K3s sets the --authorization-mode to Node and RBAC.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, 
+          ensure that you are not overriding authorization-mode.
         scored: true
 
       - id: 1.2.9
@@ -453,9 +457,9 @@ groups:
                 op: has
                 value: "RBAC"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --authorization-mode parameter to a value that includes RBAC,
-          for example `--authorization-mode=Node,RBAC`.
+          By default, K3s sets the --authorization-mode to Node and RBAC.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml,
+          ensure that you are not overriding authorization-mode.
         scored: true
 
       - id: 1.2.10
@@ -469,10 +473,10 @@ groups:
                 value: "EventRateLimit"
         remediation: |
           Follow the Kubernetes documentation and set the desired limits in a configuration file.
-          Then, edit the API server pod specification file $apiserverconf
-          and set the below parameters.
-          --enable-admission-plugins=...,EventRateLimit,...
-          --admission-control-config-file=<path/to/configuration/file>
+          Then, edit the K3s config file /etc/rancher/k3s/config.yaml and set the below parameters.
+          kube-apiserver-arg:
+          - "enable-admission-plugins=...,EventRateLimit,..."
+          - "admission-control-config-file=<path/to/configuration/file>"
         scored: false
 
       - id: 1.2.11
@@ -488,9 +492,10 @@ groups:
             - flag: "--enable-admission-plugins"
               set: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and either remove the --enable-admission-plugins parameter, or set it to a
-          value that does not include AlwaysAdmit.
+          By default, K3s does not set the --enable-admission-plugins to AlwaysAdmit.
+          If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-apiserver-arg:
+          - "enable-admission-plugins=AlwaysAdmit"
         scored: true
 
       - id: 1.2.12
@@ -503,10 +508,13 @@ groups:
                 op: has
                 value: "AlwaysPullImages"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --enable-admission-plugins parameter to include
-          AlwaysPullImages.
-          --enable-admission-plugins=...,AlwaysPullImages,...
+          Permissive, per CIS guidelines,
+          "This setting could impact offline or isolated clusters, which have images pre-loaded and
+          do not have access to a registry to pull in-use images. This setting is not appropriate for
+          clusters which use this configuration."
+          Edit the K3s config file /etc/rancher/k3s/config.yaml and set the below parameter.
+          kube-apiserver-arg:
+          - "enable-admission-plugins=...,AlwaysPullImages,..."
         scored: false
 
       - id: 1.2.13
@@ -532,7 +540,7 @@ groups:
 
       - id: 1.2.14
         text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -543,15 +551,16 @@ groups:
             - flag: "--disable-admission-plugins"
               set: false
         remediation: |
+          By default, K3s does not set the --disable-admission-plugins to anything.
           Follow the documentation and create ServiceAccount objects as per your environment.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and ensure that the --disable-admission-plugins parameter is set to a
-          value that does not include ServiceAccount.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "disable-admission-plugins=ServiceAccount"
         scored: true
 
       - id: 1.2.15
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -562,9 +571,10 @@ groups:
             - flag: "--disable-admission-plugins"
               set: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --disable-admission-plugins parameter to
-          ensure it does not include NamespaceLifecycle.
+          By default, K3s does not set the --disable-admission-plugins to anything.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "disable-admission-plugins=...,NamespaceLifecycle,..."
         scored: true
 
       - id: 1.2.16
@@ -577,11 +587,11 @@ groups:
                 op: has
                 value: "NodeRestriction"
         remediation: |
-          Follow the Kubernetes documentation and configure NodeRestriction plug-in on kubelets.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --enable-admission-plugins parameter to a
-          value that includes NodeRestriction.
-          --enable-admission-plugins=...,NodeRestriction,...
+          By default, K3s sets the --enable-admission-plugins to NodeRestriction.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, check that you are not overriding the admission plugins.
+          If you are, include NodeRestriction in the list.
+          kube-apiserver-arg:
+          - "enable-admission-plugins=...,NodeRestriction,..."
         scored: true
 
       - id: 1.2.17
@@ -597,9 +607,11 @@ groups:
             - flag: "--secure-port"
               set: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and either remove the --secure-port parameter or
-          set it to a different (non-zero) desired port.
+          By default, K3s sets the secure port to 6444.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml 
+          and remove any lines like below.
+          kube-apiserver-arg:
+          - "secure-port=<PORT>"
         scored: true
 
       - id: 1.2.18
@@ -612,28 +624,29 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the below parameter.
-          --profiling=false
+          By default, K3s sets the --profiling argument to false.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "profiling=true"
         scored: true
 
       - id: 1.2.19
         text: "Ensure that the --audit-log-path argument is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
             - flag: "--audit-log-path"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-path parameter to a suitable path and
+          Edit the K3s config file /etc/rancher/k3s/config.yaml and set the audit-log-path parameter to a suitable path and
           file where you would like audit logs to be written, for example,
-          --audit-log-path=/var/log/apiserver/audit.log
+          kube-apiserver-arg:
+          - "audit-log-path=/var/lib/rancher/k3s/server/logs/audit.log"
         scored: true
 
       - id: 1.2.20
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -642,15 +655,15 @@ groups:
                 op: gte
                 value: 30
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-maxage parameter to 30
-          or as an appropriate number of days, for example,
-          --audit-log-maxage=30
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and
+          set the audit-log-maxage parameter to 30 or as an appropriate number of days, for example,
+          kube-apiserver-arg:
+          - "audit-log-maxage=30"
         scored: true
 
       - id: 1.2.21
         text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -659,15 +672,15 @@ groups:
                 op: gte
                 value: 10
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-maxbackup parameter to 10 or to an appropriate
-          value. For example,
-          --audit-log-maxbackup=10
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and 
+          set the audit-log-maxbackup parameter to 10 or to an appropriate value. For example,
+          kube-apiserver-arg:
+          - "audit-log-maxbackup=10"
         scored: true
 
       - id: 1.2.22
         text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -676,27 +689,31 @@ groups:
                 op: gte
                 value: 100
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-maxsize parameter to an appropriate size in MB.
-          For example, to set it as 100 MB, --audit-log-maxsize=100
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and 
+          set the audit-log-maxsize parameter to an appropriate size in MB. For example,
+          kube-apiserver-arg:
+          - "audit-log-maxsize=100"
         scored: true
 
       - id: 1.2.23
         text: "Ensure that the --request-timeout argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
             - flag: "--request-timeout"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          and set the below parameter as appropriate and if needed.
-          For example, --request-timeout=300s
+          Permissive, per CIS guidelines, 
+          "it is recommended to set this limit as appropriate and change the default limit of 60 seconds only if needed".
+          Edit the K3s config file /etc/rancher/k3s/config.yaml
+          and set the below parameter if needed. For example,
+          kube-apiserver-arg:
+          - "request-timeout=300s"
         scored: true
 
       - id: 1.2.24
         text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -707,25 +724,27 @@ groups:
                 op: eq
                 value: true
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the below parameter.
-          --service-account-lookup=true
-          Alternatively, you can delete the --service-account-lookup parameter from this file so
+          By default, K3s does not set the --service-account-lookup argument.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml and set the service-account-lookup. For example,
+          kube-apiserver-arg:
+          - "service-account-lookup=true"
+          Alternatively, you can delete the service-account-lookup parameter from this file so
           that the default takes effect.
         scored: true
 
       - id: 1.2.25
         text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
             - flag: "--service-account-key-file"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --service-account-key-file parameter
-          to the public key file for service accounts. For example,
-          --service-account-key-file=<filename>
+          K3s automatically generates and sets the service account key file.
+          It is located at /var/lib/rancher/k3s/server/tls/service.key.
+          If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "service-account-key-file=<path>"
         scored: true
 
       - id: 1.2.26
@@ -739,11 +758,12 @@ groups:
             - flag: "--etcd-keyfile"
               set: true
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the etcd certificate and key file parameters.
-          --etcd-certfile=<path/to/client-certificate-file>
-          --etcd-keyfile=<path/to/client-key-file>
+          K3s automatically generates and sets the etcd certificate and key files.
+          They are located at /var/lib/rancher/k3s/server/tls/etcd/client.crt and /var/lib/rancher/k3s/server/tls/etcd/client.key.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "etcd-certfile=<path>"
+          - "etcd-keyfile=<path>"
         scored: true
 
       - id: 1.2.27
@@ -757,11 +777,12 @@ groups:
             - flag: "--tls-private-key-file"
               set: true
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the TLS certificate and private key file parameters.
-          --tls-cert-file=<path/to/tls-certificate-file>
-          --tls-private-key-file=<path/to/tls-key-file>
+          By default, K3s automatically generates and provides the TLS certificate and private key for the apiserver.
+          They are generated and located at /var/lib/rancher/k3s/server/tls/serving-kube-apiserver.crt and /var/lib/rancher/k3s/server/tls/serving-kube-apiserver.key
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "tls-cert-file=<path>"
+          - "tls-private-key-file=<path>"
         scored: true
 
       - id: 1.2.28
@@ -771,10 +792,11 @@ groups:
           test_items:
             - flag: "--client-ca-file"
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the client certificate authority file.
-          --client-ca-file=<path/to/client-ca-file>
+          By default, K3s automatically provides the client certificate authority file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/client-ca.crt.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "client-ca-file=<path>"
         scored: true
 
       - id: 1.2.29
@@ -784,10 +806,11 @@ groups:
           test_items:
             - flag: "--etcd-cafile"
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the etcd certificate authority file parameter.
-          --etcd-cafile=<path/to/ca-file>
+          By default, K3s automatically provides the etcd certificate authority file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/client-ca.crt.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "etcd-cafile=<path>"
         scored: true
 
       - id: 1.2.30
@@ -797,17 +820,18 @@ groups:
           test_items:
             - flag: "--encryption-provider-config"
         remediation: |
-          Follow the Kubernetes documentation and configure a EncryptionConfig file.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --encryption-provider-config parameter to the path of that file.
-          For example, --encryption-provider-config=</path/to/EncryptionConfig/File>
+          K3s can be configured to use encryption providers to encrypt secrets at rest.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and set the below parameter.
+          secrets-encryption: true
+          Secrets encryption can then be managed with the k3s secrets-encrypt command line tool.
+          If needed, you can find the generated encryption config at /var/lib/rancher/k3s/server/cred/encryption-config.json.
         scored: false
 
       - id: 1.2.31
         text: "Ensure that encryption providers are appropriately configured (Automated)"
         audit: |
-          ENCRYPTION_PROVIDER_CONFIG=$(ps -ef | grep $apiserverbin | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
-          if test -e $ENCRYPTION_PROVIDER_CONFIG; then grep -A1 'providers:' $ENCRYPTION_PROVIDER_CONFIG | tail -n1 | grep -o "[A-Za-z]*" | sed 's/^/provider=/'; fi
+          ENCRYPTION_PROVIDER_CONFIG=$(journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
+          if test -e $ENCRYPTION_PROVIDER_CONFIG; then grep -o 'providers\"\:\[.*\]' $ENCRYPTION_PROVIDER_CONFIG | grep -o "[A-Za-z]*" | head -2 | tail -1  | sed 's/^/provider=/'; fi
         tests:
           test_items:
             - flag: "provider"
@@ -815,8 +839,11 @@ groups:
                 op: valid_elements
                 value: "aescbc,kms,secretbox"
         remediation: |
-          Follow the Kubernetes documentation and configure a EncryptionConfig file.
-          In this file, choose aescbc, kms or secretbox as the encryption provider.
+          K3s can be configured to use encryption providers to encrypt secrets at rest. K3s will utilize the aescbc provider.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and set the below parameter.
+          secrets-encryption: true
+          Secrets encryption can then be managed with the k3s secrets-encrypt command line tool.
+          If needed, you can find the generated encryption config at /var/lib/rancher/k3s/server/cred/encryption-config.json
         scored: false
 
       - id: 1.2.32

--- a/package/cfg/k3s-cis-1.24-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/master.yaml
@@ -19,9 +19,8 @@ groups:
                 op: bitmask
                 value: "644"
         remediation: |
-          Run the below command (based on the file location on your system) on the
-          control plane node.
-          For example, chmod 644 $apiserverconf
+          Not Applicable.
+          K3s embeds the api server within the k3s process. There is no API server pod specification file.
         scored: true
 
       - id: 1.1.2
@@ -32,8 +31,8 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root $apiserverconf
+          Not Applicable.
+          K3s embeds the api server within the k3s process. There is no API server pod specification file.
         scored: true
 
       - id: 1.1.3
@@ -47,8 +46,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 $controllermanagerconf
+          Not Applicable.
+          K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
         scored: true
 
       - id: 1.1.4
@@ -59,8 +58,8 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root $controllermanagerconf
+          Not Applicable.
+          K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
         scored: true
 
       - id: 1.1.5
@@ -74,8 +73,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 $schedulerconf
+          Not Applicable.
+          K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
         scored: true
 
       - id: 1.1.6
@@ -86,8 +85,8 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root $schedulerconf
+          Not Applicable.
+          K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
         scored: true
 
       - id: 1.1.7
@@ -101,9 +100,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chmod 600 $etcdconf
+          Not Applicable.
+          K3s embeds etcd within the k3s process. There is no etcd pod specification file.
         scored: true
 
       - id: 1.1.8
@@ -114,9 +112,8 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chown root:root $etcdconf
+          Not Applicable.
+          K3s embeds etcd within the k3s process. There is no etcd pod specification file.
         scored: true
 
       - id: 1.1.9
@@ -158,11 +155,10 @@ groups:
         audit: "check_for_k3s_etcd.sh 1.1.11"
         tests:
           test_items:
-            - flag: "700"
+            - flag: "permissions"
               compare:
-                op: eq
+                op: bitmask
                 value: "700"
-              set: true
         remediation: |
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.
@@ -178,10 +174,9 @@ groups:
           test_items:
             - flag: "etcd:etcd"
         remediation: |
-          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-          from the command 'ps -ef | grep etcd'.
-          Run the below command (based on the etcd data directory found above).
-          For example, chown etcd:etcd /var/lib/etcd
+          Not Applicable.
+          For K3s, etcd is embedded within the k3s process. There is no separate etcd process.
+          Therefore the etcd data directory ownership is managed by the k3s process and should be root:root.
         scored: true
 
       - id: 1.1.13
@@ -212,12 +207,12 @@ groups:
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root /etc/kubernetes/admin.conf
+          For example, chown root:root /var/lib/rancher/k3s/server/cred/admin.kubeconfig
         scored: true
 
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c permissions=%a $schedulerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -232,7 +227,7 @@ groups:
 
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c %U:%G /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c %U:%G $schedulerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "root:root"
@@ -244,7 +239,7 @@ groups:
 
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/controller.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/controller.kubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c permissions=%a $controllermanagerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -259,7 +254,7 @@ groups:
 
       - id: 1.1.18
         text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
-        audit: "stat -c %U:%G /var/lib/rancher/k3s/server/tls"
+        audit: "stat -c %U:%G $controllermanagerkubeconfig"
         tests:
           test_items:
             - flag: "root:root"
@@ -288,7 +283,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"
-        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' | xargs stat -c permissions=%a"
+        audit: "/bin/sh -c 'stat -c permissions=%a /var/lib/rancher/k3s/server/tls/*.crt'"
         use_multiple_values: true
         tests:
           test_items:
@@ -299,12 +294,12 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 600 {} +
+          chmod -R 600 /var/lib/rancher/k3s/server/tls/*.crt
         scored: false
 
       - id: 1.1.21
-        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.key' | xargs stat -c permissions=%a"
+        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Automated)"
+        audit: "/bin/sh -c 'stat -c permissions=%a /var/lib/rancher/k3s/server/tls/*.key'"
         use_multiple_values: true
         tests:
           test_items:
@@ -315,7 +310,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {} +
+          chmod -R 600 /var/lib/rancher/k3s/server/tls/*.key
         scored: false
 
   - id: 1.2

--- a/package/cfg/k3s-cis-1.24-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/master.yaml
@@ -155,7 +155,7 @@ groups:
         audit: |
           if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
             stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
-          else 
+          else
             echo "permissions=700"
           fi
         tests:
@@ -448,7 +448,7 @@ groups:
                 value: "Node"
         remediation: |
           By default, K3s sets the --authorization-mode to Node and RBAC.
-          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, 
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml,
           ensure that you are not overriding authorization-mode.
         scored: true
 
@@ -613,8 +613,7 @@ groups:
               set: false
         remediation: |
           By default, K3s sets the secure port to 6444.
-          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml 
-          and remove any lines like below.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
           kube-apiserver-arg:
           - "secure-port=<PORT>"
         scored: true
@@ -677,7 +676,7 @@ groups:
                 op: gte
                 value: 10
         remediation: |
-          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and 
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and
           set the audit-log-maxbackup parameter to 10 or to an appropriate value. For example,
           kube-apiserver-arg:
           - "audit-log-maxbackup=10"
@@ -694,7 +693,7 @@ groups:
                 op: gte
                 value: 100
         remediation: |
-          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and 
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and
           set the audit-log-maxsize parameter to an appropriate size in MB. For example,
           kube-apiserver-arg:
           - "audit-log-maxsize=100"
@@ -708,7 +707,7 @@ groups:
           test_items:
             - flag: "--request-timeout"
         remediation: |
-          Permissive, per CIS guidelines, 
+          Permissive, per CIS guidelines,
           "it is recommended to set this limit as appropriate and change the default limit of 60 seconds only if needed".
           Edit the K3s config file /etc/rancher/k3s/config.yaml
           and set the below parameter if needed. For example,
@@ -757,7 +756,7 @@ groups:
         audit: |
           if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
             journalctl -D /var/log/journal -u k3s | grep -m1 'Running kube-apiserver' | tail -n1
-          else 
+          else
             echo "--etcd-certfile AND --etcd-keyfile"
           fi
         tests:
@@ -883,9 +882,10 @@ groups:
           test_items:
             - flag: "--terminated-pod-gc-threshold"
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --terminated-pod-gc-threshold to an appropriate threshold,
-          for example, --terminated-pod-gc-threshold=10
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node
+          and set the --terminated-pod-gc-threshold to an appropriate threshold,
+          kube-controller-manager-arg:
+          - "terminated-pod-gc-threshold=10"
         scored: false
 
       - id: 1.3.2
@@ -898,9 +898,10 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the below parameter.
-          --profiling=false
+          By default, K3s sets the --profiling argument to false.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+          - "profiling=true"
         scored: true
 
       - id: 1.3.3
@@ -913,9 +914,10 @@ groups:
                 op: noteq
                 value: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node to set the below parameter.
-          --use-service-account-credentials=true
+          By default, K3s sets the --use-service-account-credentials argument to true.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+          - "use-service-account-credentials=false"
         scored: true
 
       - id: 1.3.4
@@ -925,10 +927,11 @@ groups:
           test_items:
             - flag: "--service-account-private-key-file"
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --service-account-private-key-file parameter
-          to the private key file for service accounts.
-          --service-account-private-key-file=<filename>
+          By default, K3s automatically provides the service account private key file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/service.current.key.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+          - "service-account-private-key-file=<path>"
         scored: true
 
       - id: 1.3.5
@@ -938,15 +941,16 @@ groups:
           test_items:
             - flag: "--root-ca-file"
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --root-ca-file parameter to the certificate bundle file`.
-          --root-ca-file=<path/to/file>
+          By default, K3s automatically provides the root CA file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/server-ca.crt.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+          - "root-ca-file=<path>"
         scored: true
 
       - id: 1.3.6
         text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'RotateKubeletServerCertificate'"
-        type: "skip"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -958,9 +962,11 @@ groups:
             - flag: "--feature-gates"
               set: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --feature-gates parameter to include RotateKubeletServerCertificate=true.
-          --feature-gates=RotateKubeletServerCertificate=true
+          By default, K3s does not set the RotateKubeletServerCertificate feature gate.
+          If you have enabled this feature gate, you should remove it.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-controller-manager-arg:
+          - "feature-gate=RotateKubeletServerCertificate"
         scored: true
 
       - id: 1.3.7
@@ -977,8 +983,10 @@ groups:
             - flag: "--bind-address"
               set: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and ensure the correct value for the --bind-address parameter
+          By default, K3s sets the --bind-address argument to 127.0.0.1
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+          - "bind-address=<IP>"
         scored: true
 
   - id: 1.4
@@ -995,9 +1003,10 @@ groups:
                 value: false
               set: true
         remediation: |
-          Edit the Scheduler pod specification file $schedulerconf file
-          on the control plane node and set the below parameter.
-          --profiling=false
+          By default, K3s sets the --profiling argument to false.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-scheduler-arg:
+          - "profiling=true"
         scored: true
 
       - id: 1.4.2
@@ -1014,6 +1023,8 @@ groups:
             - flag: "--bind-address"
               set: false
         remediation: |
-          Edit the Scheduler pod specification file $schedulerconf
-          on the control plane node and ensure the correct value for the --bind-address parameter
+          By default, K3s sets the --bind-address argument to 127.0.0.1
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-scheduler-arg:
+          - "bind-address=<IP>"
         scored: true

--- a/package/cfg/k3s-cis-1.24-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/node.yaml
@@ -216,7 +216,7 @@ groups:
 
       - id: 4.2.4
         text: "Verify that the --read-only-port argument is set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -242,7 +242,7 @@ groups:
 
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -265,7 +265,7 @@ groups:
 
       - id: 4.2.6
         text: "Ensure that the --protect-kernel-defaults argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -285,7 +285,7 @@ groups:
 
       - id: 4.2.7
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -313,7 +313,7 @@ groups:
         # This is one of those properties that can only be set as a command line argument.
         # To check if the property is set as expected, we need to parse the kubelet command
         # instead reading the Kubelet Configuration file.
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -327,7 +327,7 @@ groups:
 
       - id: 4.2.9
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
           test_items:
@@ -348,7 +348,7 @@ groups:
 
       - id: 4.2.10
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --tls-cert-file
@@ -367,7 +367,7 @@ groups:
 
       - id: 4.2.11
         text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
           test_items:
@@ -390,7 +390,7 @@ groups:
 
       - id: 4.2.12
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
           bin_op: or
@@ -414,7 +414,7 @@ groups:
 
       - id: 4.2.13
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.7-hardened/config.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/config.yaml
@@ -23,10 +23,14 @@ master:
   scheduler:
     bins:
       - containerd
+    kubeconfig:
+      - /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig
 
   controllermanager:
     bins:
       - containerd
+    kubeconfig:
+      - /var/lib/rancher/k3s/server/cred/controller.kubeconfig
 
   etcd:
     bins:

--- a/package/cfg/k3s-cis-1.7-hardened/controlplane.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/controlplane.yaml
@@ -35,7 +35,7 @@ groups:
     checks:
       - id: 3.2.1
         text: "Ensure that a minimal audit policy is created (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-policy-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-policy-file'"
         tests:
           test_items:
             - flag: "--audit-policy-file"

--- a/package/cfg/k3s-cis-1.7-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/master.yaml
@@ -325,7 +325,7 @@ groups:
     checks:
       - id: 1.2.1
         text: "Ensure that the --anonymous-auth argument is set to false (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth'"
         tests:
           test_items:
             - flag: "--anonymous-auth"
@@ -341,7 +341,7 @@ groups:
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--token-auth-file"
@@ -355,7 +355,7 @@ groups:
 
       - id: 1.2.3
         text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -375,7 +375,7 @@ groups:
 
       - id: 1.2.4
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
         tests:
           bin_op: and
           test_items:
@@ -393,7 +393,7 @@ groups:
 
       - id: 1.2.5
         text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
         tests:
           test_items:
             - flag: "--kubelet-certificate-authority"
@@ -406,7 +406,7 @@ groups:
 
       - id: 1.2.6
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -422,7 +422,7 @@ groups:
 
       - id: 1.2.7
         text: "Ensure that the --authorization-mode argument includes Node (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -437,7 +437,7 @@ groups:
 
       - id: 1.2.8
         text: "Ensure that the --authorization-mode argument includes RBAC (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -452,7 +452,7 @@ groups:
 
       - id: 1.2.9
         text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -469,7 +469,7 @@ groups:
 
       - id: 1.2.10
         text: "Ensure that the admission control plugin AlwaysAdmit is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           bin_op: or
           test_items:
@@ -527,7 +527,7 @@ groups:
 
       - id: 1.2.13
         text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -547,7 +547,7 @@ groups:
 
       - id: 1.2.14
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -566,7 +566,7 @@ groups:
 
       - id: 1.2.15
         text: "Ensure that the admission control plugin NodeRestriction is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -583,7 +583,7 @@ groups:
 
       - id: 1.2.16
         text: "Ensure that the --secure-port argument is not set to 0 - NoteThis recommendation is obsolete and will be deleted per the consensus process (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'secure-port'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'secure-port'"
         tests:
           bin_op: or
           test_items:
@@ -602,7 +602,7 @@ groups:
 
       - id: 1.2.17
         text: "Ensure that the --profiling argument is set to false (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'profiling'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'profiling'"
         tests:
           test_items:
             - flag: "--profiling"
@@ -618,7 +618,7 @@ groups:
 
       - id: 1.2.18
         text: "Ensure that the --audit-log-path argument is set (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--audit-log-path"
@@ -631,7 +631,7 @@ groups:
 
       - id: 1.2.19
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--audit-log-maxage"
@@ -647,7 +647,7 @@ groups:
 
       - id: 1.2.20
         text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--audit-log-maxbackup"
@@ -663,7 +663,7 @@ groups:
 
       - id: 1.2.21
         text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--audit-log-maxsize"
@@ -679,7 +679,7 @@ groups:
 
       - id: 1.2.22
         text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--request-timeout"
@@ -694,7 +694,7 @@ groups:
 
       - id: 1.2.23
         text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -715,7 +715,7 @@ groups:
 
       - id: 1.2.24
         text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--service-account-key-file"
@@ -772,7 +772,7 @@ groups:
 
       - id: 1.2.27
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'client-ca-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'client-ca-file'"
         tests:
           test_items:
             - flag: "--client-ca-file"
@@ -786,7 +786,7 @@ groups:
 
       - id: 1.2.28
         text: "Ensure that the --etcd-cafile argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-cafile'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-cafile'"
         tests:
           test_items:
             - flag: "--etcd-cafile"
@@ -800,7 +800,7 @@ groups:
 
       - id: 1.2.29
         text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'encryption-provider-config'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'encryption-provider-config'"
         tests:
           test_items:
             - flag: "--encryption-provider-config"
@@ -853,7 +853,7 @@ groups:
     checks:
       - id: 1.3.1
         text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'terminated-pod-gc-threshold'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'terminated-pod-gc-threshold'"
         tests:
           test_items:
             - flag: "--terminated-pod-gc-threshold"
@@ -866,7 +866,7 @@ groups:
 
       - id: 1.3.2
         text: "Ensure that the --profiling argument is set to false (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'profiling'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'profiling'"
         tests:
           test_items:
             - flag: "--profiling"
@@ -882,7 +882,7 @@ groups:
 
       - id: 1.3.3
         text: "Ensure that the --use-service-account-credentials argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'use-service-account-credentials'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'use-service-account-credentials'"
         tests:
           test_items:
             - flag: "--use-service-account-credentials"
@@ -898,7 +898,7 @@ groups:
 
       - id: 1.3.4
         text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'service-account-private-key-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'service-account-private-key-file'"
         tests:
           test_items:
             - flag: "--service-account-private-key-file"
@@ -912,7 +912,7 @@ groups:
 
       - id: 1.3.5
         text: "Ensure that the --root-ca-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'root-ca-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'root-ca-file'"
         tests:
           test_items:
             - flag: "--root-ca-file"
@@ -926,7 +926,7 @@ groups:
 
       - id: 1.3.6
         text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -987,7 +987,7 @@ groups:
 
       - id: 1.4.2
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'bind-address'"
+        audit: "journalctl -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'bind-address'"
         tests:
           bin_op: or
           test_items:

--- a/package/cfg/k3s-cis-1.7-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/master.yaml
@@ -20,7 +20,7 @@ groups:
                 value: "600"
         remediation: |
           Not Applicable.
-          K3s embeds the api server within the k3s process. There is no API server pod specification file.
+          By default, K3s embeds the api server within the k3s process. There is no API server pod specification file.
         scored: true
 
       - id: 1.1.2
@@ -32,7 +32,7 @@ groups:
             - flag: "root:root"
         remediation: |
           Not Applicable.
-          K3s embeds the api server within the k3s process. There is no API server pod specification file.
+          By default, K3s embeds the api server within the k3s process. There is no API server pod specification file.
         scored: true
 
       - id: 1.1.3
@@ -47,7 +47,7 @@ groups:
                 value: "600"
         remediation: |
           Not Applicable.
-          K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
+          By default, K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
         scored: true
 
       - id: 1.1.4
@@ -59,7 +59,7 @@ groups:
             - flag: "root:root"
         remediation: |
           Not Applicable.
-          K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
+          By default, K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
         scored: true
 
       - id: 1.1.5
@@ -74,7 +74,7 @@ groups:
                 value: "600"
         remediation: |
           Not Applicable.
-          K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
+          By default, K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
         scored: true
 
       - id: 1.1.6
@@ -86,7 +86,7 @@ groups:
             - flag: "root:root"
         remediation: |
           Not Applicable.
-          K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
+          By default, K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
         scored: true
 
       - id: 1.1.7
@@ -102,7 +102,7 @@ groups:
                 value: "600"
         remediation: |
           Not Applicable.
-          K3s embeds etcd within the k3s process. There is no etcd pod specification file.
+          By default, K3s embeds etcd within the k3s process. There is no etcd pod specification file.
         scored: true
 
       - id: 1.1.8
@@ -115,7 +115,7 @@ groups:
             - flag: "root:root"
         remediation: |
           Not Applicable.
-          K3s embeds etcd within the k3s process. There is no etcd pod specification file.
+          By default, K3s embeds etcd within the k3s process. There is no etcd pod specification file.
         scored: true
 
       - id: 1.1.9
@@ -322,7 +322,7 @@ groups:
     text: "API Server"
     checks:
       - id: 1.2.1
-        text: "Ensure that the --anonymous-auth argument is set to false (Manual)"
+        text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
         audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth'"
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.7-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/master.yaml
@@ -19,10 +19,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the
-          control plane node.
-          For example, chmod 600 $apiserverconf
           Not Applicable.
+          K3s embeds the api server within the k3s process. There is no API server pod specification file.
         scored: true
 
       - id: 1.1.2
@@ -33,9 +31,8 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root $apiserverconf
           Not Applicable.
+          K3s embeds the api server within the k3s process. There is no API server pod specification file.
         scored: true
 
       - id: 1.1.3
@@ -49,9 +46,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 $controllermanagerconf
           Not Applicable.
+          K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
         scored: true
 
       - id: 1.1.4
@@ -62,9 +58,8 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root $controllermanagerconf
           Not Applicable.
+          K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
         scored: true
 
       - id: 1.1.5
@@ -78,9 +73,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 $schedulerconf
           Not Applicable.
+          K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
         scored: true
 
       - id: 1.1.6
@@ -91,9 +85,8 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root $schedulerconf
           Not Applicable.
+          K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
         scored: true
 
       - id: 1.1.7
@@ -108,10 +101,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chmod 600 $etcdconf
           Not Applicable.
+          K3s embeds etcd within the k3s process. There is no etcd pod specification file.
         scored: true
 
       - id: 1.1.8
@@ -123,10 +114,8 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chown root:root $etcdconf
           Not Applicable.
+          K3s embeds etcd within the k3s process. There is no etcd pod specification file.
         scored: true
 
       - id: 1.1.9
@@ -143,9 +132,9 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
+          Not Applicable.
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chmod 600 <path/to/cni/files>
-          Not Applicable.
         scored: false
 
       - id: 1.1.10
@@ -159,10 +148,10 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
+          Not Applicable.
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chown root:root <path/to/cni/files>
-          Not Applicable.
         scored: false
 
       - id: 1.1.11
@@ -170,16 +159,15 @@ groups:
         audit: "check_for_k3s_etcd.sh 1.1.11"
         tests:
           test_items:
-            - flag: "700"
+            - flag: "permissions"
               compare:
-                op: eq
+                op: bitmask
                 value: "700"
-              set: true
         remediation: |
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.
           Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
+          chmod 700 $etcddatadir
         scored: true
 
       - id: 1.1.12
@@ -190,11 +178,9 @@ groups:
           test_items:
             - flag: "etcd:etcd"
         remediation: |
-          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-          from the command 'ps -ef | grep etcd'.
-          Run the below command (based on the etcd data directory found above).
-          For example, chown etcd:etcd /var/lib/etcd
           Not Applicable.
+          For K3s, etcd is embedded within the k3s process. There is no separate etcd process.
+          Therefore the etcd data directory ownership is managed by the k3s process and should be root:root.
         scored: true
 
       - id: 1.1.13
@@ -224,12 +210,12 @@ groups:
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root /etc/kubernetes/admin.conf
+          For example, chown root:root /var/lib/rancher/k3s/server/cred/admin.kubeconfig
         scored: true
 
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c permissions=%a $schedulerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -244,7 +230,7 @@ groups:
 
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c %U:%G /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c %U:%G $schedulerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "root:root"
@@ -256,7 +242,7 @@ groups:
 
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/controller.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/controller.kubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c permissions=%a $controllermanagerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -271,7 +257,7 @@ groups:
 
       - id: 1.1.18
         text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
-        audit: "stat -c %U:%G /var/lib/rancher/k3s/server/cred/controller.kubeconfig"
+        audit: "stat -c %U:%G $controllermanagerkubeconfig"
         tests:
           test_items:
             - flag: "root:root"
@@ -300,7 +286,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"
-        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' | xargs stat -c permissions=%a"
+        audit: "/bin/sh -c 'stat -c permissions=%a /var/lib/rancher/k3s/server/tls/*.crt'"
         use_multiple_values: true
         tests:
           test_items:
@@ -311,12 +297,12 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 600 {} +
+          chmod -R 600 /var/lib/rancher/k3s/server/tls/*.crt
         scored: false
 
       - id: 1.1.21
-        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.key' | xargs stat -c permissions=%a"
+        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Automated)"
+        audit: "/bin/sh -c 'stat -c permissions=%a /var/lib/rancher/k3s/server/tls/*.key'"
         use_multiple_values: true
         tests:
           test_items:
@@ -327,7 +313,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {} +
+          chmod -R 600 /var/lib/rancher/k3s/server/tls/*.key
         scored: false
 
   - id: 1.2

--- a/package/cfg/k3s-cis-1.7-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/master.yaml
@@ -156,7 +156,12 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: "check_for_k3s_etcd.sh 1.1.11"
+        audit: |
+          if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
+            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
+          else 
+            echo "permissions=700"
+          fi
         tests:
           test_items:
             - flag: "permissions"
@@ -725,7 +730,12 @@ groups:
 
       - id: 1.2.25
         text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
-        audit: "check_for_k3s_etcd.sh 1.2.29"
+        audit: |
+          if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
+            journalctl -D /var/log/journal -u k3s | grep -m1 'Running kube-apiserver' | tail -n1
+          else 
+            echo "--etcd-certfile AND --etcd-keyfile"
+          fi
         tests:
           bin_op: and
           test_items:

--- a/package/cfg/k3s-cis-1.7-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/master.yaml
@@ -185,7 +185,7 @@ groups:
 
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/admin.kubeconfig'"
+        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/admin.kubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"

--- a/package/cfg/k3s-cis-1.7-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/master.yaml
@@ -159,7 +159,7 @@ groups:
         audit: |
           if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
             stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
-          else 
+          else
             echo "permissions=700"
           fi
         tests:
@@ -431,7 +431,7 @@ groups:
                 value: "Node"
         remediation: |
           By default, K3s sets the --authorization-mode to Node and RBAC.
-          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, 
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml,
           ensure that you are not overriding authorization-mode.
         scored: true
 
@@ -595,8 +595,7 @@ groups:
               set: false
         remediation: |
           By default, K3s sets the secure port to 6444.
-          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml 
-          and remove any lines like below.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
           kube-apiserver-arg:
           - "secure-port=<PORT>"
         scored: true
@@ -656,7 +655,7 @@ groups:
                 op: gte
                 value: 10
         remediation: |
-          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and 
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and
           set the audit-log-maxbackup parameter to 10 or to an appropriate value. For example,
           kube-apiserver-arg:
           - "audit-log-maxbackup=10"
@@ -672,7 +671,7 @@ groups:
                 op: gte
                 value: 100
         remediation: |
-          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and 
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and
           set the audit-log-maxsize parameter to an appropriate size in MB. For example,
           kube-apiserver-arg:
           - "audit-log-maxsize=100"
@@ -685,7 +684,7 @@ groups:
           test_items:
             - flag: "--request-timeout"
         remediation: |
-          Permissive, per CIS guidelines, 
+          Permissive, per CIS guidelines,
           "it is recommended to set this limit as appropriate and change the default limit of 60 seconds only if needed".
           Edit the K3s config file /etc/rancher/k3s/config.yaml
           and set the below parameter if needed. For example,
@@ -733,7 +732,7 @@ groups:
         audit: |
           if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
             journalctl -D /var/log/journal -u k3s | grep -m1 'Running kube-apiserver' | tail -n1
-          else 
+          else
             echo "--etcd-certfile AND --etcd-keyfile"
           fi
         tests:
@@ -859,9 +858,10 @@ groups:
           test_items:
             - flag: "--terminated-pod-gc-threshold"
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --terminated-pod-gc-threshold to an appropriate threshold,
-          for example, --terminated-pod-gc-threshold=10
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node
+          and set the --terminated-pod-gc-threshold to an appropriate threshold,
+          kube-controller-manager-arg:
+          - "terminated-pod-gc-threshold=10"
         scored: false
 
       - id: 1.3.2
@@ -874,9 +874,10 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the below parameter.
-          --profiling=false
+          By default, K3s sets the --profiling argument to false.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+          - "profiling=true"
         scored: true
 
       - id: 1.3.3
@@ -889,9 +890,10 @@ groups:
                 op: noteq
                 value: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node to set the below parameter.
-          --use-service-account-credentials=true
+          By default, K3s sets the --use-service-account-credentials argument to true.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+          - "use-service-account-credentials=false"
         scored: true
 
       - id: 1.3.4
@@ -901,10 +903,11 @@ groups:
           test_items:
             - flag: "--service-account-private-key-file"
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --service-account-private-key-file parameter
-          to the private key file for service accounts.
-          --service-account-private-key-file=<filename>
+          By default, K3s automatically provides the service account private key file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/service.current.key.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+          - "service-account-private-key-file=<path>"
         scored: true
 
       - id: 1.3.5
@@ -914,15 +917,16 @@ groups:
           test_items:
             - flag: "--root-ca-file"
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --root-ca-file parameter to the certificate bundle file`.
-          --root-ca-file=<path/to/file>
+          By default, K3s automatically provides the root CA file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/server-ca.crt.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+          - "root-ca-file=<path>"
         scored: true
 
       - id: 1.3.6
         text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
-        type: "skip"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'RotateKubeletServerCertificate'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -934,10 +938,11 @@ groups:
             - flag: "--feature-gates"
               set: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --feature-gates parameter to include RotateKubeletServerCertificate=true.
-          --feature-gates=RotateKubeletServerCertificate=true
-          Not Applicable.
+          By default, K3s does not set the RotateKubeletServerCertificate feature gate.
+          If you have enabled this feature gate, you should remove it.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-controller-manager-arg:
+          - "feature-gate=RotateKubeletServerCertificate"
         scored: true
 
       - id: 1.3.7
@@ -954,8 +959,10 @@ groups:
             - flag: "--bind-address"
               set: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and ensure the correct value for the --bind-address parameter
+          By default, K3s sets the --bind-address argument to 127.0.0.1
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+          - "bind-address=<IP>"
         scored: true
 
   - id: 1.4
@@ -972,9 +979,10 @@ groups:
                 value: false
               set: true
         remediation: |
-          Edit the Scheduler pod specification file $schedulerconf file
-          on the control plane node and set the below parameter.
-          --profiling=false
+          By default, K3s sets the --profiling argument to false.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-scheduler-arg:
+          - "profiling=true"
         scored: true
 
       - id: 1.4.2
@@ -991,6 +999,8 @@ groups:
             - flag: "--bind-address"
               set: false
         remediation: |
-          Edit the Scheduler pod specification file $schedulerconf
-          on the control plane node and ensure the correct value for the --bind-address parameter
+          By default, K3s sets the --bind-address argument to 127.0.0.1
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-scheduler-arg:
+          - "bind-address=<IP>"
         scored: true

--- a/package/cfg/k3s-cis-1.7-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/master.yaml
@@ -186,7 +186,6 @@ groups:
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 600 or more restrictive (Automated)"
         audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/admin.kubeconfig'"
-        type: "skip"
         tests:
           test_items:
             - flag: "permissions"
@@ -329,27 +328,29 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the below parameter.
-          --anonymous-auth=false
+          By default, K3s sets the --anonymous-auth argument to false. If it is set to true,
+          edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
+          kube-apiserver-arg:
+            - "anonymous-auth=true"
         scored: false
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--token-auth-file"
               set: false
         remediation: |
-          Follow the documentation and configure alternate mechanisms for authentication. Then,
-          edit the API server pod specification file $apiserverconf
-          on the control plane node and remove the --token-auth-file=<filename> parameter.
+          Follow the documentation and configure alternate mechanisms for authentication.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
+          kube-apiserver-arg:
+          - "token-auth-file=<path>".
         scored: true
 
       - id: 1.2.3
         text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -361,9 +362,10 @@ groups:
             - flag: "--enable-admission-plugins"
               set: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and remove the `DenyServiceExternalIPs`
-          from enabled admission plugins.
+          By default, K3s does not set DenyServiceExternalIPs.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-apiserver-arg:
+          - "enable-admission-plugins=DenyServiceExternalIPs"
         scored: true
 
       - id: 1.2.4
@@ -375,28 +377,26 @@ groups:
             - flag: "--kubelet-client-certificate"
             - flag: "--kubelet-client-key"
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection between the
-          apiserver and kubelets. Then, edit API server pod specification file
-          $apiserverconf on the control plane node and set the
-          kubelet client certificate and key parameters as below.
-          --kubelet-client-certificate=<path/to/client-certificate-file>
-          --kubelet-client-key=<path/to/client-key-file>
+          By default, K3s automatically provides the kubelet client certificate and key.
+          They are generated and located at /var/lib/rancher/k3s/server/tls/client-kube-apiserver.crt and /var/lib/rancher/k3s/server/tls/client-kube-apiserver.key
+          If for some reason you need to provide your own certificate and key, you can set the
+          the below parameters in the K3s config file /etc/rancher/k3s/config.yaml.
+          kube-apiserver-arg:
+          - "kubelet-client-certificate=<path/to/client-cert-file>"
+          - "kubelet-client-key=<path/to/client-key-file>"
         scored: true
 
       - id: 1.2.5
         text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
-        type: "skip"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
         tests:
           test_items:
             - flag: "--kubelet-certificate-authority"
         remediation: |
-          Follow the Kubernetes documentation and setup the TLS connection between
-          the apiserver and kubelets. Then, edit the API server pod specification file
-          $apiserverconf on the control plane node and set the
-          --kubelet-certificate-authority parameter to the path to the cert file for the certificate authority.
-          --kubelet-certificate-authority=<ca-string>
-          Permissive - When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
+          By default, K3s automatically provides the kubelet CA cert file, at /var/lib/rancher/k3s/server/tls/server-ca.crt.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "kubelet-certificate-authority=<path/to/ca-cert-file>"
         scored: true
 
       - id: 1.2.6
@@ -409,10 +409,10 @@ groups:
                 op: nothave
                 value: "AlwaysAllow"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --authorization-mode parameter to values other than AlwaysAllow.
-          One such example could be as below.
-          --authorization-mode=RBAC
+          By default, K3s does not set the --authorization-mode to AlwaysAllow.
+          If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-apiserver-arg:
+          - "authorization-mode=AlwaysAllow"
         scored: true
 
       - id: 1.2.7
@@ -425,9 +425,9 @@ groups:
                 op: has
                 value: "Node"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --authorization-mode parameter to a value that includes Node.
-          --authorization-mode=Node,RBAC
+          By default, K3s sets the --authorization-mode to Node and RBAC.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, 
+          ensure that you are not overriding authorization-mode.
         scored: true
 
       - id: 1.2.8
@@ -440,9 +440,9 @@ groups:
                 op: has
                 value: "RBAC"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --authorization-mode parameter to a value that includes RBAC,
-          for example `--authorization-mode=Node,RBAC`.
+          By default, K3s sets the --authorization-mode to Node and RBAC.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml,
+          ensure that you are not overriding authorization-mode.
         scored: true
 
       - id: 1.2.9
@@ -456,10 +456,10 @@ groups:
                 value: "EventRateLimit"
         remediation: |
           Follow the Kubernetes documentation and set the desired limits in a configuration file.
-          Then, edit the API server pod specification file $apiserverconf
-          and set the below parameters.
-          --enable-admission-plugins=...,EventRateLimit,...
-          --admission-control-config-file=<path/to/configuration/file>
+          Then, edit the K3s config file /etc/rancher/k3s/config.yaml and set the below parameters.
+          kube-apiserver-arg:
+          - "enable-admission-plugins=...,EventRateLimit,..."
+          - "admission-control-config-file=<path/to/configuration/file>"
         scored: false
 
       - id: 1.2.10
@@ -475,9 +475,10 @@ groups:
             - flag: "--enable-admission-plugins"
               set: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and either remove the --enable-admission-plugins parameter, or set it to a
-          value that does not include AlwaysAdmit.
+          By default, K3s does not set the --enable-admission-plugins to AlwaysAdmit.
+          If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-apiserver-arg:
+          - "enable-admission-plugins=AlwaysAdmit"
         scored: true
 
       - id: 1.2.11
@@ -490,10 +491,13 @@ groups:
                 op: has
                 value: "AlwaysPullImages"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --enable-admission-plugins parameter to include
-          AlwaysPullImages.
-          --enable-admission-plugins=...,AlwaysPullImages,...
+          Permissive, per CIS guidelines,
+          "This setting could impact offline or isolated clusters, which have images pre-loaded and
+          do not have access to a registry to pull in-use images. This setting is not appropriate for
+          clusters which use this configuration."
+          Edit the K3s config file /etc/rancher/k3s/config.yaml and set the below parameter.
+          kube-apiserver-arg:
+          - "enable-admission-plugins=...,AlwaysPullImages,..."
         scored: false
 
       - id: 1.2.12
@@ -512,16 +516,13 @@ groups:
                 op: has
                 value: "PodSecurityPolicy"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --enable-admission-plugins parameter to include
-          SecurityContextDeny, unless PodSecurityPolicy is already in place.
-          --enable-admission-plugins=...,SecurityContextDeny,...
-          Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
+          Not Applicable.
+          Enabling Pod Security Policy is no longer supported on K3s v1.25+ and will cause applications to unexpectedly fail.
         scored: false
 
       - id: 1.2.13
         text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -532,15 +533,16 @@ groups:
             - flag: "--disable-admission-plugins"
               set: false
         remediation: |
+          By default, K3s does not set the --disable-admission-plugins to anything.
           Follow the documentation and create ServiceAccount objects as per your environment.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and ensure that the --disable-admission-plugins parameter is set to a
-          value that does not include ServiceAccount.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "disable-admission-plugins=ServiceAccount"
         scored: true
 
       - id: 1.2.14
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -551,9 +553,10 @@ groups:
             - flag: "--disable-admission-plugins"
               set: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --disable-admission-plugins parameter to
-          ensure it does not include NamespaceLifecycle.
+          By default, K3s does not set the --disable-admission-plugins to anything.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "disable-admission-plugins=...,NamespaceLifecycle,..."
         scored: true
 
       - id: 1.2.15
@@ -566,11 +569,11 @@ groups:
                 op: has
                 value: "NodeRestriction"
         remediation: |
-          Follow the Kubernetes documentation and configure NodeRestriction plug-in on kubelets.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --enable-admission-plugins parameter to a
-          value that includes NodeRestriction.
-          --enable-admission-plugins=...,NodeRestriction,...
+          By default, K3s sets the --enable-admission-plugins to NodeRestriction.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, check that you are not overriding the admission plugins.
+          If you are, include NodeRestriction in the list.
+          kube-apiserver-arg:
+          - "enable-admission-plugins=...,NodeRestriction,..."
         scored: true
 
       - id: 1.2.16
@@ -586,9 +589,11 @@ groups:
             - flag: "--secure-port"
               set: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and either remove the --secure-port parameter or
-          set it to a different (non-zero) desired port.
+          By default, K3s sets the secure port to 6444.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml 
+          and remove any lines like below.
+          kube-apiserver-arg:
+          - "secure-port=<PORT>"
         scored: true
 
       - id: 1.2.17
@@ -601,30 +606,28 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the below parameter.
-          --profiling=false
+          By default, K3s sets the --profiling argument to false.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "profiling=true"
         scored: true
 
       - id: 1.2.18
-        text: "Ensure that the --audit-log-path argument is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
-        type: "skip"
+        text: "Ensure that the --audit-log-path argument is set (Manual)"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--audit-log-path"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-path parameter to a suitable path and
+          Edit the K3s config file /etc/rancher/k3s/config.yaml and set the audit-log-path parameter to a suitable path and
           file where you would like audit logs to be written, for example,
-          --audit-log-path=/var/log/apiserver/audit.log
-          Permissive.
+          kube-apiserver-arg:
+          - "audit-log-path=/var/lib/rancher/k3s/server/logs/audit.log"
         scored: true
 
       - id: 1.2.19
-        text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
-        type: "skip"
+        text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Manual)"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--audit-log-maxage"
@@ -632,17 +635,15 @@ groups:
                 op: gte
                 value: 30
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-maxage parameter to 30
-          or as an appropriate number of days, for example,
-          --audit-log-maxage=30
-          Permissive.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and
+          set the audit-log-maxage parameter to 30 or as an appropriate number of days, for example,
+          kube-apiserver-arg:
+          - "audit-log-maxage=30"
         scored: true
 
       - id: 1.2.20
-        text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
-        type: "skip"
+        text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Manual)"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--audit-log-maxbackup"
@@ -650,17 +651,15 @@ groups:
                 op: gte
                 value: 10
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-maxbackup parameter to 10 or to an appropriate
-          value. For example,
-          --audit-log-maxbackup=10
-          Permissive.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and 
+          set the audit-log-maxbackup parameter to 10 or to an appropriate value. For example,
+          kube-apiserver-arg:
+          - "audit-log-maxbackup=10"
         scored: true
 
       - id: 1.2.21
-        text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
-        type: "skip"
+        text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Manual)"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--audit-log-maxsize"
@@ -668,29 +667,30 @@ groups:
                 op: gte
                 value: 100
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-maxsize parameter to an appropriate size in MB.
-          For example, to set it as 100 MB, --audit-log-maxsize=100
-          Permissive.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and 
+          set the audit-log-maxsize parameter to an appropriate size in MB. For example,
+          kube-apiserver-arg:
+          - "audit-log-maxsize=100"
         scored: true
 
       - id: 1.2.22
         text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
-        type: "skip"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--request-timeout"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          and set the below parameter as appropriate and if needed.
-          For example, --request-timeout=300s
-          Permissive.
+          Permissive, per CIS guidelines, 
+          "it is recommended to set this limit as appropriate and change the default limit of 60 seconds only if needed".
+          Edit the K3s config file /etc/rancher/k3s/config.yaml
+          and set the below parameter if needed. For example,
+          kube-apiserver-arg:
+          - "request-timeout=300s"
         scored: false
 
       - id: 1.2.23
         text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -701,25 +701,26 @@ groups:
                 op: eq
                 value: true
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the below parameter.
-          --service-account-lookup=true
-          Alternatively, you can delete the --service-account-lookup parameter from this file so
+          By default, K3s does not set the --service-account-lookup argument.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml and set the service-account-lookup. For example,
+          kube-apiserver-arg:
+          - "service-account-lookup=true"
+          Alternatively, you can delete the service-account-lookup parameter from this file so
           that the default takes effect.
         scored: true
 
       - id: 1.2.24
         text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
-        type: "skip"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--service-account-key-file"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --service-account-key-file parameter
-          to the public key file for service accounts. For example,
-          --service-account-key-file=<filename>
+          K3s automatically generates and sets the service account key file.
+          It is located at /var/lib/rancher/k3s/server/tls/service.key.
+          If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "service-account-key-file=<path>"
         scored: true
 
       - id: 1.2.25
@@ -733,11 +734,12 @@ groups:
             - flag: "--etcd-keyfile"
               set: true
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the etcd certificate and key file parameters.
-          --etcd-certfile=<path/to/client-certificate-file>
-          --etcd-keyfile=<path/to/client-key-file>
+          K3s automatically generates and sets the etcd certificate and key files.
+          They are located at /var/lib/rancher/k3s/server/tls/etcd/client.crt and /var/lib/rancher/k3s/server/tls/etcd/client.key.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "etcd-certfile=<path>"
+          - "etcd-keyfile=<path>"
         scored: true
 
       - id: 1.2.26
@@ -751,11 +753,12 @@ groups:
             - flag: "--tls-private-key-file"
               set: true
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the TLS certificate and private key file parameters.
-          --tls-cert-file=<path/to/tls-certificate-file>
-          --tls-private-key-file=<path/to/tls-key-file>
+          By default, K3s automatically generates and provides the TLS certificate and private key for the apiserver.
+          They are generated and located at /var/lib/rancher/k3s/server/tls/serving-kube-apiserver.crt and /var/lib/rancher/k3s/server/tls/serving-kube-apiserver.key
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "tls-cert-file=<path>"
+          - "tls-private-key-file=<path>"
         scored: true
 
       - id: 1.2.27
@@ -765,10 +768,11 @@ groups:
           test_items:
             - flag: "--client-ca-file"
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the client certificate authority file.
-          --client-ca-file=<path/to/client-ca-file>
+          By default, K3s automatically provides the client certificate authority file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/client-ca.crt.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "client-ca-file=<path>"
         scored: true
 
       - id: 1.2.28
@@ -778,33 +782,32 @@ groups:
           test_items:
             - flag: "--etcd-cafile"
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the etcd certificate authority file parameter.
-          --etcd-cafile=<path/to/ca-file>
+          By default, K3s automatically provides the etcd certificate authority file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/client-ca.crt.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "etcd-cafile=<path>"
         scored: true
 
       - id: 1.2.29
         text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
-        type: "skip"
         audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'encryption-provider-config'"
         tests:
           test_items:
             - flag: "--encryption-provider-config"
         remediation: |
-          Follow the Kubernetes documentation and configure a EncryptionConfig file.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --encryption-provider-config parameter to the path of that file.
-          For example, --encryption-provider-config=</path/to/EncryptionConfig/File>
-          Permissive - Enabling encryption changes how data can be recovered as data is encrypted.
+          K3s can be configured to use encryption providers to encrypt secrets at rest.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and set the below parameter.
+          secrets-encryption: true
+          Secrets encryption can then be managed with the k3s secrets-encrypt command line tool.
+          If needed, you can find the generated encryption config at /var/lib/rancher/k3s/server/cred/encryption-config.json.
         scored: false
 
       - id: 1.2.30
         text: "Ensure that encryption providers are appropriately configured (Manual)"
-        type: "skip"
         audit: |
-          ENCRYPTION_PROVIDER_CONFIG=$(ps -ef | grep $apiserverbin | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
-          if test -e $ENCRYPTION_PROVIDER_CONFIG; then grep -A1 'providers:' $ENCRYPTION_PROVIDER_CONFIG | tail -n1 | grep -o "[A-Za-z]*" | sed 's/^/provider=/'; fi
+          ENCRYPTION_PROVIDER_CONFIG=$(journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
+          if test -e $ENCRYPTION_PROVIDER_CONFIG; then grep -o 'providers\"\:\[.*\]' $ENCRYPTION_PROVIDER_CONFIG | grep -o "[A-Za-z]*" | head -2 | tail -1  | sed 's/^/provider=/'; fi
         tests:
           test_items:
             - flag: "provider"
@@ -812,12 +815,14 @@ groups:
                 op: valid_elements
                 value: "aescbc,kms,secretbox"
         remediation: |
-          Follow the Kubernetes documentation and configure a EncryptionConfig file.
-          In this file, choose aescbc, kms or secretbox as the encryption provider.
-          Permissive - Enabling encryption changes how data can be recovered as data is encrypted.
+          K3s can be configured to use encryption providers to encrypt secrets at rest. K3s will utilize the aescbc provider.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and set the below parameter.
+          secrets-encryption: true
+          Secrets encryption can then be managed with the k3s secrets-encrypt command line tool.
+          If needed, you can find the generated encryption config at /var/lib/rancher/k3s/server/cred/encryption-config.json
         scored: false
 
-      - id: 1.2.32
+      - id: 1.2.31
         text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Automated)"
         audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'tls-cipher-suites'"
         tests:

--- a/package/cfg/k3s-cis-1.7-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/master.yaml
@@ -120,10 +120,7 @@ groups:
 
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Automated)"
-        type: "skip"
-        audit: |
-          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
-          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
+        audit: find /var/lib/cni/networks -type f ! -name lock 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
         use_multiple_values: true
         tests:
           test_items:
@@ -132,9 +129,10 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Not Applicable.
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 <path/to/cni/files>
+          By default, K3s sets the CNI file permissions to 600.
+          Note that for many CNIs, a lock file is created with permissions 750. This is expected and can be ignored.
+          If you modify your CNI configuration, ensure that the permissions are set to 600.
+          For example, chmod 600 /var/lib/cni/networks/<filename>
         scored: false
 
       - id: 1.1.10

--- a/package/cfg/k3s-cis-1.7-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/node.yaml
@@ -213,7 +213,7 @@ groups:
 
       - id: 4.2.4
         text: "Verify that the --read-only-port argument is set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           bin_op: or
@@ -240,7 +240,7 @@ groups:
 
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -263,7 +263,7 @@ groups:
 
       - id: 4.2.6
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --make-iptables-util-chains
@@ -286,7 +286,7 @@ groups:
 
       - id: 4.2.7
         text: "Ensure that the --hostname-override argument is not set (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -300,7 +300,7 @@ groups:
 
       - id: 4.2.8
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -325,7 +325,7 @@ groups:
 
       - id: 4.2.9
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --tls-cert-file
@@ -344,7 +344,7 @@ groups:
 
       - id: 4.2.10
         text: "Ensure that the --rotate-certificates argument is not set to false (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -367,7 +367,7 @@ groups:
 
       - id: 4.2.11
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
           bin_op: or
@@ -391,7 +391,7 @@ groups:
 
       - id: 4.2.12
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -412,7 +412,7 @@ groups:
 
       - id: 4.2.13
         text: "Ensure that a limit is set on pod PIDs (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.7-permissive/controlplane.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/controlplane.yaml
@@ -35,7 +35,7 @@ groups:
     checks:
       - id: 3.2.1
         text: "Ensure that a minimal audit policy is created (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-policy-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-policy-file'"
         tests:
           test_items:
             - flag: "--audit-policy-file"

--- a/package/cfg/k3s-cis-1.7-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/master.yaml
@@ -326,7 +326,7 @@ groups:
     checks:
       - id: 1.2.1
         text: "Ensure that the --anonymous-auth argument is set to false (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth'"
         tests:
           test_items:
             - flag: "--anonymous-auth"
@@ -342,7 +342,7 @@ groups:
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--token-auth-file"
@@ -356,7 +356,7 @@ groups:
 
       - id: 1.2.3
         text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -376,7 +376,7 @@ groups:
 
       - id: 1.2.4
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
         tests:
           bin_op: and
           test_items:
@@ -394,7 +394,7 @@ groups:
 
       - id: 1.2.5
         text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
         tests:
           test_items:
             - flag: "--kubelet-certificate-authority"
@@ -407,7 +407,7 @@ groups:
 
       - id: 1.2.6
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -423,7 +423,7 @@ groups:
 
       - id: 1.2.7
         text: "Ensure that the --authorization-mode argument includes Node (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -438,7 +438,7 @@ groups:
 
       - id: 1.2.8
         text: "Ensure that the --authorization-mode argument includes RBAC (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -453,7 +453,7 @@ groups:
 
       - id: 1.2.9
         text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -470,7 +470,7 @@ groups:
 
       - id: 1.2.10
         text: "Ensure that the admission control plugin AlwaysAdmit is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           bin_op: or
           test_items:
@@ -528,7 +528,7 @@ groups:
 
       - id: 1.2.13
         text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -548,7 +548,7 @@ groups:
 
       - id: 1.2.14
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -567,7 +567,7 @@ groups:
 
       - id: 1.2.15
         text: "Ensure that the admission control plugin NodeRestriction is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -584,7 +584,7 @@ groups:
 
       - id: 1.2.16
         text: "Ensure that the --secure-port argument is not set to 0 - NoteThis recommendation is obsolete and will be deleted per the consensus process (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'secure-port'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'secure-port'"
         tests:
           bin_op: or
           test_items:
@@ -603,7 +603,7 @@ groups:
 
       - id: 1.2.17
         text: "Ensure that the --profiling argument is set to false (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'profiling'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'profiling'"
         tests:
           test_items:
             - flag: "--profiling"
@@ -619,7 +619,7 @@ groups:
 
       - id: 1.2.18
         text: "Ensure that the --audit-log-path argument is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -634,7 +634,7 @@ groups:
 
       - id: 1.2.19
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -652,7 +652,7 @@ groups:
 
       - id: 1.2.20
         text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -670,7 +670,7 @@ groups:
 
       - id: 1.2.21
         text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -688,7 +688,7 @@ groups:
 
       - id: 1.2.22
         text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--request-timeout"
@@ -703,7 +703,7 @@ groups:
 
       - id: 1.2.23
         text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -724,7 +724,7 @@ groups:
 
       - id: 1.2.24
         text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -782,7 +782,7 @@ groups:
 
       - id: 1.2.27
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'client-ca-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'client-ca-file'"
         tests:
           test_items:
             - flag: "--client-ca-file"
@@ -796,7 +796,7 @@ groups:
 
       - id: 1.2.28
         text: "Ensure that the --etcd-cafile argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-cafile'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-cafile'"
         tests:
           test_items:
             - flag: "--etcd-cafile"
@@ -811,7 +811,7 @@ groups:
       - id: 1.2.29
         text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
         type: "skip"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'encryption-provider-config'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'encryption-provider-config'"
         tests:
           test_items:
             - flag: "--encryption-provider-config"
@@ -867,7 +867,7 @@ groups:
     checks:
       - id: 1.3.1
         text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'terminated-pod-gc-threshold'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'terminated-pod-gc-threshold'"
         tests:
           test_items:
             - flag: "--terminated-pod-gc-threshold"
@@ -880,7 +880,7 @@ groups:
 
       - id: 1.3.2
         text: "Ensure that the --profiling argument is set to false (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'profiling'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'profiling'"
         tests:
           test_items:
             - flag: "--profiling"
@@ -896,7 +896,7 @@ groups:
 
       - id: 1.3.3
         text: "Ensure that the --use-service-account-credentials argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'use-service-account-credentials'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'use-service-account-credentials'"
         tests:
           test_items:
             - flag: "--use-service-account-credentials"
@@ -912,7 +912,7 @@ groups:
 
       - id: 1.3.4
         text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'service-account-private-key-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'service-account-private-key-file'"
         tests:
           test_items:
             - flag: "--service-account-private-key-file"
@@ -926,7 +926,7 @@ groups:
 
       - id: 1.3.5
         text: "Ensure that the --root-ca-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'root-ca-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'root-ca-file'"
         tests:
           test_items:
             - flag: "--root-ca-file"
@@ -940,7 +940,7 @@ groups:
 
       - id: 1.3.6
         text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -1001,7 +1001,7 @@ groups:
 
       - id: 1.4.2
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'bind-address'"
+        audit: "journalctl -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'bind-address'"
         tests:
           bin_op: or
           test_items:

--- a/package/cfg/k3s-cis-1.7-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/master.yaml
@@ -156,7 +156,12 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: "check_for_k3s_etcd.sh 1.1.11"
+        audit: |
+          if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
+            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
+          else 
+            echo "permissions=700"
+          fi
         tests:
           test_items:
             - flag: "permissions"
@@ -735,7 +740,12 @@ groups:
 
       - id: 1.2.25
         text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
-        audit: "check_for_k3s_etcd.sh 1.2.29"
+        audit: |
+          if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
+            journalctl -D /var/log/journal -u k3s | grep -m1 'Running kube-apiserver' | tail -n1
+          else 
+            echo "--etcd-certfile AND --etcd-keyfile"
+          fi
         tests:
           bin_op: and
           test_items:

--- a/package/cfg/k3s-cis-1.7-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/master.yaml
@@ -329,27 +329,29 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the below parameter.
-          --anonymous-auth=false
+          By default, K3s sets the --anonymous-auth argument to false. If it is set to true,
+          edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
+          kube-apiserver-arg:
+            - "anonymous-auth=true"
         scored: false
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--token-auth-file"
               set: false
         remediation: |
-          Follow the documentation and configure alternate mechanisms for authentication. Then,
-          edit the API server pod specification file $apiserverconf
-          on the control plane node and remove the --token-auth-file=<filename> parameter.
+          Follow the documentation and configure alternate mechanisms for authentication.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
+          kube-apiserver-arg:
+          - "token-auth-file=<path>".
         scored: true
 
       - id: 1.2.3
         text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -361,9 +363,10 @@ groups:
             - flag: "--enable-admission-plugins"
               set: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and remove the `DenyServiceExternalIPs`
-          from enabled admission plugins.
+          By default, K3s does not set DenyServiceExternalIPs.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-apiserver-arg:
+          - "enable-admission-plugins=DenyServiceExternalIPs"
         scored: true
 
       - id: 1.2.4
@@ -375,28 +378,26 @@ groups:
             - flag: "--kubelet-client-certificate"
             - flag: "--kubelet-client-key"
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection between the
-          apiserver and kubelets. Then, edit API server pod specification file
-          $apiserverconf on the control plane node and set the
-          kubelet client certificate and key parameters as below.
-          --kubelet-client-certificate=<path/to/client-certificate-file>
-          --kubelet-client-key=<path/to/client-key-file>
+          By default, K3s automatically provides the kubelet client certificate and key.
+          They are generated and located at /var/lib/rancher/k3s/server/tls/client-kube-apiserver.crt and /var/lib/rancher/k3s/server/tls/client-kube-apiserver.key
+          If for some reason you need to provide your own certificate and key, you can set the
+          the below parameters in the K3s config file /etc/rancher/k3s/config.yaml.
+          kube-apiserver-arg:
+          - "kubelet-client-certificate=<path/to/client-cert-file>"
+          - "kubelet-client-key=<path/to/client-key-file>"
         scored: true
 
       - id: 1.2.5
         text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
-        type: "skip"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
         tests:
           test_items:
             - flag: "--kubelet-certificate-authority"
         remediation: |
-          Follow the Kubernetes documentation and setup the TLS connection between
-          the apiserver and kubelets. Then, edit the API server pod specification file
-          $apiserverconf on the control plane node and set the
-          --kubelet-certificate-authority parameter to the path to the cert file for the certificate authority.
-          --kubelet-certificate-authority=<ca-string>
-          Permissive - When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
+          By default, K3s automatically provides the kubelet CA cert file, at /var/lib/rancher/k3s/server/tls/server-ca.crt.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "kubelet-certificate-authority=<path/to/ca-cert-file>"
         scored: true
 
       - id: 1.2.6
@@ -409,10 +410,10 @@ groups:
                 op: nothave
                 value: "AlwaysAllow"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --authorization-mode parameter to values other than AlwaysAllow.
-          One such example could be as below.
-          --authorization-mode=RBAC
+          By default, K3s does not set the --authorization-mode to AlwaysAllow.
+          If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-apiserver-arg:
+          - "authorization-mode=AlwaysAllow"
         scored: true
 
       - id: 1.2.7
@@ -425,9 +426,9 @@ groups:
                 op: has
                 value: "Node"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --authorization-mode parameter to a value that includes Node.
-          --authorization-mode=Node,RBAC
+          By default, K3s sets the --authorization-mode to Node and RBAC.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, 
+          ensure that you are not overriding authorization-mode.
         scored: true
 
       - id: 1.2.8
@@ -440,9 +441,9 @@ groups:
                 op: has
                 value: "RBAC"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --authorization-mode parameter to a value that includes RBAC,
-          for example `--authorization-mode=Node,RBAC`.
+          By default, K3s sets the --authorization-mode to Node and RBAC.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml,
+          ensure that you are not overriding authorization-mode.
         scored: true
 
       - id: 1.2.9
@@ -456,10 +457,10 @@ groups:
                 value: "EventRateLimit"
         remediation: |
           Follow the Kubernetes documentation and set the desired limits in a configuration file.
-          Then, edit the API server pod specification file $apiserverconf
-          and set the below parameters.
-          --enable-admission-plugins=...,EventRateLimit,...
-          --admission-control-config-file=<path/to/configuration/file>
+          Then, edit the K3s config file /etc/rancher/k3s/config.yaml and set the below parameters.
+          kube-apiserver-arg:
+          - "enable-admission-plugins=...,EventRateLimit,..."
+          - "admission-control-config-file=<path/to/configuration/file>"
         scored: false
 
       - id: 1.2.10
@@ -475,9 +476,10 @@ groups:
             - flag: "--enable-admission-plugins"
               set: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and either remove the --enable-admission-plugins parameter, or set it to a
-          value that does not include AlwaysAdmit.
+          By default, K3s does not set the --enable-admission-plugins to AlwaysAdmit.
+          If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-apiserver-arg:
+          - "enable-admission-plugins=AlwaysAdmit"
         scored: true
 
       - id: 1.2.11
@@ -490,10 +492,13 @@ groups:
                 op: has
                 value: "AlwaysPullImages"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --enable-admission-plugins parameter to include
-          AlwaysPullImages.
-          --enable-admission-plugins=...,AlwaysPullImages,...
+          Permissive, per CIS guidelines,
+          "This setting could impact offline or isolated clusters, which have images pre-loaded and
+          do not have access to a registry to pull in-use images. This setting is not appropriate for
+          clusters which use this configuration."
+          Edit the K3s config file /etc/rancher/k3s/config.yaml and set the below parameter.
+          kube-apiserver-arg:
+          - "enable-admission-plugins=...,AlwaysPullImages,..."
         scored: false
 
       - id: 1.2.12
@@ -512,16 +517,13 @@ groups:
                 op: has
                 value: "PodSecurityPolicy"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --enable-admission-plugins parameter to include
-          SecurityContextDeny, unless PodSecurityPolicy is already in place.
-          --enable-admission-plugins=...,SecurityContextDeny,...
-          Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
+          Not Applicable.
+          Enabling Pod Security Policy is no longer supported on K3s v1.25+ and will cause applications to unexpectedly fail.
         scored: false
 
       - id: 1.2.13
         text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -532,15 +534,16 @@ groups:
             - flag: "--disable-admission-plugins"
               set: false
         remediation: |
+          By default, K3s does not set the --disable-admission-plugins to anything.
           Follow the documentation and create ServiceAccount objects as per your environment.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and ensure that the --disable-admission-plugins parameter is set to a
-          value that does not include ServiceAccount.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "disable-admission-plugins=ServiceAccount"
         scored: true
 
       - id: 1.2.14
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -551,9 +554,10 @@ groups:
             - flag: "--disable-admission-plugins"
               set: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --disable-admission-plugins parameter to
-          ensure it does not include NamespaceLifecycle.
+          By default, K3s does not set the --disable-admission-plugins to anything.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "disable-admission-plugins=...,NamespaceLifecycle,..."
         scored: true
 
       - id: 1.2.15
@@ -566,11 +570,11 @@ groups:
                 op: has
                 value: "NodeRestriction"
         remediation: |
-          Follow the Kubernetes documentation and configure NodeRestriction plug-in on kubelets.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --enable-admission-plugins parameter to a
-          value that includes NodeRestriction.
-          --enable-admission-plugins=...,NodeRestriction,...
+          By default, K3s sets the --enable-admission-plugins to NodeRestriction.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, check that you are not overriding the admission plugins.
+          If you are, include NodeRestriction in the list.
+          kube-apiserver-arg:
+          - "enable-admission-plugins=...,NodeRestriction,..."
         scored: true
 
       - id: 1.2.16
@@ -586,9 +590,11 @@ groups:
             - flag: "--secure-port"
               set: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and either remove the --secure-port parameter or
-          set it to a different (non-zero) desired port.
+          By default, K3s sets the secure port to 6444.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml 
+          and remove any lines like below.
+          kube-apiserver-arg:
+          - "secure-port=<PORT>"
         scored: true
 
       - id: 1.2.17
@@ -601,29 +607,30 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the below parameter.
-          --profiling=false
+          By default, K3s sets the --profiling argument to false.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "profiling=true"
         scored: true
 
       - id: 1.2.18
         text: "Ensure that the --audit-log-path argument is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
             - flag: "--audit-log-path"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-path parameter to a suitable path and
+          Edit the K3s config file /etc/rancher/k3s/config.yaml and set the audit-log-path parameter to a suitable path and
           file where you would like audit logs to be written, for example,
-          --audit-log-path=/var/log/apiserver/audit.log
+          kube-apiserver-arg:
+          - "audit-log-path=/var/lib/rancher/k3s/server/logs/audit.log"
           Permissive.
         scored: true
 
       - id: 1.2.19
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -632,16 +639,16 @@ groups:
                 op: gte
                 value: 30
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-maxage parameter to 30
-          or as an appropriate number of days, for example,
-          --audit-log-maxage=30
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and
+          set the audit-log-maxage parameter to 30 or as an appropriate number of days, for example,
+          kube-apiserver-arg:
+          - "audit-log-maxage=30"
           Permissive.
         scored: true
 
       - id: 1.2.20
         text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -650,16 +657,16 @@ groups:
                 op: gte
                 value: 10
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-maxbackup parameter to 10 or to an appropriate
-          value. For example,
-          --audit-log-maxbackup=10
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and 
+          set the audit-log-maxbackup parameter to 10 or to an appropriate value. For example,
+          kube-apiserver-arg:
+          - "audit-log-maxbackup=10"
           Permissive.
         scored: true
 
       - id: 1.2.21
         text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -668,29 +675,31 @@ groups:
                 op: gte
                 value: 100
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-maxsize parameter to an appropriate size in MB.
-          For example, to set it as 100 MB, --audit-log-maxsize=100
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and 
+          set the audit-log-maxsize parameter to an appropriate size in MB. For example,
+          kube-apiserver-arg:
+          - "audit-log-maxsize=100"
           Permissive.
         scored: true
 
       - id: 1.2.22
         text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
-        type: "skip"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--request-timeout"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          and set the below parameter as appropriate and if needed.
-          For example, --request-timeout=300s
-          Permissive.
+          Permissive, per CIS guidelines, 
+          "it is recommended to set this limit as appropriate and change the default limit of 60 seconds only if needed".
+          Edit the K3s config file /etc/rancher/k3s/config.yaml
+          and set the below parameter if needed. For example,
+          kube-apiserver-arg:
+          - "request-timeout=300s"
         scored: false
 
       - id: 1.2.23
         text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -701,25 +710,27 @@ groups:
                 op: eq
                 value: true
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the below parameter.
-          --service-account-lookup=true
-          Alternatively, you can delete the --service-account-lookup parameter from this file so
+          By default, K3s does not set the --service-account-lookup argument.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml and set the service-account-lookup. For example,
+          kube-apiserver-arg:
+          - "service-account-lookup=true"
+          Alternatively, you can delete the service-account-lookup parameter from this file so
           that the default takes effect.
         scored: true
 
       - id: 1.2.24
         text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
             - flag: "--service-account-key-file"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --service-account-key-file parameter
-          to the public key file for service accounts. For example,
-          --service-account-key-file=<filename>
+          K3s automatically generates and sets the service account key file.
+          It is located at /var/lib/rancher/k3s/server/tls/service.key.
+          If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "service-account-key-file=<path>"
         scored: true
 
       - id: 1.2.25
@@ -733,11 +744,12 @@ groups:
             - flag: "--etcd-keyfile"
               set: true
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the etcd certificate and key file parameters.
-          --etcd-certfile=<path/to/client-certificate-file>
-          --etcd-keyfile=<path/to/client-key-file>
+          K3s automatically generates and sets the etcd certificate and key files.
+          They are located at /var/lib/rancher/k3s/server/tls/etcd/client.crt and /var/lib/rancher/k3s/server/tls/etcd/client.key.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "etcd-certfile=<path>"
+          - "etcd-keyfile=<path>"
         scored: true
 
       - id: 1.2.26
@@ -751,11 +763,12 @@ groups:
             - flag: "--tls-private-key-file"
               set: true
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the TLS certificate and private key file parameters.
-          --tls-cert-file=<path/to/tls-certificate-file>
-          --tls-private-key-file=<path/to/tls-key-file>
+          By default, K3s automatically generates and provides the TLS certificate and private key for the apiserver.
+          They are generated and located at /var/lib/rancher/k3s/server/tls/serving-kube-apiserver.crt and /var/lib/rancher/k3s/server/tls/serving-kube-apiserver.key
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "tls-cert-file=<path>"
+          - "tls-private-key-file=<path>"
         scored: true
 
       - id: 1.2.27
@@ -765,10 +778,11 @@ groups:
           test_items:
             - flag: "--client-ca-file"
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the client certificate authority file.
-          --client-ca-file=<path/to/client-ca-file>
+          By default, K3s automatically provides the client certificate authority file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/client-ca.crt.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "client-ca-file=<path>"
         scored: true
 
       - id: 1.2.28
@@ -778,10 +792,11 @@ groups:
           test_items:
             - flag: "--etcd-cafile"
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the etcd certificate authority file parameter.
-          --etcd-cafile=<path/to/ca-file>
+          By default, K3s automatically provides the etcd certificate authority file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/client-ca.crt.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "etcd-cafile=<path>"
         scored: true
 
       - id: 1.2.29
@@ -792,10 +807,11 @@ groups:
           test_items:
             - flag: "--encryption-provider-config"
         remediation: |
-          Follow the Kubernetes documentation and configure a EncryptionConfig file.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --encryption-provider-config parameter to the path of that file.
-          For example, --encryption-provider-config=</path/to/EncryptionConfig/File>
+          K3s can be configured to use encryption providers to encrypt secrets at rest.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and set the below parameter.
+          secrets-encryption: true
+          Secrets encryption can then be managed with the k3s secrets-encrypt command line tool.
+          If needed, you can find the generated encryption config at /var/lib/rancher/k3s/server/cred/encryption-config.json.
           Permissive - Enabling encryption changes how data can be recovered as data is encrypted.
         scored: false
 
@@ -803,8 +819,8 @@ groups:
         text: "Ensure that encryption providers are appropriately configured (Manual)"
         type: "skip"
         audit: |
-          ENCRYPTION_PROVIDER_CONFIG=$(ps -ef | grep $apiserverbin | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
-          if test -e $ENCRYPTION_PROVIDER_CONFIG; then grep -A1 'providers:' $ENCRYPTION_PROVIDER_CONFIG | tail -n1 | grep -o "[A-Za-z]*" | sed 's/^/provider=/'; fi
+          ENCRYPTION_PROVIDER_CONFIG=$(journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
+          if test -e $ENCRYPTION_PROVIDER_CONFIG; then grep -o 'providers\"\:\[.*\]' $ENCRYPTION_PROVIDER_CONFIG | grep -o "[A-Za-z]*" | head -2 | tail -1  | sed 's/^/provider=/'; fi
         tests:
           test_items:
             - flag: "provider"
@@ -812,12 +828,15 @@ groups:
                 op: valid_elements
                 value: "aescbc,kms,secretbox"
         remediation: |
-          Follow the Kubernetes documentation and configure a EncryptionConfig file.
-          In this file, choose aescbc, kms or secretbox as the encryption provider.
+          K3s can be configured to use encryption providers to encrypt secrets at rest. K3s will utilize the aescbc provider.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and set the below parameter.
+          secrets-encryption: true
+          Secrets encryption can then be managed with the k3s secrets-encrypt command line tool.
+          If needed, you can find the generated encryption config at /var/lib/rancher/k3s/server/cred/encryption-config.json
           Permissive - Enabling encryption changes how data can be recovered as data is encrypted.
         scored: false
 
-      - id: 1.2.32
+      - id: 1.2.31
         text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Automated)"
         audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'tls-cipher-suites'"
         tests:

--- a/package/cfg/k3s-cis-1.7-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/master.yaml
@@ -159,7 +159,7 @@ groups:
         audit: |
           if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
             stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
-          else 
+          else
             echo "permissions=700"
           fi
         tests:
@@ -432,7 +432,7 @@ groups:
                 value: "Node"
         remediation: |
           By default, K3s sets the --authorization-mode to Node and RBAC.
-          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, 
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml,
           ensure that you are not overriding authorization-mode.
         scored: true
 
@@ -596,8 +596,7 @@ groups:
               set: false
         remediation: |
           By default, K3s sets the secure port to 6444.
-          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml 
-          and remove any lines like below.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
           kube-apiserver-arg:
           - "secure-port=<PORT>"
         scored: true
@@ -662,7 +661,7 @@ groups:
                 op: gte
                 value: 10
         remediation: |
-          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and 
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and
           set the audit-log-maxbackup parameter to 10 or to an appropriate value. For example,
           kube-apiserver-arg:
           - "audit-log-maxbackup=10"
@@ -680,7 +679,7 @@ groups:
                 op: gte
                 value: 100
         remediation: |
-          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and 
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and
           set the audit-log-maxsize parameter to an appropriate size in MB. For example,
           kube-apiserver-arg:
           - "audit-log-maxsize=100"
@@ -694,7 +693,7 @@ groups:
           test_items:
             - flag: "--request-timeout"
         remediation: |
-          Permissive, per CIS guidelines, 
+          Permissive, per CIS guidelines,
           "it is recommended to set this limit as appropriate and change the default limit of 60 seconds only if needed".
           Edit the K3s config file /etc/rancher/k3s/config.yaml
           and set the below parameter if needed. For example,
@@ -743,7 +742,7 @@ groups:
         audit: |
           if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
             journalctl -D /var/log/journal -u k3s | grep -m1 'Running kube-apiserver' | tail -n1
-          else 
+          else
             echo "--etcd-certfile AND --etcd-keyfile"
           fi
         tests:
@@ -873,9 +872,10 @@ groups:
           test_items:
             - flag: "--terminated-pod-gc-threshold"
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --terminated-pod-gc-threshold to an appropriate threshold,
-          for example, --terminated-pod-gc-threshold=10
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node
+          and set the --terminated-pod-gc-threshold to an appropriate threshold,
+          kube-controller-manager-arg:
+          - "terminated-pod-gc-threshold=10"
         scored: false
 
       - id: 1.3.2
@@ -888,9 +888,10 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the below parameter.
-          --profiling=false
+          By default, K3s sets the --profiling argument to false.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+          - "profiling=true"
         scored: true
 
       - id: 1.3.3
@@ -903,9 +904,10 @@ groups:
                 op: noteq
                 value: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node to set the below parameter.
-          --use-service-account-credentials=true
+          By default, K3s sets the --use-service-account-credentials argument to true.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+          - "use-service-account-credentials=false"
         scored: true
 
       - id: 1.3.4
@@ -915,10 +917,11 @@ groups:
           test_items:
             - flag: "--service-account-private-key-file"
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --service-account-private-key-file parameter
-          to the private key file for service accounts.
-          --service-account-private-key-file=<filename>
+          By default, K3s automatically provides the service account private key file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/service.current.key.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+          - "service-account-private-key-file=<path>"
         scored: true
 
       - id: 1.3.5
@@ -928,15 +931,16 @@ groups:
           test_items:
             - flag: "--root-ca-file"
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --root-ca-file parameter to the certificate bundle file`.
-          --root-ca-file=<path/to/file>
+          By default, K3s automatically provides the root CA file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/server-ca.crt.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+          - "root-ca-file=<path>"
         scored: true
 
       - id: 1.3.6
         text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
-        type: "skip"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'RotateKubeletServerCertificate'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -948,10 +952,11 @@ groups:
             - flag: "--feature-gates"
               set: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --feature-gates parameter to include RotateKubeletServerCertificate=true.
-          --feature-gates=RotateKubeletServerCertificate=true
-          Not Applicable.
+          By default, K3s does not set the RotateKubeletServerCertificate feature gate.
+          If you have enabled this feature gate, you should remove it.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-controller-manager-arg:
+          - "feature-gate=RotateKubeletServerCertificate"
         scored: true
 
       - id: 1.3.7
@@ -968,8 +973,10 @@ groups:
             - flag: "--bind-address"
               set: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and ensure the correct value for the --bind-address parameter
+          By default, K3s sets the --bind-address argument to 127.0.0.1
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+          - "bind-address=<IP>"
         scored: true
 
   - id: 1.4
@@ -986,9 +993,10 @@ groups:
                 value: false
               set: true
         remediation: |
-          Edit the Scheduler pod specification file $schedulerconf file
-          on the control plane node and set the below parameter.
-          --profiling=false
+          By default, K3s sets the --profiling argument to false.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-scheduler-arg:
+          - "profiling=true"
         scored: true
 
       - id: 1.4.2
@@ -1005,6 +1013,8 @@ groups:
             - flag: "--bind-address"
               set: false
         remediation: |
-          Edit the Scheduler pod specification file $schedulerconf
-          on the control plane node and ensure the correct value for the --bind-address parameter
+          By default, K3s sets the --bind-address argument to 127.0.0.1
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-scheduler-arg:
+          - "bind-address=<IP>"
         scored: true

--- a/package/cfg/k3s-cis-1.7-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/master.yaml
@@ -19,10 +19,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the
-          control plane node.
-          For example, chmod 600 $apiserverconf
           Not Applicable.
+          K3s embeds the api server within the k3s process. There is no API server pod specification file.
         scored: true
 
       - id: 1.1.2
@@ -33,9 +31,8 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root $apiserverconf
           Not Applicable.
+          K3s embeds the api server within the k3s process. There is no API server pod specification file.
         scored: true
 
       - id: 1.1.3
@@ -49,9 +46,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 $controllermanagerconf
           Not Applicable.
+          K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
         scored: true
 
       - id: 1.1.4
@@ -62,9 +58,8 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root $controllermanagerconf
           Not Applicable.
+          K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
         scored: true
 
       - id: 1.1.5
@@ -78,9 +73,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 $schedulerconf
           Not Applicable.
+          K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
         scored: true
 
       - id: 1.1.6
@@ -91,9 +85,8 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root $schedulerconf
           Not Applicable.
+          K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
         scored: true
 
       - id: 1.1.7
@@ -108,10 +101,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chmod 600 $etcdconf
           Not Applicable.
+          K3s embeds etcd within the k3s process. There is no etcd pod specification file.
         scored: true
 
       - id: 1.1.8
@@ -123,10 +114,8 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chown root:root $etcdconf
           Not Applicable.
+          K3s embeds etcd within the k3s process. There is no etcd pod specification file.
         scored: true
 
       - id: 1.1.9
@@ -143,9 +132,9 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
+          Not Applicable.
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chmod 600 <path/to/cni/files>
-          Not Applicable.
         scored: false
 
       - id: 1.1.10
@@ -159,10 +148,10 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
+          Not Applicable.
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chown root:root <path/to/cni/files>
-          Not Applicable.
         scored: false
 
       - id: 1.1.11
@@ -170,11 +159,10 @@ groups:
         audit: "check_for_k3s_etcd.sh 1.1.11"
         tests:
           test_items:
-            - flag: "700"
+            - flag: "permissions"
               compare:
-                op: eq
+                op: bitmask
                 value: "700"
-              set: true
         remediation: |
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.
@@ -190,11 +178,9 @@ groups:
           test_items:
             - flag: "etcd:etcd"
         remediation: |
-          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-          from the command 'ps -ef | grep etcd'.
-          Run the below command (based on the etcd data directory found above).
-          For example, chown etcd:etcd /var/lib/etcd
           Not Applicable.
+          For K3s, etcd is embedded within the k3s process. There is no separate etcd process.
+          Therefore the etcd data directory ownership is managed by the k3s process and should be root:root.
         scored: true
 
       - id: 1.1.13
@@ -224,12 +210,12 @@ groups:
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root /etc/kubernetes/admin.conf
+          For example, chown root:root /var/lib/rancher/k3s/server/cred/admin.kubeconfig
         scored: true
 
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c permissions=%a $schedulerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -244,7 +230,7 @@ groups:
 
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c %U:%G /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c %U:%G $schedulerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "root:root"
@@ -256,7 +242,7 @@ groups:
 
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/controller.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/controller.kubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c permissions=%a $controllermanagerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -271,7 +257,7 @@ groups:
 
       - id: 1.1.18
         text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
-        audit: "stat -c %U:%G /var/lib/rancher/k3s/server/cred/controller.kubeconfig"
+        audit: "stat -c %U:%G $controllermanagerkubeconfig"
         tests:
           test_items:
             - flag: "root:root"
@@ -300,7 +286,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"
-        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' | xargs stat -c permissions=%a"
+        audit: "/bin/sh -c 'stat -c permissions=%a /var/lib/rancher/k3s/server/tls/*.crt'"
         use_multiple_values: true
         tests:
           test_items:
@@ -311,12 +297,12 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 600 {} +
+          chmod -R 600 /var/lib/rancher/k3s/server/tls/*.crt
         scored: false
 
       - id: 1.1.21
-        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.key' | xargs stat -c permissions=%a"
+        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Automated)"
+        audit: "/bin/sh -c 'stat -c permissions=%a /var/lib/rancher/k3s/server/tls/*.key'"
         use_multiple_values: true
         tests:
           test_items:
@@ -327,7 +313,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {} +
+          chmod -R 600 /var/lib/rancher/k3s/server/tls/*.key
         scored: false
 
   - id: 1.2

--- a/package/cfg/k3s-cis-1.7-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/master.yaml
@@ -185,7 +185,7 @@ groups:
 
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/admin.kubeconfig'"
+        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/admin.kubeconfig; fi'"
         type: "skip"
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.7-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/master.yaml
@@ -20,7 +20,7 @@ groups:
                 value: "600"
         remediation: |
           Not Applicable.
-          K3s embeds the api server within the k3s process. There is no API server pod specification file.
+          By default, K3s embeds the api server within the k3s process. There is no API server pod specification file.
         scored: true
 
       - id: 1.1.2
@@ -32,7 +32,7 @@ groups:
             - flag: "root:root"
         remediation: |
           Not Applicable.
-          K3s embeds the api server within the k3s process. There is no API server pod specification file.
+          By default, K3s embeds the api server within the k3s process. There is no API server pod specification file.
         scored: true
 
       - id: 1.1.3
@@ -47,7 +47,7 @@ groups:
                 value: "600"
         remediation: |
           Not Applicable.
-          K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
+          By default, K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
         scored: true
 
       - id: 1.1.4
@@ -59,7 +59,7 @@ groups:
             - flag: "root:root"
         remediation: |
           Not Applicable.
-          K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
+          By default, K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
         scored: true
 
       - id: 1.1.5
@@ -74,7 +74,7 @@ groups:
                 value: "600"
         remediation: |
           Not Applicable.
-          K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
+          By default, K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
         scored: true
 
       - id: 1.1.6
@@ -86,7 +86,7 @@ groups:
             - flag: "root:root"
         remediation: |
           Not Applicable.
-          K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
+          By default, K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
         scored: true
 
       - id: 1.1.7
@@ -102,7 +102,7 @@ groups:
                 value: "600"
         remediation: |
           Not Applicable.
-          K3s embeds etcd within the k3s process. There is no etcd pod specification file.
+          By default, K3s embeds etcd within the k3s process. There is no etcd pod specification file.
         scored: true
 
       - id: 1.1.8
@@ -115,7 +115,7 @@ groups:
             - flag: "root:root"
         remediation: |
           Not Applicable.
-          K3s embeds etcd within the k3s process. There is no etcd pod specification file.
+          By default, K3s embeds etcd within the k3s process. There is no etcd pod specification file.
         scored: true
 
       - id: 1.1.9
@@ -323,7 +323,7 @@ groups:
     text: "API Server"
     checks:
       - id: 1.2.1
-        text: "Ensure that the --anonymous-auth argument is set to false (Manual)"
+        text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
         audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth'"
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.7-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/master.yaml
@@ -120,10 +120,7 @@ groups:
 
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Automated)"
-        type: "skip"
-        audit: |
-          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
-          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
+        audit: find /var/lib/cni/networks -type f ! -name lock 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
         use_multiple_values: true
         tests:
           test_items:
@@ -132,9 +129,10 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Not Applicable.
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 <path/to/cni/files>
+          By default, K3s sets the CNI file permissions to 600.
+          Note that for many CNIs, a lock file is created with permissions 750. This is expected and can be ignored.
+          If you modify your CNI configuration, ensure that the permissions are set to 600.
+          For example, chmod 600 /var/lib/cni/networks/<filename>
         scored: false
 
       - id: 1.1.10

--- a/package/cfg/k3s-cis-1.7-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/node.yaml
@@ -213,7 +213,7 @@ groups:
 
       - id: 4.2.4
         text: "Verify that the --read-only-port argument is set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'read-only-port' "
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'read-only-port' "
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           bin_op: or
@@ -240,7 +240,7 @@ groups:
 
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'streaming-connection-idle-timeout'"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'streaming-connection-idle-timeout'"
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -264,7 +264,7 @@ groups:
       - id: 4.2.6
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
         type: "skip"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'make-iptables-util-chains'"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep 'make-iptables-util-chains'"
         tests:
           test_items:
             - flag: --make-iptables-util-chains
@@ -289,7 +289,7 @@ groups:
       - id: 4.2.7
         text: "Ensure that the --hostname-override argument is not set (Manual)"
         type: "skip"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --hostname-override
@@ -302,7 +302,7 @@ groups:
 
       - id: 4.2.8
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -328,7 +328,7 @@ groups:
       - id: 4.2.9
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
         type: "skip"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --tls-cert-file
@@ -348,7 +348,7 @@ groups:
 
       - id: 4.2.10
         text: "Ensure that the --rotate-certificates argument is not set to false (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -371,7 +371,7 @@ groups:
 
       - id: 4.2.11
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
           bin_op: or
@@ -395,7 +395,7 @@ groups:
 
       - id: 4.2.12
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -416,7 +416,7 @@ groups:
 
       - id: 4.2.13
         text: "Ensure that a limit is set on pod PIDs (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.8-hardened/config.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/config.yaml
@@ -20,9 +20,13 @@ master:
   scheduler:
     bins:
       - containerd
+    kubeconfig:
+      - /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig
   controllermanager:
     bins:
       - containerd
+    kubeconfig:
+      - /var/lib/rancher/k3s/server/cred/controller.kubeconfig
   etcd:
     bins:
       - containerd

--- a/package/cfg/k3s-cis-1.8-hardened/controlplane.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/controlplane.yaml
@@ -37,7 +37,7 @@ groups:
     checks:
       - id: 3.2.1
         text: "Ensure that a minimal audit policy is created (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-policy-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-policy-file'"
         tests:
           test_items:
             - flag: "--audit-policy-file"

--- a/package/cfg/k3s-cis-1.8-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/master.yaml
@@ -325,7 +325,7 @@ groups:
     checks:
       - id: 1.2.1
         text: "Ensure that the --anonymous-auth argument is set to false (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth'"
         tests:
           test_items:
             - flag: "--anonymous-auth"
@@ -341,7 +341,7 @@ groups:
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--token-auth-file"
@@ -355,7 +355,7 @@ groups:
 
       - id: 1.2.3
         text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -375,7 +375,7 @@ groups:
 
       - id: 1.2.4
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: and
           test_items:
@@ -393,7 +393,7 @@ groups:
 
       - id: 1.2.5
         text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
         tests:
           test_items:
             - flag: "--kubelet-certificate-authority"
@@ -407,7 +407,7 @@ groups:
 
       - id: 1.2.6
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -423,7 +423,7 @@ groups:
 
       - id: 1.2.7
         text: "Ensure that the --authorization-mode argument includes Node (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -438,7 +438,7 @@ groups:
 
       - id: 1.2.8
         text: "Ensure that the --authorization-mode argument includes RBAC (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -453,7 +453,7 @@ groups:
 
       - id: 1.2.9
         text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -470,7 +470,7 @@ groups:
 
       - id: 1.2.10
         text: "Ensure that the admission control plugin AlwaysAdmit is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           bin_op: or
           test_items:
@@ -489,7 +489,7 @@ groups:
 
       - id: 1.2.11
         text: "Ensure that the admission control plugin AlwaysPullImages is set (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -528,7 +528,7 @@ groups:
 
       - id: 1.2.13
         text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -548,7 +548,7 @@ groups:
 
       - id: 1.2.14
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -567,7 +567,7 @@ groups:
 
       - id: 1.2.15
         text: "Ensure that the admission control plugin NodeRestriction is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -584,7 +584,7 @@ groups:
 
       - id: 1.2.16
         text: "Ensure that the --profiling argument is set to false (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'profiling'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'profiling'"
         tests:
           test_items:
             - flag: "--profiling"
@@ -600,7 +600,7 @@ groups:
 
       - id: 1.2.17
         text: "Ensure that the --audit-log-path argument is set (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--audit-log-path"
@@ -613,7 +613,7 @@ groups:
 
       - id: 1.2.18
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--audit-log-maxage"
@@ -629,7 +629,7 @@ groups:
 
       - id: 1.2.19
         text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--audit-log-maxbackup"
@@ -645,7 +645,7 @@ groups:
 
       - id: 1.2.20
         text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--audit-log-maxsize"
@@ -661,7 +661,7 @@ groups:
 
       - id: 1.2.21
         text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--request-timeout"
@@ -676,7 +676,7 @@ groups:
 
       - id: 1.2.22
         text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -697,7 +697,7 @@ groups:
 
       - id: 1.2.23
         text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--service-account-key-file"
@@ -754,7 +754,7 @@ groups:
 
       - id: 1.2.26
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'client-ca-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'client-ca-file'"
         tests:
           test_items:
             - flag: "--client-ca-file"
@@ -769,7 +769,7 @@ groups:
 
       - id: 1.2.27
         text: "Ensure that the --etcd-cafile argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-cafile'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-cafile'"
         tests:
           test_items:
             - flag: "--etcd-cafile"
@@ -837,7 +837,7 @@ groups:
     checks:
       - id: 1.3.1
         text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'terminated-pod-gc-threshold'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'terminated-pod-gc-threshold'"
         tests:
           test_items:
             - flag: "--terminated-pod-gc-threshold"
@@ -850,7 +850,7 @@ groups:
 
       - id: 1.3.2
         text: "Ensure that the --profiling argument is set to false (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'profiling'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'profiling'"
         tests:
           test_items:
             - flag: "--profiling"
@@ -866,7 +866,7 @@ groups:
 
       - id: 1.3.3
         text: "Ensure that the --use-service-account-credentials argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'use-service-account-credentials'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'use-service-account-credentials'"
         tests:
           test_items:
             - flag: "--use-service-account-credentials"
@@ -882,7 +882,7 @@ groups:
 
       - id: 1.3.4
         text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'service-account-private-key-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'service-account-private-key-file'"
         tests:
           test_items:
             - flag: "--service-account-private-key-file"
@@ -896,7 +896,7 @@ groups:
 
       - id: 1.3.5
         text: "Ensure that the --root-ca-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'root-ca-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'root-ca-file'"
         tests:
           test_items:
             - flag: "--root-ca-file"
@@ -911,7 +911,7 @@ groups:
 
       - id: 1.3.6
         text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -932,7 +932,7 @@ groups:
 
       - id: 1.3.7
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -972,7 +972,7 @@ groups:
 
       - id: 1.4.2
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'bind-address'"
+        audit: "journalctl -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'bind-address'"
         tests:
           bin_op: or
           test_items:

--- a/package/cfg/k3s-cis-1.8-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/master.yaml
@@ -20,7 +20,7 @@ groups:
                 value: "600"
         remediation: |
           Not Applicable.
-          K3s embeds the api server within the k3s process. There is no API server pod specification file.
+          By default, K3s embeds the api server within the k3s process. There is no API server pod specification file.
         scored: true
 
       - id: 1.1.2
@@ -32,7 +32,7 @@ groups:
             - flag: "root:root"
         remediation: |
           Not Applicable.
-          K3s embeds the api server within the k3s process. There is no API server pod specification file.
+          By default, K3s embeds the api server within the k3s process. There is no API server pod specification file.
         scored: true
 
       - id: 1.1.3
@@ -47,7 +47,7 @@ groups:
                 value: "600"
         remediation: |
           Not Applicable.
-          K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
+          By default, K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
         scored: true
 
       - id: 1.1.4
@@ -59,7 +59,7 @@ groups:
             - flag: "root:root"
         remediation: |
           Not Applicable.
-          K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
+          By default, K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
         scored: true
 
       - id: 1.1.5
@@ -74,7 +74,7 @@ groups:
                 value: "600"
         remediation: |
           Not Applicable.
-          K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
+          By default, K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
         scored: true
 
       - id: 1.1.6
@@ -86,7 +86,7 @@ groups:
             - flag: "root:root"
         remediation: |
           Not Applicable.
-          K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
+          By default, K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
         scored: true
 
       - id: 1.1.7
@@ -102,7 +102,7 @@ groups:
                 value: "600"
         remediation: |
           Not Applicable.
-          K3s embeds etcd within the k3s process. There is no etcd pod specification file.
+          By default, K3s embeds etcd within the k3s process. There is no etcd pod specification file.
         scored: true
 
       - id: 1.1.8
@@ -115,7 +115,7 @@ groups:
             - flag: "root:root"
         remediation: |
           Not Applicable.
-          K3s embeds etcd within the k3s process. There is no etcd pod specification file.
+          By default, K3s embeds etcd within the k3s process. There is no etcd pod specification file.
         scored: true
 
       - id: 1.1.9
@@ -322,7 +322,7 @@ groups:
     text: "API Server"
     checks:
       - id: 1.2.1
-        text: "Ensure that the --anonymous-auth argument is set to false (Manual)"
+        text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
         audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth'"
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.8-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/master.yaml
@@ -159,7 +159,7 @@ groups:
         audit: |
           if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
             stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
-          else 
+          else
             echo "permissions=700"
           fi
         tests:
@@ -432,7 +432,7 @@ groups:
                 value: "Node"
         remediation: |
           By default, K3s sets the --authorization-mode to Node and RBAC.
-          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, 
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml,
           ensure that you are not overriding authorization-mode.
         scored: true
 
@@ -637,7 +637,7 @@ groups:
                 op: gte
                 value: 10
         remediation: |
-          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and 
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and
           set the audit-log-maxbackup parameter to 10 or to an appropriate value. For example,
           kube-apiserver-arg:
           - "audit-log-maxbackup=10"
@@ -653,7 +653,7 @@ groups:
                 op: gte
                 value: 100
         remediation: |
-          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and 
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and
           set the audit-log-maxsize parameter to an appropriate size in MB. For example,
           kube-apiserver-arg:
           - "audit-log-maxsize=100"
@@ -666,7 +666,7 @@ groups:
           test_items:
             - flag: "--request-timeout"
         remediation: |
-          Permissive, per CIS guidelines, 
+          Permissive, per CIS guidelines,
           "it is recommended to set this limit as appropriate and change the default limit of 60 seconds only if needed".
           Edit the K3s config file /etc/rancher/k3s/config.yaml
           and set the below parameter if needed. For example,
@@ -714,7 +714,7 @@ groups:
         audit: |
           if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
             journalctl -D /var/log/journal -u k3s | grep -m1 'Running kube-apiserver' | tail -n1
-          else 
+          else
             echo "--etcd-certfile AND --etcd-keyfile"
           fi
         tests:
@@ -842,9 +842,10 @@ groups:
           test_items:
             - flag: "--terminated-pod-gc-threshold"
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --terminated-pod-gc-threshold to an appropriate threshold,
-          for example, --terminated-pod-gc-threshold=10
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node
+          and set the --terminated-pod-gc-threshold to an appropriate threshold,
+          kube-controller-manager-arg:
+          - "terminated-pod-gc-threshold=10"
         scored: false
 
       - id: 1.3.2
@@ -857,9 +858,10 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the below parameter.
-          --profiling=false
+          By default, K3s sets the --profiling argument to false.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+          - "profiling=true"
         scored: true
 
       - id: 1.3.3
@@ -872,9 +874,10 @@ groups:
                 op: noteq
                 value: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node to set the below parameter.
-          --use-service-account-credentials=true
+          By default, K3s sets the --use-service-account-credentials argument to true.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+          - "use-service-account-credentials=false"
         scored: true
 
       - id: 1.3.4
@@ -884,10 +887,11 @@ groups:
           test_items:
             - flag: "--service-account-private-key-file"
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --service-account-private-key-file parameter
-          to the private key file for service accounts.
-          --service-account-private-key-file=<filename>
+          By default, K3s automatically provides the service account private key file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/service.current.key.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+          - "service-account-private-key-file=<path>"
         scored: true
 
       - id: 1.3.5
@@ -897,15 +901,17 @@ groups:
           test_items:
             - flag: "--root-ca-file"
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --root-ca-file parameter to the certificate bundle file`.
-          --root-ca-file=<path/to/file>
+          By default, K3s automatically provides the root CA file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/server-ca.crt.
+          If for some reason you need to provide your own ca certificate, look at using the k3s certificate command line tool.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+          - "root-ca-file=<path>"
         scored: true
 
       - id: 1.3.6
         text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
-        type: "skip"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'RotateKubeletServerCertificate'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -917,15 +923,16 @@ groups:
             - flag: "--feature-gates"
               set: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --feature-gates parameter to include RotateKubeletServerCertificate=true.
-          --feature-gates=RotateKubeletServerCertificate=true
-          Not Applicable.
+          By default, K3s does not set the RotateKubeletServerCertificate feature gate.
+          If you have enabled this feature gate, you should remove it.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-controller-manager-arg:
+          - "feature-gate=RotateKubeletServerCertificate"
         scored: true
 
       - id: 1.3.7
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
-        audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -937,8 +944,10 @@ groups:
             - flag: "--bind-address"
               set: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and ensure the correct value for the --bind-address parameter
+          By default, K3s sets the --bind-address argument to 127.0.0.1
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+          - "bind-address=<IP>"
         scored: true
 
   - id: 1.4
@@ -946,7 +955,7 @@ groups:
     checks:
       - id: 1.4.1
         text: "Ensure that the --profiling argument is set to false (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-scheduler' | tail -n1"
+        audit: "journalctl -D /var/log/journal -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'profiling'"
         tests:
           test_items:
             - flag: "--profiling"
@@ -955,9 +964,10 @@ groups:
                 value: false
               set: true
         remediation: |
-          Edit the Scheduler pod specification file $schedulerconf file
-          on the control plane node and set the below parameter.
-          --profiling=false
+          By default, K3s sets the --profiling argument to false.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-scheduler-arg:
+          - "profiling=true"
         scored: true
 
       - id: 1.4.2
@@ -974,6 +984,8 @@ groups:
             - flag: "--bind-address"
               set: false
         remediation: |
-          Edit the Scheduler pod specification file $schedulerconf
-          on the control plane node and ensure the correct value for the --bind-address parameter
+          By default, K3s sets the --bind-address argument to 127.0.0.1
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-scheduler-arg:
+          - "bind-address=<IP>"
         scored: true

--- a/package/cfg/k3s-cis-1.8-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/master.yaml
@@ -19,10 +19,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the
-          control plane node.
-          For example, chmod 600 $apiserverconf
           Not Applicable.
+          K3s embeds the api server within the k3s process. There is no API server pod specification file.
         scored: true
 
       - id: 1.1.2
@@ -33,9 +31,8 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root $apiserverconf
           Not Applicable.
+          K3s embeds the api server within the k3s process. There is no API server pod specification file.
         scored: true
 
       - id: 1.1.3
@@ -49,9 +46,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 $controllermanagerconf
           Not Applicable.
+          K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
         scored: true
 
       - id: 1.1.4
@@ -62,9 +58,8 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root $controllermanagerconf
           Not Applicable.
+          K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
         scored: true
 
       - id: 1.1.5
@@ -78,9 +73,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 $schedulerconf
           Not Applicable.
+          K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
         scored: true
 
       - id: 1.1.6
@@ -91,9 +85,8 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root $schedulerconf
           Not Applicable.
+          K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
         scored: true
 
       - id: 1.1.7
@@ -108,10 +101,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chmod 600 $etcdconf
           Not Applicable.
+          K3s embeds etcd within the k3s process. There is no etcd pod specification file.
         scored: true
 
       - id: 1.1.8
@@ -123,10 +114,8 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chown root:root $etcdconf
           Not Applicable.
+          K3s embeds etcd within the k3s process. There is no etcd pod specification file.
         scored: true
 
       - id: 1.1.9
@@ -143,9 +132,9 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
+          Not Applicable.
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chmod 600 <path/to/cni/files>
-          Not Applicable.
         scored: false
 
       - id: 1.1.10
@@ -159,10 +148,10 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
+          Not Applicable.
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chown root:root <path/to/cni/files>
-          Not Applicable.
         scored: false
 
       - id: 1.1.11
@@ -170,11 +159,10 @@ groups:
         audit: "check_for_k3s_etcd.sh 1.1.11"
         tests:
           test_items:
-            - flag: "700"
+            - flag: "permissions"
               compare:
-                op: eq
+                op: bitmask
                 value: "700"
-              set: true
         remediation: |
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.
@@ -190,11 +178,9 @@ groups:
           test_items:
             - flag: "etcd:etcd"
         remediation: |
-          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-          from the command 'ps -ef | grep etcd'.
-          Run the below command (based on the etcd data directory found above).
-          For example, chown etcd:etcd /var/lib/etcd
           Not Applicable.
+          For K3s, etcd is embedded within the k3s process. There is no separate etcd process.
+          Therefore the etcd data directory ownership is managed by the k3s process and should be root:root.
         scored: true
 
       - id: 1.1.13
@@ -224,12 +210,12 @@ groups:
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root /etc/kubernetes/admin.conf
+          For example, chown root:root /var/lib/rancher/k3s/server/cred/admin.kubeconfig
         scored: true
 
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c permissions=%a $schedulerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -244,7 +230,7 @@ groups:
 
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c %U:%G /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c %U:%G $schedulerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "root:root"
@@ -256,7 +242,7 @@ groups:
 
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/controller.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/controller.kubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c permissions=%a $controllermanagerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -271,7 +257,7 @@ groups:
 
       - id: 1.1.18
         text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
-        audit: "stat -c %U:%G /var/lib/rancher/k3s/server/cred/controller.kubeconfig"
+        audit: "stat -c %U:%G $controllermanagerkubeconfig"
         tests:
           test_items:
             - flag: "root:root"
@@ -300,7 +286,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"
-        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' | xargs stat -c permissions=%a"
+        audit: "/bin/sh -c 'stat -c permissions=%a /var/lib/rancher/k3s/server/tls/*.crt'"
         use_multiple_values: true
         tests:
           test_items:
@@ -311,12 +297,12 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 600 {} +
+          chmod -R 600 /var/lib/rancher/k3s/server/tls/*.crt
         scored: false
 
       - id: 1.1.21
-        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.key' | xargs stat -c permissions=%a"
+        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Automated)"
+        audit: "/bin/sh -c 'stat -c permissions=%a /var/lib/rancher/k3s/server/tls/*.key'"
         use_multiple_values: true
         tests:
           test_items:
@@ -327,7 +313,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {} +
+          chmod -R 600 /var/lib/rancher/k3s/server/tls/*.key
         scored: false
 
   - id: 1.2

--- a/package/cfg/k3s-cis-1.8-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/master.yaml
@@ -156,7 +156,12 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: "check_for_k3s_etcd.sh 1.1.11"
+        audit: |
+          if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
+            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
+          else 
+            echo "permissions=700"
+          fi
         tests:
           test_items:
             - flag: "permissions"
@@ -706,7 +711,12 @@ groups:
 
       - id: 1.2.24
         text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
-        audit: "check_for_k3s_etcd.sh 1.2.29"
+        audit: |
+          if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
+            journalctl -D /var/log/journal -u k3s | grep -m1 'Running kube-apiserver' | tail -n1
+          else 
+            echo "--etcd-certfile AND --etcd-keyfile"
+          fi
         tests:
           bin_op: and
           test_items:

--- a/package/cfg/k3s-cis-1.8-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/master.yaml
@@ -185,7 +185,7 @@ groups:
 
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/admin.kubeconfig'"
+        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/admin.kubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"

--- a/package/cfg/k3s-cis-1.8-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/master.yaml
@@ -186,7 +186,6 @@ groups:
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 600 or more restrictive (Automated)"
         audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/admin.kubeconfig'"
-        type: "skip"
         tests:
           test_items:
             - flag: "permissions"
@@ -329,27 +328,29 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the below parameter.
-          --anonymous-auth=false
+          By default, K3s sets the --anonymous-auth argument to false.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
+          kube-apiserver-arg:
+            - "anonymous-auth=true"
         scored: false
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--token-auth-file"
               set: false
         remediation: |
-          Follow the documentation and configure alternate mechanisms for authentication. Then,
-          edit the API server pod specification file $apiserverconf
-          on the control plane node and remove the --token-auth-file=<filename> parameter.
+          Follow the documentation and configure alternate mechanisms for authentication.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
+          kube-apiserver-arg:
+          - "token-auth-file=<path>".
         scored: true
 
       - id: 1.2.3
         text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -361,42 +362,42 @@ groups:
             - flag: "--enable-admission-plugins"
               set: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and remove the `DenyServiceExternalIPs`
-          from enabled admission plugins.
+          By default, K3s does not set DenyServiceExternalIPs.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-apiserver-arg:
+          - "enable-admission-plugins=DenyServiceExternalIPs"
         scored: true
 
       - id: 1.2.4
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: and
           test_items:
             - flag: "--kubelet-client-certificate"
             - flag: "--kubelet-client-key"
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection between the
-          apiserver and kubelets. Then, edit API server pod specification file
-          $apiserverconf on the control plane node and set the
-          kubelet client certificate and key parameters as below.
-          --kubelet-client-certificate=<path/to/client-certificate-file>
-          --kubelet-client-key=<path/to/client-key-file>
+          By default, K3s automatically provides the kubelet client certificate and key.
+          They are generated and located at /var/lib/rancher/k3s/server/tls/client-kube-apiserver.crt and /var/lib/rancher/k3s/server/tls/client-kube-apiserver.key
+          If for some reason you need to provide your own certificate and key, you can set the
+          the below parameters in the K3s config file /etc/rancher/k3s/config.yaml.
+          kube-apiserver-arg:
+          - "kubelet-client-certificate=<path/to/client-cert-file>"
+          - "kubelet-client-key=<path/to/client-key-file>"
         scored: true
 
       - id: 1.2.5
         text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
-        type: "skip"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
         tests:
           test_items:
             - flag: "--kubelet-certificate-authority"
         remediation: |
-          Follow the Kubernetes documentation and setup the TLS connection between
-          the apiserver and kubelets. Then, edit the API server pod specification file
-          $apiserverconf on the control plane node and set the
-          --kubelet-certificate-authority parameter to the path to the cert file for the certificate authority.
-          --kubelet-certificate-authority=<ca-string>
-          Permissive - When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
+          By default, K3s automatically provides the kubelet CA cert file, at /var/lib/rancher/k3s/server/tls/server-ca.crt.
+          If for some reason you need to provide your own ca certificate, look at using the k3s certificate command line tool.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "kubelet-certificate-authority=<path/to/ca-cert-file>"
         scored: true
 
       - id: 1.2.6
@@ -409,10 +410,10 @@ groups:
                 op: nothave
                 value: "AlwaysAllow"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --authorization-mode parameter to values other than AlwaysAllow.
-          One such example could be as below.
-          --authorization-mode=RBAC
+          By default, K3s does not set the --authorization-mode to AlwaysAllow.
+          If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-apiserver-arg:
+          - "authorization-mode=AlwaysAllow"
         scored: true
 
       - id: 1.2.7
@@ -425,9 +426,9 @@ groups:
                 op: has
                 value: "Node"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --authorization-mode parameter to a value that includes Node.
-          --authorization-mode=Node,RBAC
+          By default, K3s sets the --authorization-mode to Node and RBAC.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, 
+          ensure that you are not overriding authorization-mode.
         scored: true
 
       - id: 1.2.8
@@ -440,9 +441,9 @@ groups:
                 op: has
                 value: "RBAC"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --authorization-mode parameter to a value that includes RBAC,
-          for example `--authorization-mode=Node,RBAC`.
+          By default, K3s sets the --authorization-mode to Node and RBAC.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml,
+          ensure that you are not overriding authorization-mode.
         scored: true
 
       - id: 1.2.9
@@ -456,10 +457,10 @@ groups:
                 value: "EventRateLimit"
         remediation: |
           Follow the Kubernetes documentation and set the desired limits in a configuration file.
-          Then, edit the API server pod specification file $apiserverconf
-          and set the below parameters.
-          --enable-admission-plugins=...,EventRateLimit,...
-          --admission-control-config-file=<path/to/configuration/file>
+          Then, edit the K3s config file /etc/rancher/k3s/config.yaml and set the below parameters.
+          kube-apiserver-arg:
+          - "enable-admission-plugins=...,EventRateLimit,..."
+          - "admission-control-config-file=<path/to/configuration/file>"
         scored: false
 
       - id: 1.2.10
@@ -475,14 +476,15 @@ groups:
             - flag: "--enable-admission-plugins"
               set: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and either remove the --enable-admission-plugins parameter, or set it to a
-          value that does not include AlwaysAdmit.
+          By default, K3s does not set the --enable-admission-plugins to AlwaysAdmit.
+          If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-apiserver-arg:
+          - "enable-admission-plugins=AlwaysAdmit"
         scored: true
 
       - id: 1.2.11
         text: "Ensure that the admission control plugin AlwaysPullImages is set (Manual)"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -490,10 +492,13 @@ groups:
                 op: has
                 value: "AlwaysPullImages"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --enable-admission-plugins parameter to include
-          AlwaysPullImages.
-          --enable-admission-plugins=...,AlwaysPullImages,...
+          Permissive, per CIS guidelines,
+          "This setting could impact offline or isolated clusters, which have images pre-loaded and
+          do not have access to a registry to pull in-use images. This setting is not appropriate for
+          clusters which use this configuration."
+          Edit the K3s config file /etc/rancher/k3s/config.yaml and set the below parameter.
+          kube-apiserver-arg:
+          - "enable-admission-plugins=...,AlwaysPullImages,..."
         scored: false
 
       - id: 1.2.12
@@ -512,16 +517,13 @@ groups:
                 op: has
                 value: "PodSecurityPolicy"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --enable-admission-plugins parameter to include
-          SecurityContextDeny, unless PodSecurityPolicy is already in place.
-          --enable-admission-plugins=...,SecurityContextDeny,...
-          Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
+          Not Applicable.
+          Enabling Pod Security Policy is no longer supported on K3s v1.25+ and will cause applications to unexpectedly fail.
         scored: false
 
       - id: 1.2.13
         text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -532,15 +534,16 @@ groups:
             - flag: "--disable-admission-plugins"
               set: false
         remediation: |
+          By default, K3s does not set the --disable-admission-plugins to anything.
           Follow the documentation and create ServiceAccount objects as per your environment.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and ensure that the --disable-admission-plugins parameter is set to a
-          value that does not include ServiceAccount.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "disable-admission-plugins=ServiceAccount"
         scored: true
 
       - id: 1.2.14
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -551,9 +554,10 @@ groups:
             - flag: "--disable-admission-plugins"
               set: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --disable-admission-plugins parameter to
-          ensure it does not include NamespaceLifecycle.
+          By default, K3s does not set the --disable-admission-plugins to anything.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "disable-admission-plugins=...,NamespaceLifecycle,..."
         scored: true
 
       - id: 1.2.15
@@ -566,11 +570,11 @@ groups:
                 op: has
                 value: "NodeRestriction"
         remediation: |
-          Follow the Kubernetes documentation and configure NodeRestriction plug-in on kubelets.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --enable-admission-plugins parameter to a
-          value that includes NodeRestriction.
-          --enable-admission-plugins=...,NodeRestriction,...
+          By default, K3s sets the --enable-admission-plugins to NodeRestriction.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, check that you are not overriding the admission plugins.
+          If you are, include NodeRestriction in the list.
+          kube-apiserver-arg:
+          - "enable-admission-plugins=...,NodeRestriction,..."
         scored: true
 
       - id: 1.2.16
@@ -583,30 +587,28 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the below parameter.
-          --profiling=false
+          By default, K3s sets the --profiling argument to false.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "profiling=true"
         scored: true
 
       - id: 1.2.17
-        text: "Ensure that the --audit-log-path argument is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
-        type: "skip"
+        text: "Ensure that the --audit-log-path argument is set (Manual)"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--audit-log-path"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-path parameter to a suitable path and
+          Edit the K3s config file /etc/rancher/k3s/config.yaml and set the audit-log-path parameter to a suitable path and
           file where you would like audit logs to be written, for example,
-          --audit-log-path=/var/log/apiserver/audit.log
-          Permissive.
+          kube-apiserver-arg:
+          - "audit-log-path=/var/lib/rancher/k3s/server/logs/audit.log"
         scored: true
 
       - id: 1.2.18
-        text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
-        type: "skip"
+        text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Manual)"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--audit-log-maxage"
@@ -614,17 +616,15 @@ groups:
                 op: gte
                 value: 30
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-maxage parameter to 30
-          or as an appropriate number of days, for example,
-          --audit-log-maxage=30
-          Permissive.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and
+          set the audit-log-maxage parameter to 30 or as an appropriate number of days, for example,
+          kube-apiserver-arg:
+          - "audit-log-maxage=30"
         scored: true
 
       - id: 1.2.19
-        text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
-        type: "skip"
+        text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Manual)"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--audit-log-maxbackup"
@@ -632,17 +632,15 @@ groups:
                 op: gte
                 value: 10
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-maxbackup parameter to 10 or to an appropriate
-          value. For example,
-          --audit-log-maxbackup=10
-          Permissive.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and 
+          set the audit-log-maxbackup parameter to 10 or to an appropriate value. For example,
+          kube-apiserver-arg:
+          - "audit-log-maxbackup=10"
         scored: true
 
       - id: 1.2.20
-        text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
-        type: "skip"
+        text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Manual)"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--audit-log-maxsize"
@@ -650,29 +648,30 @@ groups:
                 op: gte
                 value: 100
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-maxsize parameter to an appropriate size in MB.
-          For example, to set it as 100 MB, --audit-log-maxsize=100
-          Permissive.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and 
+          set the audit-log-maxsize parameter to an appropriate size in MB. For example,
+          kube-apiserver-arg:
+          - "audit-log-maxsize=100"
         scored: true
 
       - id: 1.2.21
         text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
-        type: "skip"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--request-timeout"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          and set the below parameter as appropriate and if needed.
-          For example, --request-timeout=300s
-          Permissive.
+          Permissive, per CIS guidelines, 
+          "it is recommended to set this limit as appropriate and change the default limit of 60 seconds only if needed".
+          Edit the K3s config file /etc/rancher/k3s/config.yaml
+          and set the below parameter if needed. For example,
+          kube-apiserver-arg:
+          - "request-timeout=300s"
         scored: false
 
       - id: 1.2.22
         text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -683,25 +682,26 @@ groups:
                 op: eq
                 value: true
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the below parameter.
-          --service-account-lookup=true
-          Alternatively, you can delete the --service-account-lookup parameter from this file so
+          By default, K3s does not set the --service-account-lookup argument.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml and set the service-account-lookup. For example,
+          kube-apiserver-arg:
+          - "service-account-lookup=true"
+          Alternatively, you can delete the service-account-lookup parameter from this file so
           that the default takes effect.
         scored: true
 
       - id: 1.2.23
         text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
-        type: "skip"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--service-account-key-file"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --service-account-key-file parameter
-          to the public key file for service accounts. For example,
-          --service-account-key-file=<filename>
+          K3s automatically generates and sets the service account key file.
+          It is located at /var/lib/rancher/k3s/server/tls/service.key.
+          If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "service-account-key-file=<path>"
         scored: true
 
       - id: 1.2.24
@@ -715,11 +715,12 @@ groups:
             - flag: "--etcd-keyfile"
               set: true
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the etcd certificate and key file parameters.
-          --etcd-certfile=<path/to/client-certificate-file>
-          --etcd-keyfile=<path/to/client-key-file>
+          K3s automatically generates and sets the etcd certificate and key files.
+          They are located at /var/lib/rancher/k3s/server/tls/etcd/client.crt and /var/lib/rancher/k3s/server/tls/etcd/client.key.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "etcd-certfile=<path>"
+          - "etcd-keyfile=<path>"
         scored: true
 
       - id: 1.2.25
@@ -733,11 +734,12 @@ groups:
             - flag: "--tls-private-key-file"
               set: true
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the TLS certificate and private key file parameters.
-          --tls-cert-file=<path/to/tls-certificate-file>
-          --tls-private-key-file=<path/to/tls-key-file>
+          By default, K3s automatically generates and provides the TLS certificate and private key for the apiserver.
+          They are generated and located at /var/lib/rancher/k3s/server/tls/serving-kube-apiserver.crt and /var/lib/rancher/k3s/server/tls/serving-kube-apiserver.key
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "tls-cert-file=<path>"
+          - "tls-private-key-file=<path>"
         scored: true
 
       - id: 1.2.26
@@ -747,10 +749,12 @@ groups:
           test_items:
             - flag: "--client-ca-file"
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the client certificate authority file.
-          --client-ca-file=<path/to/client-ca-file>
+          By default, K3s automatically provides the client certificate authority file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/client-ca.crt.
+          If for some reason you need to provide your own ca certificate, look at using the k3s certificate command line tool.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "client-ca-file=<path>"
         scored: true
 
       - id: 1.2.27
@@ -760,33 +764,33 @@ groups:
           test_items:
             - flag: "--etcd-cafile"
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the etcd certificate authority file parameter.
-          --etcd-cafile=<path/to/ca-file>
+          By default, K3s automatically provides the etcd certificate authority file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/client-ca.crt.
+          If for some reason you need to provide your own ca certificate, look at using the k3s certificate command line tool.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "etcd-cafile=<path>"
         scored: true
 
       - id: 1.2.28
         text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
-        type: "skip"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'encryption-provider-config'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'encryption-provider-config'"
         tests:
           test_items:
             - flag: "--encryption-provider-config"
         remediation: |
-          Follow the Kubernetes documentation and configure a EncryptionConfig file.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --encryption-provider-config parameter to the path of that file.
-          For example, --encryption-provider-config=</path/to/EncryptionConfig/File>
-          Permissive - Enabling encryption changes how data can be recovered as data is encrypted.
+          K3s can be configured to use encryption providers to encrypt secrets at rest.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and set the below parameter.
+          secrets-encryption: true
+          Secrets encryption can then be managed with the k3s secrets-encrypt command line tool.
+          If needed, you can find the generated encryption config at /var/lib/rancher/k3s/server/cred/encryption-config.json.
         scored: false
 
       - id: 1.2.29
         text: "Ensure that encryption providers are appropriately configured (Manual)"
-        type: "skip"
         audit: |
-          ENCRYPTION_PROVIDER_CONFIG=$(ps -ef | grep $apiserverbin | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
-          if test -e $ENCRYPTION_PROVIDER_CONFIG; then grep -A1 'providers:' $ENCRYPTION_PROVIDER_CONFIG | tail -n1 | grep -o "[A-Za-z]*" | sed 's/^/provider=/'; fi
+          ENCRYPTION_PROVIDER_CONFIG=$(journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
+          if test -e $ENCRYPTION_PROVIDER_CONFIG; then grep -o 'providers\"\:\[.*\]' $ENCRYPTION_PROVIDER_CONFIG | grep -o "[A-Za-z]*" | head -2 | tail -1  | sed 's/^/provider=/'; fi
         tests:
           test_items:
             - flag: "provider"
@@ -794,9 +798,11 @@ groups:
                 op: valid_elements
                 value: "aescbc,kms,secretbox"
         remediation: |
-          Follow the Kubernetes documentation and configure a EncryptionConfig file.
-          In this file, choose aescbc, kms or secretbox as the encryption provider.
-          Permissive - Enabling encryption changes how data can be recovered as data is encrypted.
+          K3s can be configured to use encryption providers to encrypt secrets at rest. K3s will utilize the aescbc provider.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and set the below parameter.
+          secrets-encryption: true
+          Secrets encryption can then be managed with the k3s secrets-encrypt command line tool.
+          If needed, you can find the generated encryption config at /var/lib/rancher/k3s/server/cred/encryption-config.json
         scored: false
 
       - id: 1.2.30

--- a/package/cfg/k3s-cis-1.8-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/master.yaml
@@ -120,10 +120,7 @@ groups:
 
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Automated)"
-        type: "skip"
-        audit: |
-          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
-          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
+        audit: find /var/lib/cni/networks -type f ! -name lock 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
         use_multiple_values: true
         tests:
           test_items:
@@ -132,9 +129,10 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Not Applicable.
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 <path/to/cni/files>
+          By default, K3s sets the CNI file permissions to 600.
+          Note that for many CNIs, a lock file is created with permissions 750. This is expected and can be ignored.
+          If you modify your CNI configuration, ensure that the permissions are set to 600.
+          For example, chmod 600 /var/lib/cni/networks/<filename>
         scored: false
 
       - id: 1.1.10

--- a/package/cfg/k3s-cis-1.8-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/node.yaml
@@ -209,7 +209,7 @@ groups:
 
       - id: 4.2.4
         text: "Verify that the --read-only-port argument is set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           bin_op: or
@@ -236,7 +236,7 @@ groups:
 
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -259,7 +259,7 @@ groups:
 
       - id: 4.2.6
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --make-iptables-util-chains
@@ -282,7 +282,7 @@ groups:
 
       - id: 4.2.7
         text: "Ensure that the --hostname-override argument is not set (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -296,7 +296,7 @@ groups:
 
       - id: 4.2.8
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -321,7 +321,7 @@ groups:
 
       - id: 4.2.9
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --tls-cert-file
@@ -340,7 +340,7 @@ groups:
 
       - id: 4.2.10
         text: "Ensure that the --rotate-certificates argument is not set to false (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -363,7 +363,7 @@ groups:
 
       - id: 4.2.11
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
           bin_op: or
@@ -387,7 +387,7 @@ groups:
 
       - id: 4.2.12
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -408,7 +408,7 @@ groups:
 
       - id: 4.2.13
         text: "Ensure that a limit is set on pod PIDs (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.8-permissive/config.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/config.yaml
@@ -20,9 +20,14 @@ master:
   scheduler:
     bins:
       - containerd
+    kubeconfig:
+      - /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig
   controllermanager:
     bins:
       - containerd
+    kubeconfig:
+      - /var/lib/rancher/k3s/server/cred/controller.kubeconfig
+
   etcd:
     bins:
       - containerd

--- a/package/cfg/k3s-cis-1.8-permissive/controlplane.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/controlplane.yaml
@@ -37,7 +37,7 @@ groups:
     checks:
       - id: 3.2.1
         text: "Ensure that a minimal audit policy is created (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-policy-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-policy-file'"
         tests:
           test_items:
             - flag: "--audit-policy-file"

--- a/package/cfg/k3s-cis-1.8-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/master.yaml
@@ -159,7 +159,7 @@ groups:
         audit: |
           if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
             stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
-          else 
+          else
             echo "permissions=700"
           fi
         tests:
@@ -433,7 +433,7 @@ groups:
                 value: "Node"
         remediation: |
           By default, K3s sets the --authorization-mode to Node and RBAC.
-          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, 
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml,
           ensure that you are not overriding authorization-mode.
         scored: true
 
@@ -643,7 +643,7 @@ groups:
                 op: gte
                 value: 10
         remediation: |
-          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and 
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and
           set the audit-log-maxbackup parameter to 10 or to an appropriate value. For example,
           kube-apiserver-arg:
           - "audit-log-maxbackup=10"
@@ -661,7 +661,7 @@ groups:
                 op: gte
                 value: 100
         remediation: |
-          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and 
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and
           set the audit-log-maxsize parameter to an appropriate size in MB. For example,
           kube-apiserver-arg:
           - "audit-log-maxsize=100"
@@ -675,7 +675,7 @@ groups:
           test_items:
             - flag: "--request-timeout"
         remediation: |
-          Permissive, per CIS guidelines, 
+          Permissive, per CIS guidelines,
           "it is recommended to set this limit as appropriate and change the default limit of 60 seconds only if needed".
           Edit the K3s config file /etc/rancher/k3s/config.yaml
           and set the below parameter if needed. For example,
@@ -724,7 +724,7 @@ groups:
         audit: |
           if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
             journalctl -D /var/log/journal -u k3s | grep -m1 'Running kube-apiserver' | tail -n1
-          else 
+          else
             echo "--etcd-certfile AND --etcd-keyfile"
           fi
         tests:
@@ -856,9 +856,10 @@ groups:
           test_items:
             - flag: "--terminated-pod-gc-threshold"
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --terminated-pod-gc-threshold to an appropriate threshold,
-          for example, --terminated-pod-gc-threshold=10
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node
+          and set the --terminated-pod-gc-threshold to an appropriate threshold,
+          kube-controller-manager-arg:
+          - "terminated-pod-gc-threshold=10"
         scored: false
 
       - id: 1.3.2
@@ -871,9 +872,10 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the below parameter.
-          --profiling=false
+          By default, K3s sets the --profiling argument to false.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+          - "profiling=true"
         scored: true
 
       - id: 1.3.3
@@ -886,9 +888,10 @@ groups:
                 op: noteq
                 value: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node to set the below parameter.
-          --use-service-account-credentials=true
+          By default, K3s sets the --use-service-account-credentials argument to true.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+          - "use-service-account-credentials=false"
         scored: true
 
       - id: 1.3.4
@@ -898,10 +901,11 @@ groups:
           test_items:
             - flag: "--service-account-private-key-file"
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --service-account-private-key-file parameter
-          to the private key file for service accounts.
-          --service-account-private-key-file=<filename>
+          By default, K3s automatically provides the service account private key file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/service.current.key.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+          - "service-account-private-key-file=<path>"
         scored: true
 
       - id: 1.3.5
@@ -911,15 +915,17 @@ groups:
           test_items:
             - flag: "--root-ca-file"
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --root-ca-file parameter to the certificate bundle file`.
-          --root-ca-file=<path/to/file>
+          By default, K3s automatically provides the root CA file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/server-ca.crt.
+          If for some reason you need to provide your own ca certificate, look at using the k3s certificate command line tool.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+          - "root-ca-file=<path>"
         scored: true
 
       - id: 1.3.6
         text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
-        type: "skip"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'RotateKubeletServerCertificate'"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -931,10 +937,11 @@ groups:
             - flag: "--feature-gates"
               set: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and set the --feature-gates parameter to include RotateKubeletServerCertificate=true.
-          --feature-gates=RotateKubeletServerCertificate=true
-          Not Applicable.
+          By default, K3s does not set the RotateKubeletServerCertificate feature gate.
+          If you have enabled this feature gate, you should remove it.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-controller-manager-arg:
+          - "feature-gate=RotateKubeletServerCertificate"
         scored: true
 
       - id: 1.3.7
@@ -951,8 +958,10 @@ groups:
             - flag: "--bind-address"
               set: false
         remediation: |
-          Edit the Controller Manager pod specification file $controllermanagerconf
-          on the control plane node and ensure the correct value for the --bind-address parameter
+          By default, K3s sets the --bind-address argument to 127.0.0.1
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-controller-manager-arg:
+          - "bind-address=<IP>"
         scored: true
 
   - id: 1.4
@@ -969,9 +978,10 @@ groups:
                 value: false
               set: true
         remediation: |
-          Edit the Scheduler pod specification file $schedulerconf file
-          on the control plane node and set the below parameter.
-          --profiling=false
+          By default, K3s sets the --profiling argument to false.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-scheduler-arg:
+          - "profiling=true"
         scored: true
 
       - id: 1.4.2
@@ -988,6 +998,8 @@ groups:
             - flag: "--bind-address"
               set: false
         remediation: |
-          Edit the Scheduler pod specification file $schedulerconf
-          on the control plane node and ensure the correct value for the --bind-address parameter
+          By default, K3s sets the --bind-address argument to 127.0.0.1
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-scheduler-arg:
+          - "bind-address=<IP>"
         scored: true

--- a/package/cfg/k3s-cis-1.8-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/master.yaml
@@ -156,7 +156,12 @@ groups:
 
       - id: 1.1.11
         text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: "check_for_k3s_etcd.sh 1.1.11"
+        audit: |
+          if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
+            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
+          else 
+            echo "permissions=700"
+          fi
         tests:
           test_items:
             - flag: "permissions"
@@ -716,7 +721,12 @@ groups:
 
       - id: 1.2.24
         text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
-        audit: "check_for_k3s_etcd.sh 1.2.29"
+        audit: |
+          if [ "$(journalctl -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
+            journalctl -D /var/log/journal -u k3s | grep -m1 'Running kube-apiserver' | tail -n1
+          else 
+            echo "--etcd-certfile AND --etcd-keyfile"
+          fi
         tests:
           bin_op: and
           test_items:

--- a/package/cfg/k3s-cis-1.8-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/master.yaml
@@ -326,7 +326,7 @@ groups:
     checks:
       - id: 1.2.1
         text: "Ensure that the --anonymous-auth argument is set to false (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth'"
         tests:
           test_items:
             - flag: "--anonymous-auth"
@@ -342,7 +342,7 @@ groups:
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--token-auth-file"
@@ -356,7 +356,7 @@ groups:
 
       - id: 1.2.3
         text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -376,7 +376,7 @@ groups:
 
       - id: 1.2.4
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
         tests:
           bin_op: and
           test_items:
@@ -394,7 +394,7 @@ groups:
 
       - id: 1.2.5
         text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
         tests:
           test_items:
             - flag: "--kubelet-certificate-authority"
@@ -408,7 +408,7 @@ groups:
 
       - id: 1.2.6
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -424,7 +424,7 @@ groups:
 
       - id: 1.2.7
         text: "Ensure that the --authorization-mode argument includes Node (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -439,7 +439,7 @@ groups:
 
       - id: 1.2.8
         text: "Ensure that the --authorization-mode argument includes RBAC (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'authorization-mode'"
         tests:
           test_items:
             - flag: "--authorization-mode"
@@ -454,7 +454,7 @@ groups:
 
       - id: 1.2.9
         text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -471,7 +471,7 @@ groups:
 
       - id: 1.2.10
         text: "Ensure that the admission control plugin AlwaysAdmit is not set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           bin_op: or
           test_items:
@@ -529,7 +529,7 @@ groups:
 
       - id: 1.2.13
         text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -549,7 +549,7 @@ groups:
 
       - id: 1.2.14
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -568,7 +568,7 @@ groups:
 
       - id: 1.2.15
         text: "Ensure that the admission control plugin NodeRestriction is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -585,7 +585,7 @@ groups:
 
       - id: 1.2.16
         text: "Ensure that the --profiling argument is set to false (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'profiling'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'profiling'"
         tests:
           test_items:
             - flag: "--profiling"
@@ -601,8 +601,7 @@ groups:
 
       - id: 1.2.17
         text: "Ensure that the --audit-log-path argument is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
-        type: "skip"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--audit-log-path"
@@ -612,11 +611,11 @@ groups:
           kube-apiserver-arg:
           - "audit-log-path=/var/lib/rancher/k3s/server/logs/audit.log"
           Permissive.
-        scored: true
+        scored: false
 
       - id: 1.2.18
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -634,7 +633,7 @@ groups:
 
       - id: 1.2.19
         text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -652,7 +651,7 @@ groups:
 
       - id: 1.2.20
         text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -670,7 +669,7 @@ groups:
 
       - id: 1.2.21
         text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--request-timeout"
@@ -685,7 +684,7 @@ groups:
 
       - id: 1.2.22
         text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -706,7 +705,7 @@ groups:
 
       - id: 1.2.23
         text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -764,7 +763,7 @@ groups:
 
       - id: 1.2.26
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'client-ca-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'client-ca-file'"
         tests:
           test_items:
             - flag: "--client-ca-file"
@@ -779,7 +778,7 @@ groups:
 
       - id: 1.2.27
         text: "Ensure that the --etcd-cafile argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-cafile'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'etcd-cafile'"
         tests:
           test_items:
             - flag: "--etcd-cafile"
@@ -795,7 +794,7 @@ groups:
       - id: 1.2.28
         text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
         type: "skip"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'encryption-provider-config'"
+        audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'encryption-provider-config'"
         tests:
           test_items:
             - flag: "--encryption-provider-config"
@@ -851,7 +850,7 @@ groups:
     checks:
       - id: 1.3.1
         text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'terminated-pod-gc-threshold'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'terminated-pod-gc-threshold'"
         tests:
           test_items:
             - flag: "--terminated-pod-gc-threshold"
@@ -864,7 +863,7 @@ groups:
 
       - id: 1.3.2
         text: "Ensure that the --profiling argument is set to false (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'profiling'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'profiling'"
         tests:
           test_items:
             - flag: "--profiling"
@@ -880,7 +879,7 @@ groups:
 
       - id: 1.3.3
         text: "Ensure that the --use-service-account-credentials argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'use-service-account-credentials'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'use-service-account-credentials'"
         tests:
           test_items:
             - flag: "--use-service-account-credentials"
@@ -896,7 +895,7 @@ groups:
 
       - id: 1.3.4
         text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'service-account-private-key-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'service-account-private-key-file'"
         tests:
           test_items:
             - flag: "--service-account-private-key-file"
@@ -910,7 +909,7 @@ groups:
 
       - id: 1.3.5
         text: "Ensure that the --root-ca-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'root-ca-file'"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'root-ca-file'"
         tests:
           test_items:
             - flag: "--root-ca-file"
@@ -925,7 +924,7 @@ groups:
 
       - id: 1.3.6
         text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-controller-manager' | tail -n1"
+        audit: "journalctl -u k3s | grep 'Running kube-controller-manager' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -986,7 +985,7 @@ groups:
 
       - id: 1.4.2
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'bind-address'"
+        audit: "journalctl -u k3s | grep 'Running kube-scheduler' | tail -n1 | grep 'bind-address'"
         tests:
           bin_op: or
           test_items:

--- a/package/cfg/k3s-cis-1.8-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/master.yaml
@@ -19,10 +19,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the
-          control plane node.
-          For example, chmod 600 $apiserverconf
           Not Applicable.
+          K3s embeds the api server within the k3s process. There is no API server pod specification file.
         scored: true
 
       - id: 1.1.2
@@ -33,9 +31,8 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root $apiserverconf
           Not Applicable.
+          K3s embeds the api server within the k3s process. There is no API server pod specification file.
         scored: true
 
       - id: 1.1.3
@@ -49,9 +46,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 $controllermanagerconf
           Not Applicable.
+          K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
         scored: true
 
       - id: 1.1.4
@@ -62,9 +58,8 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root $controllermanagerconf
           Not Applicable.
+          K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
         scored: true
 
       - id: 1.1.5
@@ -78,9 +73,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 $schedulerconf
           Not Applicable.
+          K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
         scored: true
 
       - id: 1.1.6
@@ -91,9 +85,8 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root $schedulerconf
           Not Applicable.
+          K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
         scored: true
 
       - id: 1.1.7
@@ -108,10 +101,8 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chmod 600 $etcdconf
           Not Applicable.
+          K3s embeds etcd within the k3s process. There is no etcd pod specification file.
         scored: true
 
       - id: 1.1.8
@@ -123,10 +114,8 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chown root:root $etcdconf
           Not Applicable.
+          K3s embeds etcd within the k3s process. There is no etcd pod specification file.
         scored: true
 
       - id: 1.1.9
@@ -143,9 +132,9 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
+          Not Applicable.
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chmod 600 <path/to/cni/files>
-          Not Applicable.
         scored: false
 
       - id: 1.1.10
@@ -159,10 +148,10 @@ groups:
           test_items:
             - flag: "root:root"
         remediation: |
+          Not Applicable.
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chown root:root <path/to/cni/files>
-          Not Applicable.
         scored: false
 
       - id: 1.1.11
@@ -170,11 +159,10 @@ groups:
         audit: "check_for_k3s_etcd.sh 1.1.11"
         tests:
           test_items:
-            - flag: "700"
+            - flag: "permissions"
               compare:
-                op: eq
+                op: bitmask
                 value: "700"
-              set: true
         remediation: |
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.
@@ -190,11 +178,9 @@ groups:
           test_items:
             - flag: "etcd:etcd"
         remediation: |
-          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-          from the command 'ps -ef | grep etcd'.
-          Run the below command (based on the etcd data directory found above).
-          For example, chown etcd:etcd /var/lib/etcd
           Not Applicable.
+          For K3s, etcd is embedded within the k3s process. There is no separate etcd process.
+          Therefore the etcd data directory ownership is managed by the k3s process and should be root:root.
         scored: true
 
       - id: 1.1.13
@@ -224,12 +210,12 @@ groups:
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root /etc/kubernetes/admin.conf
+          For example, chown root:root /var/lib/rancher/k3s/server/cred/admin.kubeconfig
         scored: true
 
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c permissions=%a $schedulerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -244,7 +230,7 @@ groups:
 
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; then stat -c %U:%G /var/lib/rancher/k3s/server/cred/scheduler.kubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e $schedulerkubeconfig; then stat -c %U:%G $schedulerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "root:root"
@@ -256,7 +242,7 @@ groups:
 
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/controller.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/controller.kubeconfig; fi'"
+        audit: "/bin/sh -c 'if test -e $controllermanagerkubeconfig; then stat -c permissions=%a $controllermanagerkubeconfig; fi'"
         tests:
           test_items:
             - flag: "permissions"
@@ -271,7 +257,7 @@ groups:
 
       - id: 1.1.18
         text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
-        audit: "stat -c %U:%G /var/lib/rancher/k3s/server/cred/controller.kubeconfig"
+        audit: "stat -c %U:%G $controllermanagerkubeconfig"
         tests:
           test_items:
             - flag: "root:root"
@@ -300,7 +286,7 @@ groups:
 
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"
-        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' | xargs stat -c permissions=%a"
+        audit: "/bin/sh -c 'stat -c permissions=%a /var/lib/rancher/k3s/server/tls/*.crt'"
         use_multiple_values: true
         tests:
           test_items:
@@ -311,12 +297,12 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          find /var/lib/rancher/k3s/server/tls/ -type f -name '*.crt' -exec chmod -v 600 {} +
+          chmod -R 600 /var/lib/rancher/k3s/server/tls/*.crt
         scored: false
 
       - id: 1.1.21
-        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
-        audit: "find /var/lib/rancher/k3s/server/tls/ -type f -name '*.key' | xargs stat -c permissions=%a"
+        text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Automated)"
+        audit: "/bin/sh -c 'stat -c permissions=%a /var/lib/rancher/k3s/server/tls/*.key'"
         use_multiple_values: true
         tests:
           test_items:
@@ -327,7 +313,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the master node.
           For example,
-          find /var/lib/rancher/k3s/server/tls/ -type f -name "*.crt" -exec chmod -v 600 {} +
+          chmod -R 600 /var/lib/rancher/k3s/server/tls/*.key
         scored: false
 
   - id: 1.2

--- a/package/cfg/k3s-cis-1.8-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/master.yaml
@@ -185,7 +185,7 @@ groups:
 
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/admin.kubeconfig'"
+        audit: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/server/cred/admin.kubeconfig; then stat -c permissions=%a /var/lib/rancher/k3s/server/cred/admin.kubeconfig; fi'"
         type: "skip"
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.8-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/master.yaml
@@ -20,7 +20,7 @@ groups:
                 value: "600"
         remediation: |
           Not Applicable.
-          K3s embeds the api server within the k3s process. There is no API server pod specification file.
+          By default, K3s embeds the api server within the k3s process. There is no API server pod specification file.
         scored: true
 
       - id: 1.1.2
@@ -32,7 +32,7 @@ groups:
             - flag: "root:root"
         remediation: |
           Not Applicable.
-          K3s embeds the api server within the k3s process. There is no API server pod specification file.
+          By default, K3s embeds the api server within the k3s process. There is no API server pod specification file.
         scored: true
 
       - id: 1.1.3
@@ -47,7 +47,7 @@ groups:
                 value: "600"
         remediation: |
           Not Applicable.
-          K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
+          By default, K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
         scored: true
 
       - id: 1.1.4
@@ -59,7 +59,7 @@ groups:
             - flag: "root:root"
         remediation: |
           Not Applicable.
-          K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
+          By default, K3s embeds the controller manager within the k3s process. There is no controller manager pod specification file.
         scored: true
 
       - id: 1.1.5
@@ -74,7 +74,7 @@ groups:
                 value: "600"
         remediation: |
           Not Applicable.
-          K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
+          By default, K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
         scored: true
 
       - id: 1.1.6
@@ -86,7 +86,7 @@ groups:
             - flag: "root:root"
         remediation: |
           Not Applicable.
-          K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
+          By default, K3s embeds the scheduler within the k3s process. There is no scheduler pod specification file.
         scored: true
 
       - id: 1.1.7
@@ -102,7 +102,7 @@ groups:
                 value: "600"
         remediation: |
           Not Applicable.
-          K3s embeds etcd within the k3s process. There is no etcd pod specification file.
+          By default, K3s embeds etcd within the k3s process. There is no etcd pod specification file.
         scored: true
 
       - id: 1.1.8
@@ -115,7 +115,7 @@ groups:
             - flag: "root:root"
         remediation: |
           Not Applicable.
-          K3s embeds etcd within the k3s process. There is no etcd pod specification file.
+          By default, K3s embeds etcd within the k3s process. There is no etcd pod specification file.
         scored: true
 
       - id: 1.1.9
@@ -323,7 +323,7 @@ groups:
     text: "API Server"
     checks:
       - id: 1.2.1
-        text: "Ensure that the --anonymous-auth argument is set to false (Manual)"
+        text: "Ensure that the --anonymous-auth argument is set to false (Automated)"
         audit: "journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'anonymous-auth'"
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.8-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/master.yaml
@@ -329,27 +329,29 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the below parameter.
-          --anonymous-auth=false
+          By default, K3s sets the --anonymous-auth argument to false. If it is set to true,
+          edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
+          kube-apiserver-arg:
+            - "anonymous-auth=true"
         scored: false
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--token-auth-file"
               set: false
         remediation: |
-          Follow the documentation and configure alternate mechanisms for authentication. Then,
-          edit the API server pod specification file $apiserverconf
-          on the control plane node and remove the --token-auth-file=<filename> parameter.
+          Follow the documentation and configure alternate mechanisms for authentication.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
+          kube-apiserver-arg:
+          - "token-auth-file=<path>".
         scored: true
 
       - id: 1.2.3
         text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -361,9 +363,10 @@ groups:
             - flag: "--enable-admission-plugins"
               set: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and remove the `DenyServiceExternalIPs`
-          from enabled admission plugins.
+          By default, K3s does not set DenyServiceExternalIPs.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-apiserver-arg:
+          - "enable-admission-plugins=DenyServiceExternalIPs"
         scored: true
 
       - id: 1.2.4
@@ -375,28 +378,27 @@ groups:
             - flag: "--kubelet-client-certificate"
             - flag: "--kubelet-client-key"
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection between the
-          apiserver and kubelets. Then, edit API server pod specification file
-          $apiserverconf on the control plane node and set the
-          kubelet client certificate and key parameters as below.
-          --kubelet-client-certificate=<path/to/client-certificate-file>
-          --kubelet-client-key=<path/to/client-key-file>
+          By default, K3s automatically provides the kubelet client certificate and key.
+          They are generated and located at /var/lib/rancher/k3s/server/tls/client-kube-apiserver.crt and /var/lib/rancher/k3s/server/tls/client-kube-apiserver.key
+          If for some reason you need to provide your own certificate and key, you can set the
+          the below parameters in the K3s config file /etc/rancher/k3s/config.yaml.
+          kube-apiserver-arg:
+          - "kubelet-client-certificate=<path/to/client-cert-file>"
+          - "kubelet-client-key=<path/to/client-key-file>"
         scored: true
 
       - id: 1.2.5
         text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
-        type: "skip"
-        audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'kubelet-certificate-authority'"
         tests:
           test_items:
             - flag: "--kubelet-certificate-authority"
         remediation: |
-          Follow the Kubernetes documentation and setup the TLS connection between
-          the apiserver and kubelets. Then, edit the API server pod specification file
-          $apiserverconf on the control plane node and set the
-          --kubelet-certificate-authority parameter to the path to the cert file for the certificate authority.
-          --kubelet-certificate-authority=<ca-string>
-          Permissive - When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
+          By default, K3s automatically provides the kubelet CA cert file, at /var/lib/rancher/k3s/server/tls/server-ca.crt.
+          If for some reason you need to provide your own ca certificate, look at using the k3s certificate command line tool.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "kubelet-certificate-authority=<path/to/ca-cert-file>"
         scored: true
 
       - id: 1.2.6
@@ -409,10 +411,10 @@ groups:
                 op: nothave
                 value: "AlwaysAllow"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --authorization-mode parameter to values other than AlwaysAllow.
-          One such example could be as below.
-          --authorization-mode=RBAC
+          By default, K3s does not set the --authorization-mode to AlwaysAllow.
+          If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-apiserver-arg:
+          - "authorization-mode=AlwaysAllow"
         scored: true
 
       - id: 1.2.7
@@ -425,9 +427,9 @@ groups:
                 op: has
                 value: "Node"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --authorization-mode parameter to a value that includes Node.
-          --authorization-mode=Node,RBAC
+          By default, K3s sets the --authorization-mode to Node and RBAC.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, 
+          ensure that you are not overriding authorization-mode.
         scored: true
 
       - id: 1.2.8
@@ -440,9 +442,9 @@ groups:
                 op: has
                 value: "RBAC"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --authorization-mode parameter to a value that includes RBAC,
-          for example `--authorization-mode=Node,RBAC`.
+          By default, K3s sets the --authorization-mode to Node and RBAC.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml,
+          ensure that you are not overriding authorization-mode.
         scored: true
 
       - id: 1.2.9
@@ -456,10 +458,10 @@ groups:
                 value: "EventRateLimit"
         remediation: |
           Follow the Kubernetes documentation and set the desired limits in a configuration file.
-          Then, edit the API server pod specification file $apiserverconf
-          and set the below parameters.
-          --enable-admission-plugins=...,EventRateLimit,...
-          --admission-control-config-file=<path/to/configuration/file>
+          Then, edit the K3s config file /etc/rancher/k3s/config.yaml and set the below parameters.
+          kube-apiserver-arg:
+          - "enable-admission-plugins=...,EventRateLimit,..."
+          - "admission-control-config-file=<path/to/configuration/file>"
         scored: false
 
       - id: 1.2.10
@@ -475,9 +477,10 @@ groups:
             - flag: "--enable-admission-plugins"
               set: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and either remove the --enable-admission-plugins parameter, or set it to a
-          value that does not include AlwaysAdmit.
+          By default, K3s does not set the --enable-admission-plugins to AlwaysAdmit.
+          If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          kube-apiserver-arg:
+          - "enable-admission-plugins=AlwaysAdmit"
         scored: true
 
       - id: 1.2.11
@@ -490,10 +493,13 @@ groups:
                 op: has
                 value: "AlwaysPullImages"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --enable-admission-plugins parameter to include
-          AlwaysPullImages.
-          --enable-admission-plugins=...,AlwaysPullImages,...
+          Permissive, per CIS guidelines,
+          "This setting could impact offline or isolated clusters, which have images pre-loaded and
+          do not have access to a registry to pull in-use images. This setting is not appropriate for
+          clusters which use this configuration."
+          Edit the K3s config file /etc/rancher/k3s/config.yaml and set the below parameter.
+          kube-apiserver-arg:
+          - "enable-admission-plugins=...,AlwaysPullImages,..."
         scored: false
 
       - id: 1.2.12
@@ -512,16 +518,13 @@ groups:
                 op: has
                 value: "PodSecurityPolicy"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --enable-admission-plugins parameter to include
-          SecurityContextDeny, unless PodSecurityPolicy is already in place.
-          --enable-admission-plugins=...,SecurityContextDeny,...
-          Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
+          Not Applicable.
+          Enabling Pod Security Policy is no longer supported on K3s v1.25+ and will cause applications to unexpectedly fail.
         scored: false
 
       - id: 1.2.13
         text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -532,15 +535,16 @@ groups:
             - flag: "--disable-admission-plugins"
               set: false
         remediation: |
+          By default, K3s does not set the --disable-admission-plugins to anything.
           Follow the documentation and create ServiceAccount objects as per your environment.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and ensure that the --disable-admission-plugins parameter is set to a
-          value that does not include ServiceAccount.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "disable-admission-plugins=ServiceAccount"
         scored: true
 
       - id: 1.2.14
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -551,9 +555,10 @@ groups:
             - flag: "--disable-admission-plugins"
               set: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --disable-admission-plugins parameter to
-          ensure it does not include NamespaceLifecycle.
+          By default, K3s does not set the --disable-admission-plugins to anything.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "disable-admission-plugins=...,NamespaceLifecycle,..."
         scored: true
 
       - id: 1.2.15
@@ -566,11 +571,11 @@ groups:
                 op: has
                 value: "NodeRestriction"
         remediation: |
-          Follow the Kubernetes documentation and configure NodeRestriction plug-in on kubelets.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --enable-admission-plugins parameter to a
-          value that includes NodeRestriction.
-          --enable-admission-plugins=...,NodeRestriction,...
+          By default, K3s sets the --enable-admission-plugins to NodeRestriction.
+          If using the K3s config file /etc/rancher/k3s/config.yaml, check that you are not overriding the admission plugins.
+          If you are, include NodeRestriction in the list.
+          kube-apiserver-arg:
+          - "enable-admission-plugins=...,NodeRestriction,..."
         scored: true
 
       - id: 1.2.16
@@ -583,29 +588,30 @@ groups:
                 op: eq
                 value: false
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the below parameter.
-          --profiling=false
+          By default, K3s sets the --profiling argument to false.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "profiling=true"
         scored: true
 
       - id: 1.2.17
         text: "Ensure that the --audit-log-path argument is set (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
             - flag: "--audit-log-path"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-path parameter to a suitable path and
+          Edit the K3s config file /etc/rancher/k3s/config.yaml and set the audit-log-path parameter to a suitable path and
           file where you would like audit logs to be written, for example,
-          --audit-log-path=/var/log/apiserver/audit.log
+          kube-apiserver-arg:
+          - "audit-log-path=/var/lib/rancher/k3s/server/logs/audit.log"
           Permissive.
         scored: true
 
       - id: 1.2.18
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -614,16 +620,16 @@ groups:
                 op: gte
                 value: 30
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-maxage parameter to 30
-          or as an appropriate number of days, for example,
-          --audit-log-maxage=30
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and
+          set the audit-log-maxage parameter to 30 or as an appropriate number of days, for example,
+          kube-apiserver-arg:
+          - "audit-log-maxage=30"
           Permissive.
         scored: true
 
       - id: 1.2.19
         text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -632,16 +638,16 @@ groups:
                 op: gte
                 value: 10
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-maxbackup parameter to 10 or to an appropriate
-          value. For example,
-          --audit-log-maxbackup=10
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and 
+          set the audit-log-maxbackup parameter to 10 or to an appropriate value. For example,
+          kube-apiserver-arg:
+          - "audit-log-maxbackup=10"
           Permissive.
         scored: true
 
       - id: 1.2.20
         text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
@@ -650,29 +656,31 @@ groups:
                 op: gte
                 value: 100
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --audit-log-maxsize parameter to an appropriate size in MB.
-          For example, to set it as 100 MB, --audit-log-maxsize=100
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and 
+          set the audit-log-maxsize parameter to an appropriate size in MB. For example,
+          kube-apiserver-arg:
+          - "audit-log-maxsize=100"
           Permissive.
         scored: true
 
       - id: 1.2.21
         text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
-        type: "skip"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:
             - flag: "--request-timeout"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          and set the below parameter as appropriate and if needed.
-          For example, --request-timeout=300s
-          Permissive.
+          Permissive, per CIS guidelines, 
+          "it is recommended to set this limit as appropriate and change the default limit of 60 seconds only if needed".
+          Edit the K3s config file /etc/rancher/k3s/config.yaml
+          and set the below parameter if needed. For example,
+          kube-apiserver-arg:
+          - "request-timeout=300s"
         scored: false
 
       - id: 1.2.22
         text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           bin_op: or
           test_items:
@@ -683,25 +691,27 @@ groups:
                 op: eq
                 value: true
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the below parameter.
-          --service-account-lookup=true
-          Alternatively, you can delete the --service-account-lookup parameter from this file so
+          By default, K3s does not set the --service-account-lookup argument.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml and set the service-account-lookup. For example,
+          kube-apiserver-arg:
+          - "service-account-lookup=true"
+          Alternatively, you can delete the service-account-lookup parameter from this file so
           that the default takes effect.
         scored: true
 
       - id: 1.2.23
         text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
-        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -v grep"
+        audit: "journalctl -D /var/log/journal  -u k3s | grep 'Running kube-apiserver' | tail -n1"
         type: "skip"
         tests:
           test_items:
             - flag: "--service-account-key-file"
         remediation: |
-          Edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --service-account-key-file parameter
-          to the public key file for service accounts. For example,
-          --service-account-key-file=<filename>
+          K3s automatically generates and sets the service account key file.
+          It is located at /var/lib/rancher/k3s/server/tls/service.key.
+          If this check fails, edit K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "service-account-key-file=<path>"
         scored: true
 
       - id: 1.2.24
@@ -715,11 +725,12 @@ groups:
             - flag: "--etcd-keyfile"
               set: true
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the etcd certificate and key file parameters.
-          --etcd-certfile=<path/to/client-certificate-file>
-          --etcd-keyfile=<path/to/client-key-file>
+          K3s automatically generates and sets the etcd certificate and key files.
+          They are located at /var/lib/rancher/k3s/server/tls/etcd/client.crt and /var/lib/rancher/k3s/server/tls/etcd/client.key.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "etcd-certfile=<path>"
+          - "etcd-keyfile=<path>"
         scored: true
 
       - id: 1.2.25
@@ -733,11 +744,12 @@ groups:
             - flag: "--tls-private-key-file"
               set: true
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the TLS certificate and private key file parameters.
-          --tls-cert-file=<path/to/tls-certificate-file>
-          --tls-private-key-file=<path/to/tls-key-file>
+          By default, K3s automatically generates and provides the TLS certificate and private key for the apiserver.
+          They are generated and located at /var/lib/rancher/k3s/server/tls/serving-kube-apiserver.crt and /var/lib/rancher/k3s/server/tls/serving-kube-apiserver.key
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "tls-cert-file=<path>"
+          - "tls-private-key-file=<path>"
         scored: true
 
       - id: 1.2.26
@@ -747,10 +759,12 @@ groups:
           test_items:
             - flag: "--client-ca-file"
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection on the apiserver.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the client certificate authority file.
-          --client-ca-file=<path/to/client-ca-file>
+          By default, K3s automatically provides the client certificate authority file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/client-ca.crt.
+          If for some reason you need to provide your own ca certificate, look at using the k3s certificate command line tool.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "client-ca-file=<path>"
         scored: true
 
       - id: 1.2.27
@@ -760,10 +774,12 @@ groups:
           test_items:
             - flag: "--etcd-cafile"
         remediation: |
-          Follow the Kubernetes documentation and set up the TLS connection between the apiserver and etcd.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the etcd certificate authority file parameter.
-          --etcd-cafile=<path/to/ca-file>
+          By default, K3s automatically provides the etcd certificate authority file.
+          It is generated and located at /var/lib/rancher/k3s/server/tls/client-ca.crt.
+          If for some reason you need to provide your own ca certificate, look at using the k3s certificate command line tool.
+          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove any lines like below.
+          kube-apiserver-arg:
+          - "etcd-cafile=<path>"
         scored: true
 
       - id: 1.2.28
@@ -774,10 +790,11 @@ groups:
           test_items:
             - flag: "--encryption-provider-config"
         remediation: |
-          Follow the Kubernetes documentation and configure a EncryptionConfig file.
-          Then, edit the API server pod specification file $apiserverconf
-          on the control plane node and set the --encryption-provider-config parameter to the path of that file.
-          For example, --encryption-provider-config=</path/to/EncryptionConfig/File>
+          K3s can be configured to use encryption providers to encrypt secrets at rest.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and set the below parameter.
+          secrets-encryption: true
+          Secrets encryption can then be managed with the k3s secrets-encrypt command line tool.
+          If needed, you can find the generated encryption config at /var/lib/rancher/k3s/server/cred/encryption-config.json.
           Permissive - Enabling encryption changes how data can be recovered as data is encrypted.
         scored: false
 
@@ -785,8 +802,8 @@ groups:
         text: "Ensure that encryption providers are appropriately configured (Manual)"
         type: "skip"
         audit: |
-          ENCRYPTION_PROVIDER_CONFIG=$(ps -ef | grep $apiserverbin | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
-          if test -e $ENCRYPTION_PROVIDER_CONFIG; then grep -A1 'providers:' $ENCRYPTION_PROVIDER_CONFIG | tail -n1 | grep -o "[A-Za-z]*" | sed 's/^/provider=/'; fi
+          ENCRYPTION_PROVIDER_CONFIG=$(journalctl -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
+          if test -e $ENCRYPTION_PROVIDER_CONFIG; then grep -o 'providers\"\:\[.*\]' $ENCRYPTION_PROVIDER_CONFIG | grep -o "[A-Za-z]*" | head -2 | tail -1  | sed 's/^/provider=/'; fi
         tests:
           test_items:
             - flag: "provider"
@@ -794,8 +811,11 @@ groups:
                 op: valid_elements
                 value: "aescbc,kms,secretbox"
         remediation: |
-          Follow the Kubernetes documentation and configure a EncryptionConfig file.
-          In this file, choose aescbc, kms or secretbox as the encryption provider.
+          K3s can be configured to use encryption providers to encrypt secrets at rest. K3s will utilize the aescbc provider.
+          Edit the K3s config file /etc/rancher/k3s/config.yaml on the control plane node and set the below parameter.
+          secrets-encryption: true
+          Secrets encryption can then be managed with the k3s secrets-encrypt command line tool.
+          If needed, you can find the generated encryption config at /var/lib/rancher/k3s/server/cred/encryption-config.json
           Permissive - Enabling encryption changes how data can be recovered as data is encrypted.
         scored: false
 

--- a/package/cfg/k3s-cis-1.8-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/master.yaml
@@ -120,10 +120,7 @@ groups:
 
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Automated)"
-        type: "skip"
-        audit: |
-          ps -ef | grep $kubeletbin | grep -- --cni-conf-dir | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c permissions=%a
-          find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
+        audit: find /var/lib/cni/networks -type f ! -name lock 2> /dev/null | xargs --no-run-if-empty stat -c permissions=%a
         use_multiple_values: true
         tests:
           test_items:
@@ -132,9 +129,10 @@ groups:
                 op: bitmask
                 value: "600"
         remediation: |
-          Not Applicable.
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example, chmod 600 <path/to/cni/files>
+          By default, K3s sets the CNI file permissions to 600.
+          Note that for many CNIs, a lock file is created with permissions 750. This is expected and can be ignored.
+          If you modify your CNI configuration, ensure that the permissions are set to 600.
+          For example, chmod 600 /var/lib/cni/networks/<filename>
         scored: false
 
       - id: 1.1.10

--- a/package/cfg/k3s-cis-1.8-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/node.yaml
@@ -206,7 +206,7 @@ groups:
 
       - id: 4.2.4
         text: "Verify that the --read-only-port argument is set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           bin_op: or
@@ -233,7 +233,7 @@ groups:
 
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --streaming-connection-idle-timeout
@@ -257,7 +257,7 @@ groups:
       - id: 4.2.6
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
         type: "skip"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --make-iptables-util-chains
@@ -285,7 +285,7 @@ groups:
         # To check if the property is set as expected, we need to parse the kubelet command
         # instead reading the Kubelet Configuration file.
         type: "skip"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --hostname-override
@@ -298,7 +298,7 @@ groups:
 
       - id: 4.2.8
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -324,7 +324,7 @@ groups:
       - id: 4.2.9
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
         type: "skip"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         tests:
           test_items:
             - flag: --tls-cert-file
@@ -344,7 +344,7 @@ groups:
 
       - id: 4.2.10
         text: "Ensure that the --rotate-certificates argument is not set to false (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -367,7 +367,7 @@ groups:
 
       - id: 4.2.11
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Automated)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/cat $kubeletconf"
         tests:
           bin_op: or
@@ -391,7 +391,7 @@ groups:
 
       - id: 4.2.12
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
@@ -412,7 +412,7 @@ groups:
 
       - id: 4.2.13
         text: "Ensure that a limit is set on pod PIDs (Manual)"
-        audit: "journalctl -D /var/log/journal -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: "journalctl -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:

--- a/package/helper_scripts/check_for_k3s_etcd.sh
+++ b/package/helper_scripts/check_for_k3s_etcd.sh
@@ -17,10 +17,6 @@ fi
 
 if [[ "$(journalctl -D $JOURNAL_LOG -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]]; then
     case $1 in
-        "1.1.11")
-            echo $(stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd);;
-        "1.2.29")
-            echo $(journalctl -D $JOURNAL_LOG -u k3s | grep -m1 'Running kube-apiserver');;
         "2.1")
             echo $(grep -A 5 'client-transport-security' /var/lib/rancher/k3s/server/db/etcd/config | grep -E 'cert-file|key-file');;
         "2.2")
@@ -39,10 +35,6 @@ if [[ "$(journalctl -D $JOURNAL_LOG -u k3s | grep -m1 'Managed etcd cluster' | w
 else
 # If another database is running, return whatever is required to pass the scan
     case $1 in
-        "1.1.11")
-            echo "permissions=700";;
-        "1.2.29")
-            echo "--etcd-certfile AND --etcd-keyfile";;
         "2.1")
             echo "cert-file AND key-file";;
         "2.2")

--- a/package/helper_scripts/check_for_k3s_etcd.sh
+++ b/package/helper_scripts/check_for_k3s_etcd.sh
@@ -18,7 +18,7 @@ fi
 if [[ "$(journalctl -D $JOURNAL_LOG -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]]; then
     case $1 in
         "1.1.11")
-            echo $(stat -c %a /var/lib/rancher/k3s/server/db/etcd);;
+            echo $(stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd);;
         "1.2.29")
             echo $(journalctl -D $JOURNAL_LOG -u k3s | grep -m1 'Running kube-apiserver');;
         "2.1")
@@ -40,7 +40,7 @@ else
 # If another database is running, return whatever is required to pass the scan
     case $1 in
         "1.1.11")
-            echo "700";;
+            echo "permissions=700";;
         "1.2.29")
             echo "--etcd-certfile AND --etcd-keyfile";;
         "2.1")


### PR DESCRIPTION
Build on top of https://github.com/rancher/security-scan/pull/219, once that merges I will rebase

## Changes:
- Overhaul of existing audits and give proper remediations for all K3s 1.XX.XX sections
- Remove use of the K3s etcd helper script from 1.1.11 and 1.2.29
- Ensure that titles (Automated) and (Manual) are used properly
- Don't look at specific journal logs, just grab K3s service logs wherever they are 

## Verification

Config for K3s (note the last line is different for PSP vs PSA)
```
cluster-init: true
protect-kernel-defaults: true
secrets-encryption: true
kube-controller-manager-arg:
  - 'terminated-pod-gc-threshold=10'
kubelet-arg:
  - 'streaming-connection-idle-timeout=5m'
  - 'make-iptables-util-chains=true'
  - 'event-qps=0'
  - "tls-cipher-suites=TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305"
kube-apiserver-arg:
  - 'audit-log-path=/var/lib/rancher/k3s/server/logs/audit.log'
  - 'audit-policy-file=/var/lib/rancher/k3s/server/audit.yaml'
  - 'audit-log-maxage=30'
  - 'audit-log-maxbackup=10'
  - 'audit-log-maxsize=100'
  - 'admission-control-config-file=/var/lib/rancher/k3s/server/psa.yaml'
```

 K3s-cis-1.24-hardened (v1.24.17+k3s1)
| old | new |
| - | - |
| ![image](https://github.com/user-attachments/assets/0a7d222b-1885-4a31-8aed-3914b25a2f37) | ![image](https://github.com/user-attachments/assets/b1e7f5f5-9a91-40f7-9054-fcdb7ad23d2f) |
  
 K3s-cis-1.7-hardened (v1.25.16+k3s4)
| old | new |
| - | - |
| ![image](https://github.com/user-attachments/assets/e846870b-01f0-4f71-8acb-95c66c1348f9) | ![image](https://github.com/user-attachments/assets/b220f5b1-c19f-479c-b1f5-94d106c24ef7) |

 
 K3s-cis-1.8-hardened (v1.28.11+k3s1)
| old | new |
| - | - |
| ![image](https://github.com/user-attachments/assets/6e19a357-4b1d-4ffd-ad0e-d2f2a958635d) | ![image](https://github.com/user-attachments/assets/b8940a44-4fb2-4cc6-8e7a-6bb13fd7dedb) |