### PR TITLE
Minor changes around the build process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,11 +17,11 @@ jobs:
       id-token: write
     
     strategy:
+      # For sequential execution, to leverage both docker buildx
+      # caching and to avoid each job having to push the same layers
+      # to the target registry.
+      max-parallel: 1
       matrix:
-        # For sequential execution, to leverage both docker buildx
-        # caching and to avoid each job having to push the same layers
-        # to the target registry.
-        max-parallel: 1
         include:
           # Three images are created:
           # - Multi-arch manifest for both amd64 and arm64

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
         KUBERNETES_VERSION: ${{ matrix.k8s-version }}
       run: make e2e
 
-  image-build:    
+  build-image:
     runs-on: ubuntu-latest
     needs: [ validate ]
 
@@ -78,4 +78,4 @@ jobs:
       uses: actions/checkout@v4
   
     - name: Image build
-      run: make image-test
+      run: make test-image

--- a/Makefile
+++ b/Makefile
@@ -31,13 +31,13 @@ build: # build project and output binary to TARGET_BIN.
 	$(TARGET_BIN) --version
 	md5sum $(TARGET_BIN)
 
-image-test: buildx-machine ## build the container image for all target architecures.
+test-image: buildx-machine ## build the container image for all target architecures.
 	# Instead of loading image, target all platforms, effectivelly testing
 	# the build for the target architectures.
-	$(MAKE) image-build BUILD_ACTION="--platform=$(TARGET_PLATFORMS)"
+	$(MAKE) build-image BUILD_ACTION="--platform=$(TARGET_PLATFORMS)"
 
-.PHONY: image-build
-image-build: buildx-machine ## build (and load) the container image targeting the current platform.
+.PHONY: build-image
+build-image: buildx-machine ## build (and load) the container image targeting the current platform.
 	$(IMAGE_BUILDER) build -f package/Dockerfile \
 		--builder $(MACHINE) $(IMAGE_ARGS) \
 		--build-arg VERSION=$(VERSION) -t "$(IMAGE)" $(BUILD_ACTION) .
@@ -50,7 +50,7 @@ push-image: buildx-machine ## build the container image targeting all platforms 
 		--build-arg VERSION=$(VERSION) --platform=$(TARGET_PLATFORMS) -t "$(IMAGE)" --push .
 	@echo "Pushed $(IMAGE)"
 
-e2e: $(KIND) image-build ## run E2E tests.
+e2e: $(KIND) build-image ## run E2E tests.
 	@KUBERNETES_VERSION=$(KUBERNETES_VERSION) IMAGE=$(IMAGE) \
 	SONOBUOY_IMAGE=$(SONOBUOY_IMAGE) ARCH=$(ARCH) \
 	./hack/e2e

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -82,7 +82,7 @@ RUN curl --output /tmp/kubebench.tar.gz -sLf "https://github.com/aquasecurity/ku
 
 # Copy the files within /cfg straight from the immutable GitHub source to /etc/kube-bench/cfg/ into micro
 RUN mkdir -p /chroot/etc/kube-bench/ && \
-    curl -sLf "https://github.com/aquasecurity/kube-bench/archive/refs/tags/${KUBE_BENCH_VERSION}.tar.gz" | \
+    curl --output - -sLf "https://github.com/aquasecurity/kube-bench/archive/refs/tags/${KUBE_BENCH_VERSION}.tar.gz" | \
     tar xvz -C /chroot/etc/kube-bench/ --strip-components=1 "kube-bench-${KUBE_BENCH_VERSION#v}/cfg"
 
 WORKDIR /src


### PR DESCRIPTION
Changes:
- 5dc077031c80fe2c3ed93453a131370dcaebc823: fixes the broken [build](https://github.com/rancher/security-scan/actions/runs/10182011725/job/28163577213).
- 0557554b68011b72f149b86a6e35242f97baffc1: optimises the use of runners during the release process.
- 7f88c56e073f3599868134fa8967c7345de88721: aligns with some of the changes driven from `ecm-distro-tools`.