### PR TITLE
kubectl version bump to v1.28.12

### DIFF
--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -18,7 +18,7 @@ SONOBUOY_SUM_arm64 ?= b6665011ae337e51cd6032ebfc37a6818dc8481c6cf6f2692e109a08be
 # renovate: datasource=github-release-attachments depName=vmware-tanzu/sonobuoy digestVersion=v0.57.1
 SONOBUOY_SUM_amd64 ?= 0fd3ae735ee25b6b37b713aadd4a836b53aa2b82c8e6ecad0c2359de046f8212
 
-KUBECTL_VERSION ?= 1.28.7
+KUBECTL_VERSION ?= 1.28.12
 KUBECTL_SUM_arm64 ?= $(shell curl -L "https://dl.k8s.io/release/v$(KUBECTL_VERSION)/bin/linux/arm64/kubectl.sha256")
 KUBECTL_SUM_amd64 ?= $(shell curl -L "https://dl.k8s.io/release/v$(KUBECTL_VERSION)/bin/linux/amd64/kubectl.sha256")
 


### PR DESCRIPTION
### Updates

- `kubectl` version bump to `v1.30.1`
