### PR TITLE
Add new yaml validation around checks nature (Automated or Manual)

### DIFF
--- a/hack/validate-yaml
+++ b/hack/validate-yaml
@@ -10,14 +10,36 @@ function main(){
 
     FAILED_CFGS_YML=()
     FAILED_CFGS_KB=()
+    FAILED_CHECKS_TYPE=()
 
     # Loop through all benchmarks
     for cfg in ${CFGS}; do
     set -x
         # yammlint is configured with ../.yamllint.yaml, to catch any liniting errors for a given benchmark. If result isn't empty, FAILED_CFGS_YML is appended with the failing benchmark.
         if [ -n "$(yamllint -s package/cfg/$cfg)" ]; then
-            FAILED_CFGS_YML+=("package/cfg/$cfg")
+            FAILED_CFGS_YML+=("$cfg")
         fi
+        # verify each check content to confirm type Automated matches scored to true and type Manual matches scored to false.
+        for component in $(find package/cfg/$cfg -type f -name "*.yaml" ! -name "config.yaml"); do
+            readarray checks < <(yq -o=j -I=0 '.groups[].checks[]' $component )
+            for check in "${checks[@]}"; do
+                id=$(echo $check | yq '.id')
+                text=$(echo $check | yq '.text')
+                scored=$(echo $check | yq '.scored')
+                type=$(echo $text | sed -n 's/.*(\(.*\)).*/\1/p')
+                # check if type is present and spelled correctly.
+                if [[ "$type" == "Automated" || "$type" == "Manual" ]]; then
+                        # check if type is Automated with scored to true or type is Manual with scored to false.
+                        if [[ "$type" == "Automated" && "$scored" != "true" ]] || [[ "$type" == "Manual" && "$scored" != "false" ]] ; then
+                            echo "Error mismatch found in $id: $text - 'type' is $type but 'scored' is $scored."
+                            FAILED_CHECKS_TYPE+=("$cfg:$id")
+                        fi
+                else
+                    echo "Error in $id: $text - type is misspelled or not recognized. Make sure to set title type to Manual/Automated."
+                    FAILED_CHECKS_TYPE+=("$cfg:$id")
+                fi
+            done
+        done
         # kube-bench dry-run to detect any errors for a given benchmark's files - check 1.1 is common to all benchmarks and used to speed up the test. If kube-bench commands fails, FAILED_CFGS_KB is appended with the failing benchmark.
         if kube-bench --config-dir package/cfg --config package/cfg/config.yaml --benchmark "$cfg" --check 1.1 --noremediations --noresults --nosummary --nototals; then
         echo "$cfg is OK"
@@ -27,13 +49,17 @@ function main(){
     set +x
     done
 
-    # Test if any profiles have errors, either FAILED_CFGS_YML or FAILED_CFGS_KB is greater than 0, fails. 
+    # Test if any profiles have errors, either FAILED_CFGS_YML or FAILED_CFGS_KB or FAILED_CHECKS_TYPE is greater than 0, fails. 
     if [ ${#FAILED_CFGS_YML[@]} -gt 0 ]; then
         echo "Error - yamllint failed for these cfgs: ${FAILED_CFGS_YML[@]}"
         exit 1
     fi
     if [ ${#FAILED_CFGS_KB[@]} -gt 0 ]; then
         echo "Error - kube-bench dry-run failed for these cfgs: ${FAILED_CFGS_KB[@]}"
+        exit 1
+    fi
+    if [ ${#FAILED_CHECKS_TYPE[@]} -gt 0 ]; then
+        echo "Error - check type verification failed for these checks: ${FAILED_CHECKS_TYPE[@]}"
         exit 1
     fi
 }

--- a/package/cfg/cis-1.23/policies.yaml
+++ b/package/cfg/cis-1.23/policies.yaml
@@ -98,7 +98,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostPID` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.4
         text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
@@ -106,7 +106,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostIPC` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.5
         text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
@@ -114,7 +114,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostNetwork` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.6
         text: "Minimize the admission of containers with allowPrivilegeEscalation (Automated)"
@@ -122,7 +122,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with `.spec.allowPrivilegeEscalation` set to `true`.
-        scored: false
+        scored: true
 
       - id: 5.2.7
         text: "Minimize the admission of root containers (Automated)"
@@ -130,7 +130,7 @@ groups:
         remediation: |
           Create a policy for each namespace in the cluster, ensuring that either `MustRunAsNonRoot`
           or `MustRunAs` with the range of UIDs not including 0, is set.
-        scored: false
+        scored: true
 
       - id: 5.2.8
         text: "Minimize the admission of containers with the NET_RAW capability (Automated)"
@@ -138,7 +138,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with the `NET_RAW` capability.
-        scored: false
+        scored: true
 
       - id: 5.2.9
         text: "Minimize the admission of containers with added capabilities (Automated)"
@@ -146,7 +146,7 @@ groups:
         remediation: |
           Ensure that `allowedCapabilities` is not present in policies for the cluster unless
           it is set to an empty array.
-        scored: false
+        scored: true
 
       - id: 5.2.10
         text: "Minimize the admission of containers with capabilities assigned (Manual)"

--- a/package/cfg/cis-1.24/policies.yaml
+++ b/package/cfg/cis-1.24/policies.yaml
@@ -98,7 +98,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostPID` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.4
         text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
@@ -106,7 +106,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostIPC` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.5
         text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
@@ -114,7 +114,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostNetwork` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.6
         text: "Minimize the admission of containers with allowPrivilegeEscalation (Automated)"
@@ -122,7 +122,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with `.spec.allowPrivilegeEscalation` set to `true`.
-        scored: false
+        scored: true
 
       - id: 5.2.7
         text: "Minimize the admission of root containers (Automated)"
@@ -130,7 +130,7 @@ groups:
         remediation: |
           Create a policy for each namespace in the cluster, ensuring that either `MustRunAsNonRoot`
           or `MustRunAs` with the range of UIDs not including 0, is set.
-        scored: false
+        scored: true
 
       - id: 5.2.8
         text: "Minimize the admission of containers with the NET_RAW capability (Automated)"
@@ -138,7 +138,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with the `NET_RAW` capability.
-        scored: false
+        scored: true
 
       - id: 5.2.9
         text: "Minimize the admission of containers with added capabilities (Automated)"
@@ -146,7 +146,7 @@ groups:
         remediation: |
           Ensure that `allowedCapabilities` is not present in policies for the cluster unless
           it is set to an empty array.
-        scored: false
+        scored: true
 
       - id: 5.2.10
         text: "Minimize the admission of containers with capabilities assigned (Manual)"

--- a/package/cfg/cis-1.7/policies.yaml
+++ b/package/cfg/cis-1.7/policies.yaml
@@ -133,7 +133,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostPID` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.4
         text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
@@ -141,7 +141,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostIPC` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.5
         text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
@@ -149,7 +149,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostNetwork` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.6
         text: "Minimize the admission of containers with allowPrivilegeEscalation (Automated)"
@@ -157,7 +157,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with `.spec.allowPrivilegeEscalation` set to `true`.
-        scored: false
+        scored: true
 
       - id: 5.2.7
         text: "Minimize the admission of root containers (Automated)"
@@ -165,7 +165,7 @@ groups:
         remediation: |
           Create a policy for each namespace in the cluster, ensuring that either `MustRunAsNonRoot`
           or `MustRunAs` with the range of UIDs not including 0, is set.
-        scored: false
+        scored: true
 
       - id: 5.2.8
         text: "Minimize the admission of containers with the NET_RAW capability (Automated)"
@@ -173,7 +173,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with the `NET_RAW` capability.
-        scored: false
+        scored: true
 
       - id: 5.2.9
         text: "Minimize the admission of containers with added capabilities (Automated)"
@@ -181,7 +181,7 @@ groups:
         remediation: |
           Ensure that `allowedCapabilities` is not present in policies for the cluster unless
           it is set to an empty array.
-        scored: false
+        scored: true
 
       - id: 5.2.10
         text: "Minimize the admission of containers with capabilities assigned (Manual)"

--- a/package/cfg/cis-1.8/policies.yaml
+++ b/package/cfg/cis-1.8/policies.yaml
@@ -118,49 +118,49 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostPID` containers.
-        scored: false
+        scored: true
       - id: 5.2.4
         text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
         type: "manual"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostIPC` containers.
-        scored: false
+        scored: true
       - id: 5.2.5
         text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
         type: "manual"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostNetwork` containers.
-        scored: false
+        scored: true
       - id: 5.2.6
         text: "Minimize the admission of containers with allowPrivilegeEscalation (Automated)"
         type: "manual"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with `.spec.allowPrivilegeEscalation` set to `true`.
-        scored: false
+        scored: true
       - id: 5.2.7
         text: "Minimize the admission of root containers (Automated)"
         type: "manual"
         remediation: |
           Create a policy for each namespace in the cluster, ensuring that either `MustRunAsNonRoot`
           or `MustRunAs` with the range of UIDs not including 0, is set.
-        scored: false
+        scored: true
       - id: 5.2.8
         text: "Minimize the admission of containers with the NET_RAW capability (Automated)"
         type: "manual"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with the `NET_RAW` capability.
-        scored: false
+        scored: true
       - id: 5.2.9
         text: "Minimize the admission of containers with added capabilities (Automated)"
         type: "manual"
         remediation: |
           Ensure that `allowedCapabilities` is not present in policies for the cluster unless
           it is set to an empty array.
-        scored: false
+        scored: true
       - id: 5.2.10
         text: "Minimize the admission of containers with capabilities assigned (Manual)"
         type: "manual"

--- a/package/cfg/k3s-cis-1.23-hardened/etcd.yaml
+++ b/package/cfg/k3s-cis-1.23-hardened/etcd.yaml
@@ -9,7 +9,7 @@ groups:
     text: "Etcd Node Configuration"
     checks:
       - id: 2.1
-        text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Automated)"
+        text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: and
@@ -31,7 +31,7 @@ groups:
         scored: false
 
       - id: 2.2
-        text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
+        text: "Ensure that the --client-cert-auth argument is set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           test_items:
@@ -47,7 +47,7 @@ groups:
         scored: false
 
       - id: 2.3
-        text: "Ensure that the --auto-tls argument is not set to true (Automated)"
+        text: "Ensure that the --auto-tls argument is not set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: or
@@ -68,7 +68,7 @@ groups:
         scored: false
 
       - id: 2.4
-        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
+        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: and
@@ -90,7 +90,7 @@ groups:
         scored: false
 
       - id: 2.5
-        text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
+        text: "Ensure that the --peer-client-cert-auth argument is set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           test_items:
@@ -106,7 +106,7 @@ groups:
         scored: false
 
       - id: 2.6
-        text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
+        text: "Ensure that the --peer-auto-tls argument is not set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: or
@@ -127,7 +127,7 @@ groups:
         scored: false
 
       - id: 2.7
-        text: "Ensure that a unique Certificate Authority is used for etcd (Automated)"
+        text: "Ensure that a unique Certificate Authority is used for etcd (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.23-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.23-hardened/master.yaml
@@ -699,7 +699,7 @@ groups:
           Edit the API server pod specification file $apiserverconf
           and set the below parameter as appropriate and if needed.
           For example, --request-timeout=300s
-        scored: true
+        scored: false
 
       - id: 1.2.24
         text: "Ensure that the --service-account-lookup argument is set to true (Automated)"

--- a/package/cfg/k3s-cis-1.23-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.23-hardened/node.yaml
@@ -388,7 +388,7 @@ groups:
         scored: false
 
       - id: 4.2.11
-        text: "Ensure that the --rotate-certificates argument is not set to false (Manual)"
+        text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
@@ -436,7 +436,7 @@ groups:
           Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
-        scored: false
+        scored: true
 
       - id: 4.2.13
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"

--- a/package/cfg/k3s-cis-1.23-hardened/policies.yaml
+++ b/package/cfg/k3s-cis-1.23-hardened/policies.yaml
@@ -98,7 +98,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostPID` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.4
         text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
@@ -106,7 +106,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostIPC` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.5
         text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
@@ -114,7 +114,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostNetwork` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.6
         text: "Minimize the admission of containers with allowPrivilegeEscalation (Automated)"
@@ -122,7 +122,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with `.spec.allowPrivilegeEscalation` set to `true`.
-        scored: false
+        scored: true
 
       - id: 5.2.7
         text: "Minimize the admission of root containers (Automated)"
@@ -130,7 +130,7 @@ groups:
         remediation: |
           Create a policy for each namespace in the cluster, ensuring that either `MustRunAsNonRoot`
           or `MustRunAs` with the range of UIDs not including 0, is set.
-        scored: false
+        scored: true
 
       - id: 5.2.8
         text: "Minimize the admission of containers with the NET_RAW capability (Automated)"
@@ -138,7 +138,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with the `NET_RAW` capability.
-        scored: false
+        scored: true
 
       - id: 5.2.9
         text: "Minimize the admission of containers with added capabilities (Automated)"
@@ -146,7 +146,7 @@ groups:
         remediation: |
           Ensure that `allowedCapabilities` is not present in policies for the cluster unless
           it is set to an empty array.
-        scored: false
+        scored: true
 
       - id: 5.2.10
         text: "Minimize the admission of containers with capabilities assigned (Manual)"

--- a/package/cfg/k3s-cis-1.23-permissive/etcd.yaml
+++ b/package/cfg/k3s-cis-1.23-permissive/etcd.yaml
@@ -9,7 +9,7 @@ groups:
     text: "Etcd Node Configuration"
     checks:
       - id: 2.1
-        text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Automated)"
+        text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: and
@@ -31,7 +31,7 @@ groups:
         scored: false
 
       - id: 2.2
-        text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
+        text: "Ensure that the --client-cert-auth argument is set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           test_items:
@@ -47,7 +47,7 @@ groups:
         scored: false
 
       - id: 2.3
-        text: "Ensure that the --auto-tls argument is not set to true (Automated)"
+        text: "Ensure that the --auto-tls argument is not set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: or
@@ -68,7 +68,7 @@ groups:
         scored: false
 
       - id: 2.4
-        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
+        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: and
@@ -90,7 +90,7 @@ groups:
         scored: false
 
       - id: 2.5
-        text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
+        text: "Ensure that the --peer-client-cert-auth argument is set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           test_items:
@@ -106,7 +106,7 @@ groups:
         scored: false
 
       - id: 2.6
-        text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
+        text: "Ensure that the --peer-auto-tls argument is not set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: or
@@ -127,7 +127,7 @@ groups:
         scored: false
 
       - id: 2.7
-        text: "Ensure that a unique Certificate Authority is used for etcd (Automated)"
+        text: "Ensure that a unique Certificate Authority is used for etcd (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.23-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.23-permissive/node.yaml
@@ -438,7 +438,7 @@ groups:
           Based on your system, restart the kubelet service. For example:
           systemctl daemon-reload
           systemctl restart kubelet.service
-        scored: false
+        scored: true
 
       - id: 4.2.13
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"

--- a/package/cfg/k3s-cis-1.23-permissive/policies.yaml
+++ b/package/cfg/k3s-cis-1.23-permissive/policies.yaml
@@ -90,7 +90,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of privileged containers.
-        scored: false
+        scored: true
 
       - id: 5.2.3
         text: "Minimize the admission of containers wishing to share the host process ID namespace (Automated)"
@@ -98,7 +98,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostPID` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.4
         text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
@@ -106,7 +106,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostIPC` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.5
         text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
@@ -114,7 +114,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostNetwork` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.6
         text: "Minimize the admission of containers with allowPrivilegeEscalation (Automated)"
@@ -122,7 +122,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with `.spec.allowPrivilegeEscalation` set to `true`.
-        scored: false
+        scored: true
 
       - id: 5.2.7
         text: "Minimize the admission of root containers (Automated)"
@@ -130,7 +130,7 @@ groups:
         remediation: |
           Create a policy for each namespace in the cluster, ensuring that either `MustRunAsNonRoot`
           or `MustRunAs` with the range of UIDs not including 0, is set.
-        scored: false
+        scored: true
 
       - id: 5.2.8
         text: "Minimize the admission of containers with the NET_RAW capability (Automated)"
@@ -138,7 +138,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with the `NET_RAW` capability.
-        scored: false
+        scored: true
 
       - id: 5.2.9
         text: "Minimize the admission of containers with added capabilities (Automated)"
@@ -146,7 +146,7 @@ groups:
         remediation: |
           Ensure that `allowedCapabilities` is not present in policies for the cluster unless
           it is set to an empty array.
-        scored: false
+        scored: true
 
       - id: 5.2.10
         text: "Minimize the admission of containers with capabilities assigned (Manual)"

--- a/package/cfg/k3s-cis-1.24-hardened/etcd.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/etcd.yaml
@@ -9,7 +9,7 @@ groups:
     text: "Etcd Node Configuration"
     checks:
       - id: 2.1
-        text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Automated)"
+        text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: and
@@ -31,7 +31,7 @@ groups:
         scored: false
 
       - id: 2.2
-        text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
+        text: "Ensure that the --client-cert-auth argument is set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           test_items:
@@ -47,7 +47,7 @@ groups:
         scored: false
 
       - id: 2.3
-        text: "Ensure that the --auto-tls argument is not set to true (Automated)"
+        text: "Ensure that the --auto-tls argument is not set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: or
@@ -68,7 +68,7 @@ groups:
         scored: false
 
       - id: 2.4
-        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
+        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: and
@@ -90,7 +90,7 @@ groups:
         scored: false
 
       - id: 2.5
-        text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
+        text: "Ensure that the --peer-client-cert-auth argument is set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           test_items:
@@ -106,7 +106,7 @@ groups:
         scored: false
 
       - id: 2.6
-        text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
+        text: "Ensure that the --peer-auto-tls argument is not set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: or
@@ -127,7 +127,7 @@ groups:
         scored: false
 
       - id: 2.7
-        text: "Ensure that a unique Certificate Authority is used for etcd (Automated)"
+        text: "Ensure that a unique Certificate Authority is used for etcd (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.24-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/master.yaml
@@ -313,7 +313,7 @@ groups:
           Run the below command (based on the file location on your system) on the master node.
           For example,
           chmod -R 600 /var/lib/rancher/k3s/server/tls/*.key
-        scored: false
+        scored: true
 
   - id: 1.2
     text: "API Server"
@@ -332,7 +332,7 @@ groups:
           edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
           kube-apiserver-arg:
             - "anonymous-auth=true"
-        scored: false
+        scored: true
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
@@ -641,7 +641,7 @@ groups:
           file where you would like audit logs to be written, for example,
           kube-apiserver-arg:
             - "audit-log-path=/var/lib/rancher/k3s/server/logs/audit.log"
-        scored: true
+        scored: false
 
       - id: 1.2.20
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"

--- a/package/cfg/k3s-cis-1.24-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/node.yaml
@@ -317,7 +317,7 @@ groups:
           Not Applicable.
           By default, K3s does set the --hostname-override argument. Per CIS guidelines, this is to comply
           with cloud providers that require this flag to ensure that hostname matches node names.
-        scored: false
+        scored: true
 
       - id: 4.2.9
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"

--- a/package/cfg/k3s-cis-1.24-hardened/policies.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/policies.yaml
@@ -98,7 +98,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostPID` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.4
         text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
@@ -106,7 +106,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostIPC` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.5
         text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
@@ -114,7 +114,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostNetwork` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.6
         text: "Minimize the admission of containers with allowPrivilegeEscalation (Automated)"
@@ -122,7 +122,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with `.spec.allowPrivilegeEscalation` set to `true`.
-        scored: false
+        scored: true
 
       - id: 5.2.7
         text: "Minimize the admission of root containers (Automated)"
@@ -130,7 +130,7 @@ groups:
         remediation: |
           Create a policy for each namespace in the cluster, ensuring that either `MustRunAsNonRoot`
           or `MustRunAs` with the range of UIDs not including 0, is set.
-        scored: false
+        scored: true
 
       - id: 5.2.8
         text: "Minimize the admission of containers with the NET_RAW capability (Automated)"
@@ -138,7 +138,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with the `NET_RAW` capability.
-        scored: false
+        scored: true
 
       - id: 5.2.9
         text: "Minimize the admission of containers with added capabilities (Automated)"
@@ -146,7 +146,7 @@ groups:
         remediation: |
           Ensure that `allowedCapabilities` is not present in policies for the cluster unless
           it is set to an empty array.
-        scored: false
+        scored: true
 
       - id: 5.2.10
         text: "Minimize the admission of containers with capabilities assigned (Manual)"

--- a/package/cfg/k3s-cis-1.24-permissive/controlplane.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/controlplane.yaml
@@ -20,7 +20,7 @@ groups:
     text: "Logging"
     checks:
       - id: 3.2.1
-        text: "Ensure that a minimal audit policy is created (Automated)"
+        text: "Ensure that a minimal audit policy is created (Manual)"
         audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'audit-policy-file'"
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.24-permissive/etcd.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/etcd.yaml
@@ -9,7 +9,7 @@ groups:
     text: "Etcd Node Configuration"
     checks:
       - id: 2.1
-        text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Automated)"
+        text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: and
@@ -31,7 +31,7 @@ groups:
         scored: false
 
       - id: 2.2
-        text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
+        text: "Ensure that the --client-cert-auth argument is set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           test_items:
@@ -47,7 +47,7 @@ groups:
         scored: false
 
       - id: 2.3
-        text: "Ensure that the --auto-tls argument is not set to true (Automated)"
+        text: "Ensure that the --auto-tls argument is not set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: or
@@ -68,7 +68,7 @@ groups:
         scored: false
 
       - id: 2.4
-        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
+        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: and
@@ -90,7 +90,7 @@ groups:
         scored: false
 
       - id: 2.5
-        text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
+        text: "Ensure that the --peer-client-cert-auth argument is set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           test_items:
@@ -106,7 +106,7 @@ groups:
         scored: false
 
       - id: 2.6
-        text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
+        text: "Ensure that the --peer-auto-tls argument is not set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: or
@@ -127,7 +127,7 @@ groups:
         scored: false
 
       - id: 2.7
-        text: "Ensure that a unique Certificate Authority is used for etcd (Automated)"
+        text: "Ensure that a unique Certificate Authority is used for etcd (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.24-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/master.yaml
@@ -314,7 +314,7 @@ groups:
           Run the below command (based on the file location on your system) on the master node.
           For example,
           chmod -R 600 /var/lib/rancher/k3s/server/tls/*.key
-        scored: false
+        scored: true
 
   - id: 1.2
     text: "API Server"
@@ -333,7 +333,7 @@ groups:
           edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
           kube-apiserver-arg:
             - "anonymous-auth=true"
-        scored: false
+        scored: true
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
@@ -466,7 +466,7 @@ groups:
         scored: true
 
       - id: 1.2.10
-        text: "Ensure that the admission control plugin EventRateLimit is set (Automated)"
+        text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
         audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           test_items:
@@ -502,7 +502,7 @@ groups:
         scored: true
 
       - id: 1.2.12
-        text: "Ensure that the admission control plugin AlwaysPullImages is set (Automated)"
+        text: "Ensure that the admission control plugin AlwaysPullImages is set (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -521,7 +521,7 @@ groups:
         scored: false
 
       - id: 1.2.13
-        text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Automated)"
+        text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)"
         audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'enable-admission-plugins'"
         tests:
           bin_op: or
@@ -821,7 +821,7 @@ groups:
         scored: true
 
       - id: 1.2.30
-        text: "Ensure that the --encryption-provider-config argument is set as appropriate (Automated)"
+        text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
         audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep 'encryption-provider-config'"
         tests:
           test_items:
@@ -835,7 +835,7 @@ groups:
         scored: false
 
       - id: 1.2.31
-        text: "Ensure that encryption providers are appropriately configured (Automated)"
+        text: "Ensure that encryption providers are appropriately configured (Manual)"
         audit: |
           ENCRYPTION_PROVIDER_CONFIG=$(journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1 | grep -- --encryption-provider-config | sed 's%.*encryption-provider-config[= ]\([^ ]*\).*%\1%')
           if test -e $ENCRYPTION_PROVIDER_CONFIG; then grep -o 'providers\"\:\[.*\]' $ENCRYPTION_PROVIDER_CONFIG | grep -o "[A-Za-z]*" | head -2 | tail -1  | sed 's/^/provider=/'; fi
@@ -874,7 +874,7 @@ groups:
     text: "Controller Manager"
     checks:
       - id: 1.3.1
-        text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Automated)"
+        text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Manual)"
         audit: "journalctl -m -u k3s | grep 'Running kube-controller-manager' | tail -n1 | grep 'terminated-pod-gc-threshold'"
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.24-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/node.yaml
@@ -140,7 +140,7 @@ groups:
         scored: true
 
       - id: 4.1.10
-        text: "If the kubelet config.yaml configuration file is being used validate file ownership is set to root:root (Manual)"
+        text: "If the kubelet config.yaml configuration file is being used validate file ownership is set to root:root (Automated)"
         audit: '/bin/sh -c ''if test -e $kubeletconf; then stat -c %U:%G $kubeletconf; fi'' '
         type: "skip"
         tests:
@@ -237,7 +237,7 @@ groups:
           Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
           systemctl restart k3s.service
-        scored: false
+        scored: true
 
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
@@ -322,7 +322,7 @@ groups:
           Not Applicable.
           By default, K3s does set the --hostname-override argument. Per CIS guidelines, this is to comply
           with cloud providers that require this flag to ensure that hostname matches node names.
-        scored: false
+        scored: true
 
       - id: 4.2.9
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
@@ -362,7 +362,7 @@ groups:
           kubelet-arg:
             - "tls-cert-file=<path/to/tls-cert-file>"
             - "tls-private-key-file=<path/to/tls-private-key-file>"
-        scored: false
+        scored: true
 
       - id: 4.2.11
         text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"

--- a/package/cfg/k3s-cis-1.24-permissive/policies.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/policies.yaml
@@ -98,7 +98,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostPID` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.4
         text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
@@ -106,7 +106,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostIPC` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.5
         text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
@@ -114,7 +114,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostNetwork` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.6
         text: "Minimize the admission of containers with allowPrivilegeEscalation (Automated)"
@@ -122,7 +122,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with `.spec.allowPrivilegeEscalation` set to `true`.
-        scored: false
+        scored: true
 
       - id: 5.2.7
         text: "Minimize the admission of root containers (Automated)"
@@ -130,7 +130,7 @@ groups:
         remediation: |
           Create a policy for each namespace in the cluster, ensuring that either `MustRunAsNonRoot`
           or `MustRunAs` with the range of UIDs not including 0, is set.
-        scored: false
+        scored: true
 
       - id: 5.2.8
         text: "Minimize the admission of containers with the NET_RAW capability (Automated)"
@@ -138,7 +138,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with the `NET_RAW` capability.
-        scored: false
+        scored: true
 
       - id: 5.2.9
         text: "Minimize the admission of containers with added capabilities (Automated)"
@@ -146,7 +146,7 @@ groups:
         remediation: |
           Ensure that `allowedCapabilities` is not present in policies for the cluster unless
           it is set to an empty array.
-        scored: false
+        scored: true
 
       - id: 5.2.10
         text: "Minimize the admission of containers with capabilities assigned (Manual)"

--- a/package/cfg/k3s-cis-1.7-hardened/etcd.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/etcd.yaml
@@ -9,7 +9,7 @@ groups:
     text: "Etcd Node Configuration"
     checks:
       - id: 2.1
-        text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Automated)"
+        text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: and
@@ -31,7 +31,7 @@ groups:
         scored: false
 
       - id: 2.2
-        text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
+        text: "Ensure that the --client-cert-auth argument is set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           test_items:
@@ -47,7 +47,7 @@ groups:
         scored: false
 
       - id: 2.3
-        text: "Ensure that the --auto-tls argument is not set to true (Automated)"
+        text: "Ensure that the --auto-tls argument is not set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: or
@@ -68,7 +68,7 @@ groups:
         scored: false
 
       - id: 2.4
-        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
+        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: and
@@ -90,7 +90,7 @@ groups:
         scored: false
 
       - id: 2.5
-        text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
+        text: "Ensure that the --peer-client-cert-auth argument is set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           test_items:
@@ -106,7 +106,7 @@ groups:
         scored: false
 
       - id: 2.6
-        text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
+        text: "Ensure that the --peer-auto-tls argument is not set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: or
@@ -127,7 +127,7 @@ groups:
         scored: false
 
       - id: 2.7
-        text: "Ensure that a unique Certificate Authority is used for etcd (Automated)"
+        text: "Ensure that a unique Certificate Authority is used for etcd (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.7-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/master.yaml
@@ -133,7 +133,7 @@ groups:
           Note that for many CNIs, a lock file is created with permissions 750. This is expected and can be ignored.
           If you modify your CNI configuration, ensure that the permissions are set to 600.
           For example, chmod 600 /var/lib/cni/networks/<filename>
-        scored: true
+        scored: false
 
       - id: 1.1.10
         text: "Ensure that the Container Network Interface file ownership is set to root:root (Automated)"
@@ -312,7 +312,7 @@ groups:
           Run the below command (based on the file location on your system) on the master node.
           For example,
           chmod -R 600 /var/lib/rancher/k3s/server/tls/*.key
-        scored: false
+        scored: true
 
   - id: 1.2
     text: "API Server"
@@ -331,7 +331,7 @@ groups:
           edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
           kube-apiserver-arg:
             - "anonymous-auth=true"
-        scored: false
+        scored: true
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
@@ -621,7 +621,7 @@ groups:
           file where you would like audit logs to be written, for example,
           kube-apiserver-arg:
             - "audit-log-path=/var/lib/rancher/k3s/server/logs/audit.log"
-        scored: true
+        scored: false
 
       - id: 1.2.19
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Manual)"
@@ -637,7 +637,7 @@ groups:
           set the audit-log-maxage parameter to 30 or as an appropriate number of days, for example,
           kube-apiserver-arg:
             - "audit-log-maxage=30"
-        scored: true
+        scored: false
 
       - id: 1.2.20
         text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Manual)"
@@ -653,7 +653,7 @@ groups:
           set the audit-log-maxbackup parameter to 10 or to an appropriate value. For example,
           kube-apiserver-arg:
             - "audit-log-maxbackup=10"
-        scored: true
+        scored: false
 
       - id: 1.2.21
         text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Manual)"
@@ -669,7 +669,7 @@ groups:
           set the audit-log-maxsize parameter to an appropriate size in MB. For example,
           kube-apiserver-arg:
             - "audit-log-maxsize=100"
-        scored: true
+        scored: false
 
       - id: 1.2.22
         text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"

--- a/package/cfg/k3s-cis-1.7-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/node.yaml
@@ -294,7 +294,7 @@ groups:
           Not Applicable.
           By default, K3s does set the --hostname-override argument. Per CIS guidelines, this is to comply
           with cloud providers that require this flag to ensure that hostname matches node names.
-        scored: false
+        scored: true
 
       - id: 4.2.8
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"

--- a/package/cfg/k3s-cis-1.7-hardened/policies.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/policies.yaml
@@ -136,24 +136,27 @@ groups:
 
       - id: 5.2.3
         text: "Minimize the admission of containers wishing to share the host process ID namespace (Automated)"
+        type: "manual"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostPID` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.4
         text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
+        type: "manual"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostIPC` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.5
         text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
+        type: "manual"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostNetwork` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.6
         text: "Minimize the admission of containers with allowPrivilegeEscalation (Automated)"
@@ -169,7 +172,7 @@ groups:
         remediation: |
           Create a policy for each namespace in the cluster, ensuring that either `MustRunAsNonRoot`
           or `MustRunAs` with the range of UIDs not including 0, is set.
-        scored: false
+        scored: true
 
       - id: 5.2.8
         text: "Minimize the admission of containers with the NET_RAW capability (Automated)"
@@ -177,7 +180,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with the `NET_RAW` capability.
-        scored: false
+        scored: true
 
       - id: 5.2.9
         text: "Minimize the admission of containers with added capabilities (Automated)"
@@ -185,7 +188,7 @@ groups:
         remediation: |
           Ensure that `allowedCapabilities` is not present in policies for the cluster unless
           it is set to an empty array.
-        scored: false
+        scored: true
 
       - id: 5.2.10
         text: "Minimize the admission of containers with capabilities assigned (Manual)"

--- a/package/cfg/k3s-cis-1.7-permissive/etcd.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/etcd.yaml
@@ -9,7 +9,7 @@ groups:
     text: "Etcd Node Configuration"
     checks:
       - id: 2.1
-        text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Automated)"
+        text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: and
@@ -31,7 +31,7 @@ groups:
         scored: false
 
       - id: 2.2
-        text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
+        text: "Ensure that the --client-cert-auth argument is set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           test_items:
@@ -47,7 +47,7 @@ groups:
         scored: false
 
       - id: 2.3
-        text: "Ensure that the --auto-tls argument is not set to true (Automated)"
+        text: "Ensure that the --auto-tls argument is not set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: or
@@ -68,7 +68,7 @@ groups:
         scored: false
 
       - id: 2.4
-        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
+        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: and
@@ -90,7 +90,7 @@ groups:
         scored: false
 
       - id: 2.5
-        text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
+        text: "Ensure that the --peer-client-cert-auth argument is set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           test_items:
@@ -106,7 +106,7 @@ groups:
         scored: false
 
       - id: 2.6
-        text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
+        text: "Ensure that the --peer-auto-tls argument is not set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: or
@@ -127,7 +127,7 @@ groups:
         scored: false
 
       - id: 2.7
-        text: "Ensure that a unique Certificate Authority is used for etcd (Automated)"
+        text: "Ensure that a unique Certificate Authority is used for etcd (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.7-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/master.yaml
@@ -133,7 +133,7 @@ groups:
           Note that for many CNIs, a lock file is created with permissions 750. This is expected and can be ignored.
           If you modify your CNI configuration, ensure that the permissions are set to 600.
           For example, chmod 600 /var/lib/cni/networks/<filename>
-        scored: true
+        scored: false
 
       - id: 1.1.10
         text: "Ensure that the Container Network Interface file ownership is set to root:root (Automated)"
@@ -313,7 +313,7 @@ groups:
           Run the below command (based on the file location on your system) on the master node.
           For example,
           chmod -R 600 /var/lib/rancher/k3s/server/tls/*.key
-        scored: false
+        scored: true
 
   - id: 1.2
     text: "API Server"
@@ -332,7 +332,7 @@ groups:
           edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
           kube-apiserver-arg:
             - "anonymous-auth=true"
-        scored: false
+        scored: true
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"

--- a/package/cfg/k3s-cis-1.7-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/node.yaml
@@ -234,7 +234,7 @@ groups:
           Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
           systemctl restart k3s.service
-        scored: false
+        scored: true
 
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
@@ -296,7 +296,7 @@ groups:
           Not Applicable.
           By default, K3s does set the --hostname-override argument. Per CIS guidelines, this is to comply
           with cloud providers that require this flag to ensure that hostname matches node names.
-        scored: false
+        scored: true
 
       - id: 4.2.8
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
@@ -342,7 +342,7 @@ groups:
             - "tls-cert-file=<path/to/tls-cert-file>"
             - "tls-private-key-file=<path/to/tls-private-key-file>"
           Permissive - When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
-        scored: false
+        scored: true
 
       - id: 4.2.10
         text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"
@@ -365,7 +365,7 @@ groups:
           If using the command line, remove the K3s flag --kubelet-arg="rotate-certificates".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
-        scored: false
+        scored: true
 
       - id: 4.2.11
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Automated)"

--- a/package/cfg/k3s-cis-1.7-permissive/policies.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/policies.yaml
@@ -143,7 +143,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostPID` containers.
           Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
-        scored: false
+        scored: true
 
       - id: 5.2.4
         text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
@@ -152,7 +152,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostIPC` containers.
           Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
-        scored: false
+        scored: true
 
       - id: 5.2.5
         text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
@@ -161,7 +161,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostNetwork` containers.
           Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
-        scored: false
+        scored: true
 
       - id: 5.2.6
         text: "Minimize the admission of containers with allowPrivilegeEscalation (Automated)"
@@ -177,7 +177,7 @@ groups:
         remediation: |
           Create a policy for each namespace in the cluster, ensuring that either `MustRunAsNonRoot`
           or `MustRunAs` with the range of UIDs not including 0, is set.
-        scored: false
+        scored: true
 
       - id: 5.2.8
         text: "Minimize the admission of containers with the NET_RAW capability (Automated)"
@@ -185,7 +185,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with the `NET_RAW` capability.
-        scored: false
+        scored: true
 
       - id: 5.2.9
         text: "Minimize the admission of containers with added capabilities (Automated)"
@@ -193,7 +193,7 @@ groups:
         remediation: |
           Ensure that `allowedCapabilities` is not present in policies for the cluster unless
           it is set to an empty array.
-        scored: false
+        scored: true
 
       - id: 5.2.10
         text: "Minimize the admission of containers with capabilities assigned (Manual)"

--- a/package/cfg/k3s-cis-1.8-hardened/etcd.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/etcd.yaml
@@ -9,7 +9,7 @@ groups:
     text: "Etcd Node Configuration"
     checks:
       - id: 2.1
-        text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Automated)"
+        text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: and
@@ -31,7 +31,7 @@ groups:
         scored: false
 
       - id: 2.2
-        text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
+        text: "Ensure that the --client-cert-auth argument is set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           test_items:
@@ -47,7 +47,7 @@ groups:
         scored: false
 
       - id: 2.3
-        text: "Ensure that the --auto-tls argument is not set to true (Automated)"
+        text: "Ensure that the --auto-tls argument is not set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: or
@@ -68,7 +68,7 @@ groups:
         scored: false
 
       - id: 2.4
-        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
+        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: and
@@ -90,7 +90,7 @@ groups:
         scored: false
 
       - id: 2.5
-        text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
+        text: "Ensure that the --peer-client-cert-auth argument is set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           test_items:
@@ -106,7 +106,7 @@ groups:
         scored: false
 
       - id: 2.6
-        text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
+        text: "Ensure that the --peer-auto-tls argument is not set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: or
@@ -127,7 +127,7 @@ groups:
         scored: false
 
       - id: 2.7
-        text: "Ensure that a unique Certificate Authority is used for etcd (Automated)"
+        text: "Ensure that a unique Certificate Authority is used for etcd (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.8-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/master.yaml
@@ -312,7 +312,7 @@ groups:
           Run the below command (based on the file location on your system) on the master node.
           For example,
           chmod -R 600 /var/lib/rancher/k3s/server/tls/*.key
-        scored: false
+        scored: true
 
   - id: 1.2
     text: "API Server"
@@ -331,7 +331,7 @@ groups:
           If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
           kube-apiserver-arg:
             - "anonymous-auth=true"
-        scored: false
+        scored: true
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
@@ -603,7 +603,7 @@ groups:
           file where you would like audit logs to be written, for example,
           kube-apiserver-arg:
             - "audit-log-path=/var/lib/rancher/k3s/server/logs/audit.log"
-        scored: true
+        scored: false
 
       - id: 1.2.18
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Manual)"
@@ -619,7 +619,7 @@ groups:
           set the audit-log-maxage parameter to 30 or as an appropriate number of days, for example,
           kube-apiserver-arg:
             - "audit-log-maxage=30"
-        scored: true
+        scored: false
 
       - id: 1.2.19
         text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Manual)"
@@ -635,7 +635,7 @@ groups:
           set the audit-log-maxbackup parameter to 10 or to an appropriate value. For example,
           kube-apiserver-arg:
             - "audit-log-maxbackup=10"
-        scored: true
+        scored: false
 
       - id: 1.2.20
         text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Manual)"
@@ -651,7 +651,7 @@ groups:
           set the audit-log-maxsize parameter to an appropriate size in MB. For example,
           kube-apiserver-arg:
             - "audit-log-maxsize=100"
-        scored: true
+        scored: false
 
       - id: 1.2.21
         text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"

--- a/package/cfg/k3s-cis-1.8-hardened/node.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/node.yaml
@@ -292,7 +292,7 @@ groups:
           Not Applicable.
           By default, K3s does set the --hostname-override argument. Per CIS guidelines, this is to comply
           with cloud providers that require this flag to ensure that hostname matches node names.
-        scored: false
+        scored: true
 
       - id: 4.2.8
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"

--- a/package/cfg/k3s-cis-1.8-hardened/policies.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/policies.yaml
@@ -136,24 +136,27 @@ groups:
 
       - id: 5.2.3
         text: "Minimize the admission of containers wishing to share the host process ID namespace (Automated)"
+        type: "manual"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostPID` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.4
         text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
+        type: "manual"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostIPC` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.5
         text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
+        type: "manual"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostNetwork` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.6
         text: "Minimize the admission of containers with allowPrivilegeEscalation (Automated)"
@@ -169,7 +172,7 @@ groups:
         remediation: |
           Create a policy for each namespace in the cluster, ensuring that either `MustRunAsNonRoot`
           or `MustRunAs` with the range of UIDs not including 0, is set.
-        scored: false
+        scored: true
 
       - id: 5.2.8
         text: "Minimize the admission of containers with the NET_RAW capability (Automated)"
@@ -177,7 +180,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with the `NET_RAW` capability.
-        scored: false
+        scored: true
 
       - id: 5.2.9
         text: "Minimize the admission of containers with added capabilities (Automated)"
@@ -185,7 +188,7 @@ groups:
         remediation: |
           Ensure that `allowedCapabilities` is not present in policies for the cluster unless
           it is set to an empty array.
-        scored: false
+        scored: true
 
       - id: 5.2.10
         text: "Minimize the admission of containers with capabilities assigned (Manual)"

--- a/package/cfg/k3s-cis-1.8-permissive/etcd.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/etcd.yaml
@@ -9,7 +9,7 @@ groups:
     text: "Etcd Node Configuration"
     checks:
       - id: 2.1
-        text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Automated)"
+        text: "Ensure that the --cert-file and --key-file arguments are set as appropriate (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: and
@@ -31,7 +31,7 @@ groups:
         scored: false
 
       - id: 2.2
-        text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
+        text: "Ensure that the --client-cert-auth argument is set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           test_items:
@@ -47,7 +47,7 @@ groups:
         scored: false
 
       - id: 2.3
-        text: "Ensure that the --auto-tls argument is not set to true (Automated)"
+        text: "Ensure that the --auto-tls argument is not set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: or
@@ -68,7 +68,7 @@ groups:
         scored: false
 
       - id: 2.4
-        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
+        text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: and
@@ -90,7 +90,7 @@ groups:
         scored: false
 
       - id: 2.5
-        text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
+        text: "Ensure that the --peer-client-cert-auth argument is set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           test_items:
@@ -106,7 +106,7 @@ groups:
         scored: false
 
       - id: 2.6
-        text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
+        text: "Ensure that the --peer-auto-tls argument is not set to true (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           bin_op: or
@@ -127,7 +127,7 @@ groups:
         scored: false
 
       - id: 2.7
-        text: "Ensure that a unique Certificate Authority is used for etcd (Automated)"
+        text: "Ensure that a unique Certificate Authority is used for etcd (Manual)"
         audit_config: "cat $etcdconf"
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.8-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/master.yaml
@@ -313,7 +313,7 @@ groups:
           Run the below command (based on the file location on your system) on the master node.
           For example,
           chmod -R 600 /var/lib/rancher/k3s/server/tls/*.key
-        scored: false
+        scored: true
 
   - id: 1.2
     text: "API Server"
@@ -332,7 +332,7 @@ groups:
           edit the K3s config file /etc/rancher/k3s/config.yaml and remove anything similar to below.
           kube-apiserver-arg:
             - "anonymous-auth=true"
-        scored: false
+        scored: true
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
@@ -594,7 +594,7 @@ groups:
         scored: true
 
       - id: 1.2.17
-        text: "Ensure that the --audit-log-path argument is set (Automated)"
+        text: "Ensure that the --audit-log-path argument is set (Manual)"
         audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.8-permissive/node.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/node.yaml
@@ -62,7 +62,7 @@ groups:
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
           chown root:root $proxykubeconfig
-        scored: false
+        scored: true
 
       - id: 4.1.5
         text: "Ensure that the --kubeconfig kubelet.conf file permissions are set to 600 or more restrictive (Automated)"
@@ -103,7 +103,7 @@ groups:
         remediation: |
           Run the following command to modify the file permissions of the
           --client-ca-file chmod 600 $kubeletcafile
-        scored: false
+        scored: true
 
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Automated)"
@@ -117,7 +117,7 @@ groups:
         remediation: |
           Run the following command to modify the ownership of the --client-ca-file.
           chown root:root $kubeletcafile
-        scored: false
+        scored: true
 
       - id: 4.1.9
         text: "Ensure that the kubelet --config configuration file has permissions set to 600 or more restrictive (Automated)"
@@ -231,7 +231,7 @@ groups:
           Based on your system, restart the k3s service. For example,
           systemctl daemon-reload
           systemctl restart k3s.service
-        scored: false
+        scored: true
 
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
@@ -296,7 +296,7 @@ groups:
           Not Applicable.
           By default, K3s does set the --hostname-override argument. Per CIS guidelines, this is to comply
           with cloud providers that require this flag to ensure that hostname matches node names.
-        scored: false
+        scored: true
 
       - id: 4.2.8
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
@@ -342,7 +342,7 @@ groups:
             - "tls-cert-file=<path/to/tls-cert-file>"
             - "tls-private-key-file=<path/to/tls-private-key-file>"
           Permissive - When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
-        scored: false
+        scored: true
 
       - id: 4.2.10
         text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"
@@ -365,7 +365,7 @@ groups:
           If using the command line, remove the K3s flag --kubelet-arg="rotate-certificates".
           Based on your system, restart the k3s service. For example,
           systemctl restart k3s.service
-        scored: false
+        scored: true
 
       - id: 4.2.11
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Automated)"

--- a/package/cfg/k3s-cis-1.8-permissive/policies.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/policies.yaml
@@ -143,7 +143,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostPID` containers.
           Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
-        scored: false
+        scored: true
 
       - id: 5.2.4
         text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
@@ -152,7 +152,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostIPC` containers.
           Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
-        scored: false
+        scored: true
 
       - id: 5.2.5
         text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
@@ -161,7 +161,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostNetwork` containers.
           Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
-        scored: false
+        scored: true
 
       - id: 5.2.6
         text: "Minimize the admission of containers with allowPrivilegeEscalation (Automated)"
@@ -177,7 +177,7 @@ groups:
         remediation: |
           Create a policy for each namespace in the cluster, ensuring that either `MustRunAsNonRoot`
           or `MustRunAs` with the range of UIDs not including 0, is set.
-        scored: false
+        scored: true
 
       - id: 5.2.8
         text: "Minimize the admission of containers with the NET_RAW capability (Automated)"
@@ -185,7 +185,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with the `NET_RAW` capability.
-        scored: false
+        scored: true
 
       - id: 5.2.9
         text: "Minimize the admission of containers with added capabilities (Automated)"
@@ -193,7 +193,7 @@ groups:
         remediation: |
           Ensure that `allowedCapabilities` is not present in policies for the cluster unless
           it is set to an empty array.
-        scored: false
+        scored: true
 
       - id: 5.2.10
         text: "Minimize the admission of containers with capabilities assigned (Manual)"

--- a/package/cfg/rke-cis-1.23-hardened/master.yaml
+++ b/package/cfg/rke-cis-1.23-hardened/master.yaml
@@ -133,7 +133,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chmod 644 <path/to/cni/files>
-        scored: false
+        scored: true
 
       - id: 1.1.10
         text: "Ensure that the Container Network Interface file ownership is set to root:root (Automated)"
@@ -148,7 +148,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chown root:root <path/to/cni/files>
-        scored: false
+        scored: true
 
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 600 or more restrictive (Automated)"
@@ -412,7 +412,7 @@ groups:
           and set the below parameters.
           --enable-admission-plugins=...,EventRateLimit,...
           --admission-control-config-file=<path/to/configuration/file>
-        scored: true
+        scored: false
 
       - id: 1.2.11
         text: "Ensure that the admission control plugin AlwaysAdmit is not set (Automated)"
@@ -771,7 +771,7 @@ groups:
         scored: true
 
       - id: 1.2.32
-        text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Automated)"
+        text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -806,7 +806,7 @@ groups:
           Edit the Controller Manager pod specification file $controllermanagerconf
           on the control plane node and set the --terminated-pod-gc-threshold to an appropriate threshold,
           for example, --terminated-pod-gc-threshold=10
-        scored: false
+        scored: true
 
       - id: 1.3.2
         text: "Ensure that the --profiling argument is set to false (Automated)"

--- a/package/cfg/rke-cis-1.23-hardened/node.yaml
+++ b/package/cfg/rke-cis-1.23-hardened/node.yaml
@@ -255,7 +255,7 @@ groups:
         scored: true
 
       - id: 4.2.5
-        text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
+        text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
@@ -353,7 +353,7 @@ groups:
         scored: false
 
       - id: 4.2.9
-        text: "Ensure that the --event-qps argument is set to 0 or a level which ensures appropriate event capture (Manual)"
+        text: "Ensure that the --event-qps argument is set to 0 or a level which ensures appropriate event capture (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:

--- a/package/cfg/rke-cis-1.23-hardened/policies.yaml
+++ b/package/cfg/rke-cis-1.23-hardened/policies.yaml
@@ -165,7 +165,7 @@ groups:
         remediation: |
           Create a policy for each namespace in the cluster, ensuring that either `MustRunAsNonRoot`
           or `MustRunAs` with the range of UIDs not including 0, is set.
-        scored: false
+        scored: true
 
       - id: 5.2.8
         text: "Minimize the admission of containers with the NET_RAW capability (Automated)"
@@ -173,7 +173,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with the `NET_RAW` capability.
-        scored: false
+        scored: true
 
       - id: 5.2.9
         text: "Minimize the admission of containers with added capabilities (Automated)"
@@ -181,7 +181,7 @@ groups:
         remediation: |
           Ensure that `allowedCapabilities` is not present in policies for the cluster unless
           it is set to an empty array.
-        scored: false
+        scored: true
 
       - id: 5.2.10
         text: "Minimize the admission of containers with capabilities assigned (Manual)"

--- a/package/cfg/rke-cis-1.23-permissive/controlplane.yaml
+++ b/package/cfg/rke-cis-1.23-permissive/controlplane.yaml
@@ -20,7 +20,7 @@ groups:
     text: "Logging"
     checks:
       - id: 3.2.1
-        text: "Ensure that a minimal audit policy is created (Manual)"
+        text: "Ensure that a minimal audit policy is created (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:

--- a/package/cfg/rke-cis-1.23-permissive/master.yaml
+++ b/package/cfg/rke-cis-1.23-permissive/master.yaml
@@ -384,7 +384,7 @@ groups:
         scored: true
 
       - id: 1.2.10
-        text: "Ensure that the admission control plugin EventRateLimit is set (Automated)"
+        text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:

--- a/package/cfg/rke-cis-1.23-permissive/node.yaml
+++ b/package/cfg/rke-cis-1.23-permissive/node.yaml
@@ -36,7 +36,7 @@ groups:
         scored: true
 
       - id: 4.1.3
-        text: "If proxy kubeconfig file exists ensure permissions are set to 644 or more restrictive (Manual)"
+        text: "If proxy kubeconfig file exists ensure permissions are set to 644 or more restrictive (Automated)"
         audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c permissions=%a $proxykubeconfig; fi'' '
         tests:
           bin_op: or
@@ -55,7 +55,7 @@ groups:
         scored: true
 
       - id: 4.1.4
-        text: "If proxy kubeconfig file exists ensure ownership is set to root:root (Manual)"
+        text: "If proxy kubeconfig file exists ensure ownership is set to root:root (Automated)"
         audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c %U:%G $proxykubeconfig; fi'' '
         tests:
           bin_op: or

--- a/package/cfg/rke-cis-1.23-permissive/policies.yaml
+++ b/package/cfg/rke-cis-1.23-permissive/policies.yaml
@@ -57,7 +57,7 @@ groups:
           to the Kubernetes API server.
           Modify the configuration of each default service account to include this value
           automountServiceAccountToken: false
-        scored: false
+        scored: true
 
       - id: 5.1.6
         text: "Ensure that Service Account Tokens are only mounted where necessary (Manual)"
@@ -106,7 +106,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostPID` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.4
         text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
@@ -114,7 +114,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostIPC` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.5
         text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
@@ -122,7 +122,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostNetwork` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.6
         text: "Minimize the admission of containers with allowPrivilegeEscalation (Manual)"

--- a/package/cfg/rke-cis-1.24-hardened/master.yaml
+++ b/package/cfg/rke-cis-1.24-hardened/master.yaml
@@ -148,7 +148,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chown root:root <path/to/cni/files>
-        scored: false
+        scored: true
 
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 600 or more restrictive (Automated)"
@@ -452,7 +452,6 @@ groups:
 
       - id: 1.2.13
         text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)"
-        type: "manual"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           bin_op: or
@@ -472,7 +471,7 @@ groups:
           on the control plane node and set the --enable-admission-plugins parameter to include
           SecurityContextDeny, unless PodSecurityPolicy is already in place.
           --enable-admission-plugins=...,SecurityContextDeny,...
-        scored: true
+        scored: false
 
       - id: 1.2.14
         text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
@@ -743,7 +742,7 @@ groups:
         scored: true
 
       - id: 1.2.30
-        text: "Ensure that the --encryption-provider-config argument is set as appropriate (Automated)"
+        text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -772,7 +771,7 @@ groups:
         scored: true
 
       - id: 1.2.32
-        text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Automated)"
+        text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -807,7 +806,7 @@ groups:
           Edit the Controller Manager pod specification file $controllermanagerconf
           on the control plane node and set the --terminated-pod-gc-threshold to an appropriate threshold,
           for example, --terminated-pod-gc-threshold=10
-        scored: false
+        scored: true
 
       - id: 1.3.2
         text: "Ensure that the --profiling argument is set to false (Automated)"

--- a/package/cfg/rke-cis-1.24-hardened/node.yaml
+++ b/package/cfg/rke-cis-1.24-hardened/node.yaml
@@ -251,7 +251,7 @@ groups:
         scored: true
 
       - id: 4.2.5
-        text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
+        text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
@@ -349,7 +349,7 @@ groups:
         scored: false
 
       - id: 4.2.9
-        text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
+        text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
@@ -421,7 +421,7 @@ groups:
         scored: true
 
       - id: 4.2.12
-        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
+        text: "Verify that the RotateKubeletServerCertificate argument is set to true (Automated)"
         type: "skip"
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "

--- a/package/cfg/rke-cis-1.24-permissive/controlplane.yaml
+++ b/package/cfg/rke-cis-1.24-permissive/controlplane.yaml
@@ -20,7 +20,7 @@ groups:
     text: "Logging"
     checks:
       - id: 3.2.1
-        text: "Ensure that a minimal audit policy is created (Manual)"
+        text: "Ensure that a minimal audit policy is created (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:

--- a/package/cfg/rke-cis-1.24-permissive/master.yaml
+++ b/package/cfg/rke-cis-1.24-permissive/master.yaml
@@ -429,7 +429,7 @@ groups:
         scored: true
 
       - id: 1.2.12
-        text: "Ensure that the admission control plugin AlwaysPullImages is set (Automated)"
+        text: "Ensure that the admission control plugin AlwaysPullImages is set (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -445,7 +445,7 @@ groups:
         scored: false
 
       - id: 1.2.13
-        text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Automated)"
+        text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           bin_op: or
@@ -764,7 +764,7 @@ groups:
         scored: false
 
       - id: 1.2.32
-        text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Automated)"
+        text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
           test_items:
@@ -789,7 +789,7 @@ groups:
     text: "Controller Manager"
     checks:
       - id: 1.3.1
-        text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Manual)"
+        text: "Ensure that the --terminated-pod-gc-threshold argument is set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
         tests:
           test_items:

--- a/package/cfg/rke-cis-1.24-permissive/node.yaml
+++ b/package/cfg/rke-cis-1.24-permissive/node.yaml
@@ -37,7 +37,7 @@ groups:
         scored: true
 
       - id: 4.1.3
-        text: "If proxy kubeconfig file exists ensure permissions are set to 600 or more restrictive (Manual)"
+        text: "If proxy kubeconfig file exists ensure permissions are set to 600 or more restrictive (Automated)"
         audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c permissions=%a $proxykubeconfig; fi'' '
         tests:
           bin_op: or
@@ -54,7 +54,7 @@ groups:
         scored: true
 
       - id: 4.1.4
-        text: "If proxy kubeconfig file exists ensure ownership is set to root:root (Manual)"
+        text: "If proxy kubeconfig file exists ensure ownership is set to root:root (Automated)"
         audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c %U:%G $proxykubeconfig; fi'' '
         tests:
           bin_op: or
@@ -133,7 +133,7 @@ groups:
         remediation: |
           Cluster provisioned by RKE doesn't require or maintain a configuration file for the kubelet.
           All configuration is passed in as arguments at container run time.
-        scored: true
+        scored: false
 
       - id: 4.1.10
         text: "If the kubelet config.yaml configuration file is being used validate file ownership is set to root:root (Manual)"
@@ -145,7 +145,7 @@ groups:
         remediation: |
           Cluster provisioned by RKE doesn’t require or maintain a configuration file for the kubelet.
           All configuration is passed in as arguments at container run time.
-        scored: true
+        scored: false
 
   - id: 4.2
     text: "Kubelet"

--- a/package/cfg/rke-cis-1.24-permissive/policies.yaml
+++ b/package/cfg/rke-cis-1.24-permissive/policies.yaml
@@ -106,7 +106,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostPID` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.4
         text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
@@ -114,7 +114,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostIPC` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.5
         text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
@@ -122,7 +122,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostNetwork` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.6
         text: "Minimize the admission of containers with allowPrivilegeEscalation (Automated)"
@@ -130,7 +130,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with `.spec.allowPrivilegeEscalation` set to `true`.
-        scored: false
+        scored: true
 
       - id: 5.2.7
         text: "Minimize the admission of root containers (Automated)"
@@ -138,7 +138,7 @@ groups:
         remediation: |
           Create a policy for each namespace in the cluster, ensuring that either `MustRunAsNonRoot`
           or `MustRunAs` with the range of UIDs not including 0, is set.
-        scored: false
+        scored: true
 
       - id: 5.2.8
         text: "Minimize the admission of containers with the NET_RAW capability (Automated)"
@@ -146,7 +146,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with the `NET_RAW` capability.
-        scored: false
+        scored: true
 
       - id: 5.2.9
         text: "Minimize the admission of containers with added capabilities (Automated)"
@@ -154,7 +154,7 @@ groups:
         remediation: |
           Ensure that `allowedCapabilities` is not present in policies for the cluster unless
           it is set to an empty array.
-        scored: false
+        scored: true
 
       - id: 5.2.10
         text: "Minimize the admission of containers with capabilities assigned (Manual)"

--- a/package/cfg/rke-cis-1.7-hardened/policies.yaml
+++ b/package/cfg/rke-cis-1.7-hardened/policies.yaml
@@ -136,24 +136,27 @@ groups:
 
       - id: 5.2.3
         text: "Minimize the admission of containers wishing to share the host process ID namespace (Automated)"
+        type: "manual"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostPID` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.4
         text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
+        type: "manual"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostIPC` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.5
         text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
+        type: "manual"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostNetwork` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.6
         text: "Minimize the admission of containers with allowPrivilegeEscalation (Manual)"

--- a/package/cfg/rke-cis-1.7-permissive/policies.yaml
+++ b/package/cfg/rke-cis-1.7-permissive/policies.yaml
@@ -143,7 +143,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostPID` containers.
           Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
-        scored: false
+        scored: true
 
       - id: 5.2.4
         text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
@@ -152,7 +152,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostIPC` containers.
           Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
-        scored: false
+        scored: true
 
       - id: 5.2.5
         text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
@@ -161,7 +161,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostNetwork` containers.
           Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
-        scored: false
+        scored: true
 
       - id: 5.2.6
         text: "Minimize the admission of containers with allowPrivilegeEscalation (Manual)"

--- a/package/cfg/rke-cis-1.8-hardened/controlplane.yaml
+++ b/package/cfg/rke-cis-1.8-hardened/controlplane.yaml
@@ -15,6 +15,7 @@ groups:
           Alternative mechanisms provided by Kubernetes such as the use of OIDC should be
           implemented in place of client certificates.
         scored: false
+
       - id: 3.1.2
         text: "Service account token authentication should not be used for users (Manual)"
         type: "manual"
@@ -22,6 +23,7 @@ groups:
           Alternative mechanisms provided by Kubernetes such as the use of OIDC should be implemented
           in place of service account tokens.
         scored: false
+
       - id: 3.1.3
         text: "Bootstrap token authentication should not be used for users (Manual)"
         type: "manual"
@@ -29,6 +31,7 @@ groups:
           Alternative mechanisms provided by Kubernetes such as the use of OIDC should be implemented
           in place of bootstrap tokens.
         scored: false
+
   - id: 3.2
     text: "Logging"
     checks:
@@ -42,6 +45,7 @@ groups:
         remediation: |
           Create an audit policy file for your cluster.
         scored: true
+
       - id: 3.2.2
         text: "Ensure that the audit policy covers key security concerns (Manual)"
         type: "manual"

--- a/package/cfg/rke-cis-1.8-hardened/etcd.yaml
+++ b/package/cfg/rke-cis-1.8-hardened/etcd.yaml
@@ -24,6 +24,7 @@ groups:
           Run the below command (based on the etcd data directory found above). For example,
           chmod 700 /var/lib/etcd
         scored: true
+
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
         audit: "stat -c %U:%G /node/var/lib/etcd"
@@ -37,6 +38,7 @@ groups:
           Run the below command (based on the etcd data directory found above).
           For example, chown etcd:etcd /var/lib/etcd
         scored: true
+
       - id: 1.1.19
         text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
         audit: "check_files_owner_in_dir.sh /node/etc/kubernetes/ssl"
@@ -52,6 +54,7 @@ groups:
           For example,
           chown -R root:root /etc/kubernetes/pki/
         scored: true
+
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"
         audit: "find /node/etc/kubernetes/ssl/ -name '*.pem' ! -name '*key.pem' | xargs stat -c permissions=%a"
@@ -67,6 +70,7 @@ groups:
           For example,
           find /node/etc/kubernetes/ssl/ -name '*.pem' ! -name '*key.pem' -exec chmod -R 600 {} +
         scored: false
+
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
         audit: "find /node/etc/kubernetes/ssl/ -name '*key.pem' | xargs stat -c permissions=%a"
@@ -82,6 +86,7 @@ groups:
           For example,
           find /node/etc/kubernetes/ssl/ -name '*key.pem' -exec chmod -R 600 {} +
         scored: false
+
   - id: 2
     text: "Etcd Node Configuration"
     checks:
@@ -102,6 +107,7 @@ groups:
           --cert-file=</path/to/ca-file>
           --key-file=</path/to/key-file>
         scored: true
+
       - id: 2.2
         text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
         audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
@@ -117,6 +123,7 @@ groups:
           node and set the below parameter.
           --client-cert-auth="true"
         scored: true
+
       - id: 2.3
         text: "Ensure that the --auto-tls argument is not set to true (Automated)"
         audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
@@ -136,6 +143,7 @@ groups:
           node and either remove the --auto-tls parameter or set it to false.
             --auto-tls=false
         scored: true
+
       - id: 2.4
         text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
         audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
@@ -154,6 +162,7 @@ groups:
           --peer-client-file=</path/to/peer-cert-file>
           --peer-key-file=</path/to/peer-key-file>
         scored: true
+
       - id: 2.5
         text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
         audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
@@ -169,6 +178,7 @@ groups:
           node and set the below parameter.
           --peer-client-cert-auth=true
         scored: true
+
       - id: 2.6
         text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
         audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
@@ -188,6 +198,7 @@ groups:
           node and either remove the --peer-auto-tls parameter or set it to false.
           --peer-auto-tls=false
         scored: true
+
       - id: 2.7
         text: "Ensure that a unique Certificate Authority is used for etcd (Automated)"
         audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"

--- a/package/cfg/rke-cis-1.8-hardened/master.yaml
+++ b/package/cfg/rke-cis-1.8-hardened/master.yaml
@@ -25,6 +25,7 @@ groups:
           Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
+
       - id: 1.1.2
         text: "Ensure that the API server pod specification file ownership is set to root:root (Automated)"
         type: "skip"
@@ -38,6 +39,7 @@ groups:
           Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
+
       - id: 1.1.3
         text: "Ensure that the controller manager pod specification file permissions are set to 600 or more restrictive (Automated)"
         type: "skip"
@@ -54,6 +56,7 @@ groups:
           Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
+
       - id: 1.1.4
         text: "Ensure that the controller manager pod specification file ownership is set to root:root (Automated)"
         type: "skip"
@@ -67,6 +70,7 @@ groups:
           Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
+
       - id: 1.1.5
         text: "Ensure that the scheduler pod specification file permissions are set to 600 or more restrictive (Automated)"
         type: "skip"
@@ -83,6 +87,7 @@ groups:
           Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
+
       - id: 1.1.6
         text: "Ensure that the scheduler pod specification file ownership is set to root:root (Automated)"
         type: "skip"
@@ -96,6 +101,7 @@ groups:
           Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
+
       - id: 1.1.7
         text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
         type: "skip"
@@ -114,6 +120,7 @@ groups:
           Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
+
       - id: 1.1.8
         text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
         type: "skip"
@@ -129,6 +136,7 @@ groups:
           Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
+
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Manual)"
         audit: |
@@ -145,6 +153,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chmod 600 <path/to/cni/files>
         scored: false
+
       - id: 1.1.10
         text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
         audit: |
@@ -159,6 +168,7 @@ groups:
           For example,
           chown root:root <path/to/cni/files>
         scored: false
+
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 600 or more restrictive (Automated)"
         type: "skip"
@@ -174,6 +184,7 @@ groups:
           For example, chmod 600 /etc/kubernetes/admin.conf
           Not Applicable -  Cluster provisioned by RKE does not store the kubernetes default kubeconfig credentials file on the nodes.
         scored: true
+
       - id: 1.1.14
         text: "Ensure that the admin.conf file ownership is set to root:root (Automated)"
         type: "skip"
@@ -186,6 +197,7 @@ groups:
           For example, chown root:root /etc/kubernetes/admin.conf
           Not Applicable -  Cluster provisioned by RKE does not store the kubernetes default kubeconfig credentials file on the nodes.
         scored: true
+
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 600 or more restrictive (Automated)"
         type: "skip"
@@ -203,6 +215,7 @@ groups:
           Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for scheduler.
           All configuration is passed in as arguments at container run time.
         scored: true
+
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
         type: "skip"
@@ -217,6 +230,7 @@ groups:
           Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for scheduler.
           All configuration is passed in as arguments at container run time.
         scored: true
+
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 600 or more restrictive (Automated)"
         type: "skip"
@@ -234,6 +248,7 @@ groups:
           Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for controller-manager.
           All configuration is passed in as arguments at container run time.
         scored: true
+
       - id: 1.1.18
         text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
         type: "skip"
@@ -248,6 +263,7 @@ groups:
           Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for controller-manager.
           All configuration is passed in as arguments at container run time.
         scored: true
+
   - id: 1.2
     text: "API Server"
     checks:
@@ -266,6 +282,7 @@ groups:
           on the control plane node and set the below parameter.
           --anonymous-auth=false
         scored: true
+
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -278,6 +295,7 @@ groups:
           edit the API server pod specification file $apiserverconf
           on the control plane node and remove the --token-auth-file=<filename> parameter.
         scored: true
+
       - id: 1.2.3
         text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -296,6 +314,7 @@ groups:
           on the control plane node and remove the `DenyServiceExternalIPs`
           from enabled admission plugins.
         scored: true
+
       - id: 1.2.4
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -312,6 +331,7 @@ groups:
           --kubelet-client-certificate=<path/to/client-certificate-file>
           --kubelet-client-key=<path/to/client-key-file>
         scored: true
+
       - id: 1.2.5
         text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
         type: "skip"
@@ -328,6 +348,7 @@ groups:
           --kubelet-certificate-authority=<ca-string>
           When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
         scored: true
+
       - id: 1.2.6
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -343,6 +364,7 @@ groups:
           One such example could be as below.
           --authorization-mode=RBAC
         scored: true
+
       - id: 1.2.7
         text: "Ensure that the --authorization-mode argument includes Node (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -357,6 +379,7 @@ groups:
           on the control plane node and set the --authorization-mode parameter to a value that includes Node.
           --authorization-mode=Node,RBAC
         scored: true
+
       - id: 1.2.8
         text: "Ensure that the --authorization-mode argument includes RBAC (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -371,6 +394,7 @@ groups:
           on the control plane node and set the --authorization-mode parameter to a value that includes RBAC,
           for example `--authorization-mode=Node,RBAC`.
         scored: true
+
       - id: 1.2.9
         text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -387,6 +411,7 @@ groups:
           --enable-admission-plugins=...,EventRateLimit,...
           --admission-control-config-file=<path/to/configuration/file>
         scored: false
+
       - id: 1.2.10
         text: "Ensure that the admission control plugin AlwaysAdmit is not set (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -404,6 +429,7 @@ groups:
           on the control plane node and either remove the --enable-admission-plugins parameter, or set it to a
           value that does not include AlwaysAdmit.
         scored: true
+
       - id: 1.2.11
         text: "Ensure that the admission control plugin AlwaysPullImages is set (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -419,6 +445,7 @@ groups:
           AlwaysPullImages.
           --enable-admission-plugins=...,AlwaysPullImages,...
         scored: false
+
       - id: 1.2.12
         text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -439,6 +466,7 @@ groups:
           SecurityContextDeny, unless PodSecurityPolicy is already in place.
           --enable-admission-plugins=...,SecurityContextDeny,...
         scored: false
+
       - id: 1.2.13
         text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -457,6 +485,7 @@ groups:
           on the control plane node and ensure that the --disable-admission-plugins parameter is set to a
           value that does not include ServiceAccount.
         scored: true
+
       - id: 1.2.14
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -474,6 +503,7 @@ groups:
           on the control plane node and set the --disable-admission-plugins parameter to
           ensure it does not include NamespaceLifecycle.
         scored: true
+
       - id: 1.2.15
         text: "Ensure that the admission control plugin NodeRestriction is set (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -490,6 +520,7 @@ groups:
           value that includes NodeRestriction.
           --enable-admission-plugins=...,NodeRestriction,...
         scored: true
+
       - id: 1.2.16
         text: "Ensure that the --profiling argument is set to false (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -504,6 +535,7 @@ groups:
           on the control plane node and set the below parameter.
           --profiling=false
         scored: true
+
       - id: 1.2.17
         text: "Ensure that the --audit-log-path argument is set (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -516,6 +548,7 @@ groups:
           file where you would like audit logs to be written, for example,
           --audit-log-path=/var/log/apiserver/audit.log
         scored: true
+
       - id: 1.2.18
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -531,6 +564,7 @@ groups:
           or as an appropriate number of days, for example,
           --audit-log-maxage=30
         scored: true
+
       - id: 1.2.19
         text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -546,6 +580,7 @@ groups:
           value. For example,
           --audit-log-maxbackup=10
         scored: true
+
       - id: 1.2.20
         text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -560,6 +595,7 @@ groups:
           on the control plane node and set the --audit-log-maxsize parameter to an appropriate size in MB.
           For example, to set it as 100 MB, --audit-log-maxsize=100
         scored: true
+
       - id: 1.2.21
         text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -569,6 +605,7 @@ groups:
           and set the below parameter as appropriate and if needed.
           For example, --request-timeout=300s
         scored: false
+
       - id: 1.2.22
         text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -588,6 +625,7 @@ groups:
           Alternatively, you can delete the --service-account-lookup parameter from this file so
           that the default takes effect.
         scored: true
+
       - id: 1.2.23
         text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -600,6 +638,7 @@ groups:
           to the public key file for service accounts. For example,
           --service-account-key-file=<filename>
         scored: true
+
       - id: 1.2.24
         text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -615,6 +654,7 @@ groups:
           --etcd-certfile=<path/to/client-certificate-file>
           --etcd-keyfile=<path/to/client-key-file>
         scored: true
+
       - id: 1.2.25
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -630,6 +670,7 @@ groups:
           --tls-cert-file=<path/to/tls-certificate-file>
           --tls-private-key-file=<path/to/tls-key-file>
         scored: true
+
       - id: 1.2.26
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -642,6 +683,7 @@ groups:
           on the control plane node and set the client certificate authority file.
           --client-ca-file=<path/to/client-ca-file>
         scored: true
+
       - id: 1.2.27
         text: "Ensure that the --etcd-cafile argument is set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -654,6 +696,7 @@ groups:
           on the control plane node and set the etcd certificate authority file parameter.
           --etcd-cafile=<path/to/ca-file>
         scored: true
+
       - id: 1.2.28
         text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -666,6 +709,7 @@ groups:
           on the control plane node and set the --encryption-provider-config parameter to the path of that file.
           For example, --encryption-provider-config=</path/to/EncryptionConfig/File>
         scored: false
+
       - id: 1.2.29
         text: "Ensure that encryption providers are appropriately configured (Manual)"
         audit: |
@@ -681,6 +725,7 @@ groups:
           Follow the Kubernetes documentation and configure a EncryptionConfig file.
           In this file, choose aescbc, kms or secretbox as the encryption provider.
         scored: false
+
       - id: 1.2.30
         text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -702,6 +747,7 @@ groups:
           TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_RSA_WITH_3DES_EDE_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,
           TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_256_GCM_SHA384
         scored: false
+
   - id: 1.3
     text: "Controller Manager"
     checks:
@@ -716,6 +762,7 @@ groups:
           on the control plane node and set the --terminated-pod-gc-threshold to an appropriate threshold,
           for example, --terminated-pod-gc-threshold=10
         scored: true
+
       - id: 1.3.2
         text: "Ensure that the --profiling argument is set to false (Automated)"
         audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
@@ -730,6 +777,7 @@ groups:
           on the control plane node and set the below parameter.
           --profiling=false
         scored: true
+
       - id: 1.3.3
         text: "Ensure that the --use-service-account-credentials argument is set to true (Automated)"
         audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
@@ -744,6 +792,7 @@ groups:
           on the control plane node to set the below parameter.
           --use-service-account-credentials=true
         scored: true
+
       - id: 1.3.4
         text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
@@ -756,6 +805,7 @@ groups:
           to the private key file for service accounts.
           --service-account-private-key-file=<filename>
         scored: true
+
       - id: 1.3.5
         text: "Ensure that the --root-ca-file argument is set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
@@ -767,6 +817,7 @@ groups:
           on the control plane node and set the --root-ca-file parameter to the certificate bundle file`.
           --root-ca-file=<path/to/file>
         scored: true
+
       - id: 1.3.6
         text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
         type: "skip"
@@ -787,6 +838,7 @@ groups:
           --feature-gates=RotateKubeletServerCertificate=true
           Cluster provisioned by RKE handles certificate rotation directly through RKE.
         scored: true
+
       - id: 1.3.7
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
         audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
@@ -803,6 +855,7 @@ groups:
           Edit the Controller Manager pod specification file $controllermanagerconf
           on the control plane node and ensure the correct value for the --bind-address parameter
         scored: true
+
   - id: 1.4
     text: "Scheduler"
     checks:
@@ -820,6 +873,7 @@ groups:
           on the control plane node and set the below parameter.
           --profiling=false
         scored: true
+
       - id: 1.4.2
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
         audit: "/bin/ps -ef | grep $schedulerbin | grep -v grep"

--- a/package/cfg/rke-cis-1.8-hardened/node.yaml
+++ b/package/cfg/rke-cis-1.8-hardened/node.yaml
@@ -24,6 +24,7 @@ groups:
           Not Applicable - Clusters provisioned by RKE doesn’t require or maintain a configuration file for the kubelet service.
           All configuration is passed in as arguments at container run time.
         scored: true
+
       - id: 4.1.2
         text: "Ensure that the kubelet service file ownership is set to root:root (Automated)"
         type: "skip"
@@ -38,6 +39,7 @@ groups:
           Not Applicable - Clusters provisioned by RKE doesn’t require or maintain a configuration file for the kubelet service.
            All configuration is passed in as arguments at container run time.
         scored: true
+
       - id: 4.1.3
         text: "If proxy kubeconfig file exists ensure permissions are set to 600 or more restrictive (Automated)"
         audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c permissions=%a $proxykubeconfig; fi'' '
@@ -54,6 +56,7 @@ groups:
           For example,
           chmod 600 $proxykubeconfig
         scored: true
+
       - id: 4.1.4
         text: "If proxy kubeconfig file exists ensure ownership is set to root:root (Automated)"
         audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c %U:%G $proxykubeconfig; fi'' '
@@ -65,6 +68,7 @@ groups:
           Run the below command (based on the file location on your system) on the each worker node.
           For example, chown root:root $proxykubeconfig
         scored: true
+
       - id: 4.1.5
         text: "Ensure that the --kubeconfig kubelet.conf file permissions are set to 600 or more restrictive (Automated)"
         audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c permissions=%a $kubeletkubeconfig; fi'' '
@@ -79,6 +83,7 @@ groups:
           For example,
           chmod 600 $kubeletkubeconfig
         scored: true
+
       - id: 4.1.6
         text: "Ensure that the --kubeconfig kubelet.conf file ownership is set to root:root (Automated)"
         audit: '/bin/sh -c ''if test -e $kubeletkubeconfig; then stat -c %U:%G $kubeletkubeconfig; fi'' '
@@ -90,6 +95,7 @@ groups:
           For example,
           chown root:root $kubeletkubeconfig
         scored: true
+
       - id: 4.1.7
         text: "Ensure that the certificate authorities file permissions are set to 600 or more restrictive (Automated)"
         audit: "stat -c permissions=%a /node/etc/kubernetes/ssl/kube-ca.pem"
@@ -103,6 +109,7 @@ groups:
           Run the following command to modify the file permissions of the
           --client-ca-file chmod 600 <filename>
         scored: true
+
       - id: 4.1.8
         text: "Ensure that the client certificate authorities file ownership is set to root:root (Automated)"
         audit: "stat -c %U:%G /node/etc/kubernetes/ssl/kube-ca.pem"
@@ -116,6 +123,7 @@ groups:
           Run the following command to modify the ownership of the --client-ca-file.
           chown root:root <filename>
         scored: true
+
       - id: 4.1.9
         text: "If the kubelet config.yaml configuration file is being used validate permissions set to 600 or more restrictive (Automated)"
         type: "skip"
@@ -132,6 +140,7 @@ groups:
           Not Applicable - Clusters provisioned by RKE do not require or maintain a configuration file for the kubelet.
           All configuration is passed in as arguments at container run time.
         scored: true
+
       - id: 4.1.10
         text: "If the kubelet config.yaml configuration file is being used validate file ownership is set to root:root (Manual)"
         type: "skip"
@@ -145,6 +154,7 @@ groups:
           Not Applicable - Clusters provisioned by RKE doesn’t require or maintain a configuration file for the kubelet.
           All configuration is passed in as arguments at container run time.
         scored: false
+
   - id: 4.2
     text: "Kubelet"
     checks:
@@ -170,6 +180,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: true
+
       - id: 4.2.2
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
@@ -191,6 +202,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: true
+
       - id: 4.2.3
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
@@ -210,6 +222,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: true
+
       - id: 4.2.4
         text: "Verify that the --read-only-port argument is set to 0 (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
@@ -235,6 +248,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: true
+
       - id: 4.2.5
         text: "Ensure that the --streaming-connection-idle-timeout argument is not set to 0 (Manual)"
         audit: "/bin/ps -fC $kubeletbin"
@@ -261,6 +275,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: false
+
       - id: 4.2.6
         text: "Ensure that the --make-iptables-util-chains argument is set to true (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
@@ -286,6 +301,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: true
+
       - id: 4.2.7
         text: "Ensure that the --hostname-override argument is not set (Manual)"
         # This is one of those properties that can only be set as a command line argument.
@@ -306,6 +322,7 @@ groups:
           systemctl restart kubelet.service
           Not Applicable - Clusters provisioned by RKE set the --hostname-override to avoid any hostname configuration errors
         scored: false
+
       - id: 4.2.8
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
         audit: "/bin/ps -fC $kubeletbin"
@@ -330,6 +347,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: false
+
       - id: 4.2.9
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
         audit: "/bin/ps -fC $kubeletbin"
@@ -353,6 +371,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: false
+
       - id: 4.2.10
         text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
@@ -379,6 +398,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: true
+
       - id: 4.2.11
         text: "Verify that the RotateKubeletServerCertificate argument is set to true (Manual)"
         type: "skip"
@@ -404,6 +424,7 @@ groups:
           systemctl restart kubelet.service
           Not Applicable - Clusters provisioned by RKE handles certificate rotation directly through RKE.
         scored: false
+
       - id: 4.2.12
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
@@ -427,6 +448,7 @@ groups:
           systemctl daemon-reload
           systemctl restart kubelet.service
         scored: true
+
       - id: 4.2.13
         text: "Ensure that a limit is set on pod PIDs (Manual)"
         audit: "/bin/ps -fC $kubeletbin"

--- a/package/cfg/rke-cis-1.8-hardened/policies.yaml
+++ b/package/cfg/rke-cis-1.8-hardened/policies.yaml
@@ -18,12 +18,14 @@ groups:
           clusterrolebinding to the cluster-admin role :
           kubectl delete clusterrolebinding [name]
         scored: false
+
       - id: 5.1.2
         text: "Minimize access to secrets (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove get, list and watch access to Secret objects in the cluster.
         scored: false
+
       - id: 5.1.3
         text: "Minimize wildcard use in Roles and ClusterRoles (Manual)"
         type: "manual"
@@ -31,12 +33,14 @@ groups:
           Where possible replace any use of wildcards in clusterroles and roles with specific
           objects or actions.
         scored: false
+
       - id: 5.1.4
         text: "Minimize access to create pods (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove create access to pod objects in the cluster.
         scored: false
+
       - id: 5.1.5
         text: "Ensure that default service accounts are not actively used. (Manual)"
         audit: check_for_default_sa.sh
@@ -53,6 +57,7 @@ groups:
           Modify the configuration of each default service account to include this value
           automountServiceAccountToken: false
         scored: false
+
       - id: 5.1.6
         text: "Ensure that Service Account Tokens are only mounted where necessary (Manual)"
         type: "manual"
@@ -60,48 +65,56 @@ groups:
           Modify the definition of pods and service accounts which do not need to mount service
           account tokens to disable it.
         scored: false
+
       - id: 5.1.7
         text: "Avoid use of system:masters group (Manual)"
         type: "manual"
         remediation: |
           Remove the system:masters group from all users in the cluster.
         scored: false
+
       - id: 5.1.8
         text: "Limit use of the Bind, Impersonate and Escalate permissions in the Kubernetes cluster (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove the impersonate, bind and escalate rights from subjects.
         scored: false
+
       - id: 5.1.9
         text: "Minimize access to create persistent volumes (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove create access to PersistentVolume objects in the cluster.
         scored: false
+
       - id: 5.1.10
         text: "Minimize access to the proxy sub-resource of nodes (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove access to the proxy sub-resource of node objects.
         scored: false
+
       - id: 5.1.11
         text: "Minimize access to the approval sub-resource of certificatesigningrequests objects (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove access to the approval sub-resource of certificatesigningrequest objects.
         scored: false
+
       - id: 5.1.12
         text: "Minimize access to webhook configuration objects (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove access to the validatingwebhookconfigurations or mutatingwebhookconfigurations objects
         scored: false
+
       - id: 5.1.13
         text: "Minimize access to the service account token creation (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove access to the token sub-resource of serviceaccount objects.
         scored: false
+
   - id: 5.2
     text: "Pod Security Standards"
     checks:
@@ -112,6 +125,7 @@ groups:
           Ensure that either Pod Security Admission or an external policy control system is in place
           for every namespace which contains user workloads.
         scored: false
+
       - id: 5.2.2
         text: "Minimize the admission of privileged containers (Manual)"
         type: "manual"
@@ -119,24 +133,31 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of privileged containers.
         scored: false
+
       - id: 5.2.3
         text: "Minimize the admission of containers wishing to share the host process ID namespace (Automated)"
+        type: "manual"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostPID` containers.
-        scored: false
+        scored: true
+
       - id: 5.2.4
         text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
+        type: "manual"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostIPC` containers.
-        scored: false
+        scored: true
+
       - id: 5.2.5
         text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
+        type: "manual"
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostNetwork` containers.
-        scored: false
+        scored: true
+
       - id: 5.2.6
         text: "Minimize the admission of containers with allowPrivilegeEscalation (Manual)"
         type: "manual"
@@ -144,6 +165,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with `.spec.allowPrivilegeEscalation` set to `true`.
         scored: false
+
       - id: 5.2.7
         text: "Minimize the admission of root containers (Manual)"
         type: "manual"
@@ -151,6 +173,7 @@ groups:
           Create a policy for each namespace in the cluster, ensuring that either `MustRunAsNonRoot`
           or `MustRunAs` with the range of UIDs not including 0, is set.
         scored: false
+
       - id: 5.2.8
         text: "Minimize the admission of containers with the NET_RAW capability (Manual)"
         type: "manual"
@@ -158,6 +181,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with the `NET_RAW` capability.
         scored: false
+
       - id: 5.2.9
         text: "Minimize the admission of containers with added capabilities (Manual)"
         type: "manual"
@@ -165,6 +189,7 @@ groups:
           Ensure that `allowedCapabilities` is not present in policies for the cluster unless
           it is set to an empty array.
         scored: false
+
       - id: 5.2.10
         text: "Minimize the admission of containers with capabilities assigned (Manual)"
         type: "manual"
@@ -173,6 +198,7 @@ groups:
           contains applicaions which do not require any Linux capabities to operate consider adding
           a PSP which forbids the admission of containers which do not drop all capabilities.
         scored: false
+
       - id: 5.2.11
         text: "Minimize the admission of Windows HostProcess containers (Manual)"
         type: "manual"
@@ -180,6 +206,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers that have `.securityContext.windowsOptions.hostProcess` set to `true`.
         scored: false
+
       - id: 5.2.12
         text: "Minimize the admission of HostPath volumes (Manual)"
         type: "manual"
@@ -187,6 +214,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with `hostPath` volumes.
         scored: false
+
       - id: 5.2.13
         text: "Minimize the admission of containers which use HostPorts (Manual)"
         type: "manual"
@@ -194,6 +222,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers which use `hostPort` sections.
         scored: false
+
   - id: 5.3
     text: "Network Policies and CNI"
     checks:
@@ -205,11 +234,13 @@ groups:
           making use of a different plugin, or finding an alternate mechanism for restricting traffic
           in the Kubernetes cluster.
         scored: false
+
       - id: 5.3.2
         text: "Ensure that all Namespaces have NetworkPolicies defined (Manual)"
         remediation: |
           Follow the documentation and create NetworkPolicy objects as you need them.
         scored: false
+
   - id: 5.4
     text: "Secrets Management"
     checks:
@@ -220,6 +251,7 @@ groups:
           If possible, rewrite application code to read Secrets from mounted secret files, rather than
           from environment variables.
         scored: false
+
       - id: 5.4.2
         text: "Consider external secret storage (Manual)"
         type: "manual"
@@ -227,6 +259,7 @@ groups:
           Refer to the Secrets management options offered by your cloud provider or a third-party
           secrets management solution.
         scored: false
+
   - id: 5.5
     text: "Extensible Admission Control"
     checks:
@@ -236,6 +269,7 @@ groups:
         remediation: |
           Follow the Kubernetes documentation and setup image provenance.
         scored: false
+
   - id: 5.7
     text: "General Policies"
     checks:
@@ -246,6 +280,7 @@ groups:
           Follow the documentation and create namespaces for objects in your deployment as you need
           them.
         scored: false
+
       - id: 5.7.2
         text: "Ensure that the seccomp profile is set to docker/default in your Pod definitions (Manual)"
         type: "manual"
@@ -256,6 +291,7 @@ groups:
               seccompProfile:
                 type: RuntimeDefault
         scored: false
+
       - id: 5.7.3
         text: "Apply SecurityContext to your Pods and Containers (Manual)"
         type: "manual"
@@ -264,6 +300,7 @@ groups:
           suggested list of SecurityContexts, you may refer to the CIS Security Benchmark for Docker
           Containers.
         scored: false
+
       - id: 5.7.4
         text: "The default namespace should not be used (Manual)"
         type: "skip"

--- a/package/cfg/rke-cis-1.8-permissive/controlplane.yaml
+++ b/package/cfg/rke-cis-1.8-permissive/controlplane.yaml
@@ -15,6 +15,7 @@ groups:
           Alternative mechanisms provided by Kubernetes such as the use of OIDC should be
           implemented in place of client certificates.
         scored: false
+
       - id: 3.1.2
         text: "Service account token authentication should not be used for users (Manual)"
         type: "manual"
@@ -22,6 +23,7 @@ groups:
           Alternative mechanisms provided by Kubernetes such as the use of OIDC should be implemented
           in place of service account tokens.
         scored: false
+
       - id: 3.1.3
         text: "Bootstrap token authentication should not be used for users (Manual)"
         type: "manual"
@@ -29,6 +31,7 @@ groups:
           Alternative mechanisms provided by Kubernetes such as the use of OIDC should be implemented
           in place of bootstrap tokens.
         scored: false
+
   - id: 3.2
     text: "Logging"
     checks:
@@ -42,6 +45,7 @@ groups:
         remediation: |
           Create an audit policy file for your cluster.
         scored: true
+
       - id: 3.2.2
         text: "Ensure that the audit policy covers key security concerns (Manual)"
         type: "manual"

--- a/package/cfg/rke-cis-1.8-permissive/etcd.yaml
+++ b/package/cfg/rke-cis-1.8-permissive/etcd.yaml
@@ -24,6 +24,7 @@ groups:
           Run the below command (based on the etcd data directory found above). For example,
           chmod 700 /var/lib/etcd
         scored: true
+
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
         type: "skip"
@@ -40,6 +41,7 @@ groups:
           Permissive - A system service account is required for etcd data directory ownership.
           Refer to Rancher's hardening guide for more details on how to configure this ownership.
         scored: true
+
       - id: 1.1.19
         text: "Ensure that the Kubernetes PKI directory and file ownership is set to root:root (Automated)"
         audit: "check_files_owner_in_dir.sh /node/etc/kubernetes/ssl"
@@ -55,6 +57,7 @@ groups:
           For example,
           chown -R root:root /etc/kubernetes/pki/
         scored: true
+
       - id: 1.1.20
         text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"
         audit: "find /node/etc/kubernetes/ssl/  -name '*.pem' ! -name '*key.pem' | xargs stat -c permissions=%a"
@@ -70,6 +73,7 @@ groups:
           For example,
           find /node/etc/kubernetes/ssl/  -name '*.pem' ! -name '*key.pem' -exec chmod -R 600 {} +
         scored: false
+
       - id: 1.1.21
         text: "Ensure that the Kubernetes PKI key file permissions are set to 600 (Manual)"
         audit: "find /node/etc/kubernetes/ssl/ -name '*key.pem' | xargs stat -c permissions=%a"
@@ -85,6 +89,7 @@ groups:
           For example,
           find /node/etc/kubernetes/ssl/ -name '*key.pem' -exec chmod -R 600 {} +
         scored: false
+
   - id: 2
     text: "Etcd Node Configuration"
     checks:
@@ -105,6 +110,7 @@ groups:
           --cert-file=</path/to/ca-file>
           --key-file=</path/to/key-file>
         scored: true
+
       - id: 2.2
         text: "Ensure that the --client-cert-auth argument is set to true (Automated)"
         audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
@@ -120,6 +126,7 @@ groups:
           node and set the below parameter.
           --client-cert-auth="true"
         scored: true
+
       - id: 2.3
         text: "Ensure that the --auto-tls argument is not set to true (Automated)"
         audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
@@ -139,6 +146,7 @@ groups:
           node and either remove the --auto-tls parameter or set it to false.
             --auto-tls=false
         scored: true
+
       - id: 2.4
         text: "Ensure that the --peer-cert-file and --peer-key-file arguments are set as appropriate (Automated)"
         audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
@@ -157,6 +165,7 @@ groups:
           --peer-client-file=</path/to/peer-cert-file>
           --peer-key-file=</path/to/peer-key-file>
         scored: true
+
       - id: 2.5
         text: "Ensure that the --peer-client-cert-auth argument is set to true (Automated)"
         audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
@@ -172,6 +181,7 @@ groups:
           node and set the below parameter.
           --peer-client-cert-auth=true
         scored: true
+
       - id: 2.6
         text: "Ensure that the --peer-auto-tls argument is not set to true (Automated)"
         audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"
@@ -191,6 +201,7 @@ groups:
           node and either remove the --peer-auto-tls parameter or set it to false.
           --peer-auto-tls=false
         scored: true
+
       - id: 2.7
         text: "Ensure that a unique Certificate Authority is used for etcd (Automated)"
         audit: "/bin/ps -ef | /bin/grep $etcdbin | /bin/grep -v grep"

--- a/package/cfg/rke-cis-1.8-permissive/master.yaml
+++ b/package/cfg/rke-cis-1.8-permissive/master.yaml
@@ -25,6 +25,7 @@ groups:
           Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
+
       - id: 1.1.2
         text: "Ensure that the API server pod specification file ownership is set to root:root (Automated)"
         type: "skip"
@@ -38,6 +39,7 @@ groups:
           Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
+
       - id: 1.1.3
         text: "Ensure that the controller manager pod specification file permissions are set to 600 or more restrictive (Automated)"
         type: "skip"
@@ -54,6 +56,7 @@ groups:
           Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
+
       - id: 1.1.4
         text: "Ensure that the controller manager pod specification file ownership is set to root:root (Automated)"
         type: "skip"
@@ -67,6 +70,7 @@ groups:
           Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
+
       - id: 1.1.5
         text: "Ensure that the scheduler pod specification file permissions are set to 600 or more restrictive (Automated)"
         type: "skip"
@@ -83,6 +87,7 @@ groups:
           Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
+
       - id: 1.1.6
         text: "Ensure that the scheduler pod specification file ownership is set to root:root (Automated)"
         type: "skip"
@@ -96,6 +101,7 @@ groups:
           Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
+
       - id: 1.1.7
         text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
         type: "skip"
@@ -114,6 +120,7 @@ groups:
           Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
+
       - id: 1.1.8
         text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
         type: "skip"
@@ -129,6 +136,7 @@ groups:
           Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for kube-apiserver.
           All configuration is passed in as arguments at container run time.
         scored: true
+
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Manual)"
         audit: |
@@ -145,6 +153,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chmod 600 <path/to/cni/files>
         scored: false
+
       - id: 1.1.10
         text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
         audit: |
@@ -159,6 +168,7 @@ groups:
           For example,
           chown root:root <path/to/cni/files>
         scored: false
+
       - id: 1.1.13
         text: "Ensure that the admin.conf file permissions are set to 600 or more restrictive (Automated)"
         type: "skip"
@@ -174,6 +184,7 @@ groups:
           For example, chmod 600 /etc/kubernetes/admin.conf
           Not Applicable -  Cluster provisioned by RKE does not store the kubernetes default kubeconfig credentials file on the nodes.
         scored: true
+
       - id: 1.1.14
         text: "Ensure that the admin.conf file ownership is set to root:root (Automated)"
         type: "skip"
@@ -186,6 +197,7 @@ groups:
           For example, chown root:root /etc/kubernetes/admin.conf
           Not Applicable -  Cluster provisioned by RKE does not store the kubernetes default kubeconfig credentials file on the nodes.
         scored: true
+
       - id: 1.1.15
         text: "Ensure that the scheduler.conf file permissions are set to 600 or more restrictive (Automated)"
         type: "skip"
@@ -203,6 +215,7 @@ groups:
           Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for scheduler.
           All configuration is passed in as arguments at container run time.
         scored: true
+
       - id: 1.1.16
         text: "Ensure that the scheduler.conf file ownership is set to root:root (Automated)"
         type: "skip"
@@ -217,6 +230,7 @@ groups:
           Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for scheduler.
           All configuration is passed in as arguments at container run time.
         scored: true
+
       - id: 1.1.17
         text: "Ensure that the controller-manager.conf file permissions are set to 600 or more restrictive (Automated)"
         type: "skip"
@@ -234,6 +248,7 @@ groups:
           Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for controller-manager.
           All configuration is passed in as arguments at container run time.
         scored: true
+
       - id: 1.1.18
         text: "Ensure that the controller-manager.conf file ownership is set to root:root (Automated)"
         type: "skip"
@@ -248,6 +263,7 @@ groups:
           Not Applicable -  Cluster provisioned by RKE doesn't require or maintain a configuration file for controller-manager.
           All configuration is passed in as arguments at container run time.
         scored: true
+
   - id: 1.2
     text: "API Server"
     checks:
@@ -266,6 +282,7 @@ groups:
           on the control plane node and set the below parameter.
           --anonymous-auth=false
         scored: true
+
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -278,6 +295,7 @@ groups:
           edit the API server pod specification file $apiserverconf
           on the control plane node and remove the --token-auth-file=<filename> parameter.
         scored: true
+
       - id: 1.2.3
         text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -296,6 +314,7 @@ groups:
           on the control plane node and remove the `DenyServiceExternalIPs`
           from enabled admission plugins.
         scored: true
+
       - id: 1.2.4
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -312,6 +331,7 @@ groups:
           --kubelet-client-certificate=<path/to/client-certificate-file>
           --kubelet-client-key=<path/to/client-key-file>
         scored: true
+
       - id: 1.2.5
         text: "Ensure that the --kubelet-certificate-authority argument is set as appropriate (Automated)"
         type: "skip"
@@ -328,6 +348,7 @@ groups:
           --kubelet-certificate-authority=<ca-string>
           Permissive - When generating serving certificates, functionality could break in conjunction with hostname overrides which are required for certain cloud providers.
         scored: true
+
       - id: 1.2.6
         text: "Ensure that the --authorization-mode argument is not set to AlwaysAllow (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -343,6 +364,7 @@ groups:
           One such example could be as below.
           --authorization-mode=RBAC
         scored: true
+
       - id: 1.2.7
         text: "Ensure that the --authorization-mode argument includes Node (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -357,6 +379,7 @@ groups:
           on the control plane node and set the --authorization-mode parameter to a value that includes Node.
           --authorization-mode=Node,RBAC
         scored: true
+
       - id: 1.2.8
         text: "Ensure that the --authorization-mode argument includes RBAC (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -371,6 +394,7 @@ groups:
           on the control plane node and set the --authorization-mode parameter to a value that includes RBAC,
           for example `--authorization-mode=Node,RBAC`.
         scored: true
+
       - id: 1.2.9
         text: "Ensure that the admission control plugin EventRateLimit is set (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -387,6 +411,7 @@ groups:
           --enable-admission-plugins=...,EventRateLimit,...
           --admission-control-config-file=<path/to/configuration/file>
         scored: false
+
       - id: 1.2.10
         text: "Ensure that the admission control plugin AlwaysAdmit is not set (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -404,6 +429,7 @@ groups:
           on the control plane node and either remove the --enable-admission-plugins parameter, or set it to a
           value that does not include AlwaysAdmit.
         scored: true
+
       - id: 1.2.11
         text: "Ensure that the admission control plugin AlwaysPullImages is set (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -419,6 +445,7 @@ groups:
           AlwaysPullImages.
           --enable-admission-plugins=...,AlwaysPullImages,...
         scored: false
+
       - id: 1.2.12
         text: "Ensure that the admission control plugin SecurityContextDeny is set if PodSecurityPolicy is not used (Manual)"
         type: "skip"
@@ -441,6 +468,7 @@ groups:
           --enable-admission-plugins=...,SecurityContextDeny,...
           Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
         scored: false
+
       - id: 1.2.13
         text: "Ensure that the admission control plugin ServiceAccount is set (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -459,6 +487,7 @@ groups:
           on the control plane node and ensure that the --disable-admission-plugins parameter is set to a
           value that does not include ServiceAccount.
         scored: true
+
       - id: 1.2.14
         text: "Ensure that the admission control plugin NamespaceLifecycle is set (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -476,6 +505,7 @@ groups:
           on the control plane node and set the --disable-admission-plugins parameter to
           ensure it does not include NamespaceLifecycle.
         scored: true
+
       - id: 1.2.15
         text: "Ensure that the admission control plugin NodeRestriction is set (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -492,6 +522,7 @@ groups:
           value that includes NodeRestriction.
           --enable-admission-plugins=...,NodeRestriction,...
         scored: true
+
       - id: 1.2.16
         text: "Ensure that the --profiling argument is set to false (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -506,6 +537,7 @@ groups:
           on the control plane node and set the below parameter.
           --profiling=false
         scored: true
+
       - id: 1.2.17
         text: "Ensure that the --audit-log-path argument is set (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -518,6 +550,7 @@ groups:
           file where you would like audit logs to be written, for example,
           --audit-log-path=/var/log/apiserver/audit.log
         scored: true
+
       - id: 1.2.18
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -533,6 +566,7 @@ groups:
           or as an appropriate number of days, for example,
           --audit-log-maxage=30
         scored: true
+
       - id: 1.2.19
         text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -548,6 +582,7 @@ groups:
           value. For example,
           --audit-log-maxbackup=10
         scored: true
+
       - id: 1.2.20
         text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -562,6 +597,7 @@ groups:
           on the control plane node and set the --audit-log-maxsize parameter to an appropriate size in MB.
           For example, to set it as 100 MB, --audit-log-maxsize=100
         scored: true
+
       - id: 1.2.21
         text: "Ensure that the --request-timeout argument is set as appropriate (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -571,6 +607,7 @@ groups:
           and set the below parameter as appropriate and if needed.
           For example, --request-timeout=300s
         scored: false
+
       - id: 1.2.22
         text: "Ensure that the --service-account-lookup argument is set to true (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -590,6 +627,7 @@ groups:
           Alternatively, you can delete the --service-account-lookup parameter from this file so
           that the default takes effect.
         scored: true
+
       - id: 1.2.23
         text: "Ensure that the --service-account-key-file argument is set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -602,6 +640,7 @@ groups:
           to the public key file for service accounts. For example,
           --service-account-key-file=<filename>
         scored: true
+
       - id: 1.2.24
         text: "Ensure that the --etcd-certfile and --etcd-keyfile arguments are set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -617,6 +656,7 @@ groups:
           --etcd-certfile=<path/to/client-certificate-file>
           --etcd-keyfile=<path/to/client-key-file>
         scored: true
+
       - id: 1.2.25
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -632,6 +672,7 @@ groups:
           --tls-cert-file=<path/to/tls-certificate-file>
           --tls-private-key-file=<path/to/tls-key-file>
         scored: true
+
       - id: 1.2.26
         text: "Ensure that the --client-ca-file argument is set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -644,6 +685,7 @@ groups:
           on the control plane node and set the client certificate authority file.
           --client-ca-file=<path/to/client-ca-file>
         scored: true
+
       - id: 1.2.27
         text: "Ensure that the --etcd-cafile argument is set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -656,6 +698,7 @@ groups:
           on the control plane node and set the etcd certificate authority file parameter.
           --etcd-cafile=<path/to/ca-file>
         scored: true
+
       - id: 1.2.28
         text: "Ensure that the --encryption-provider-config argument is set as appropriate (Manual)"
         type: "skip"
@@ -670,6 +713,7 @@ groups:
           For example, --encryption-provider-config=</path/to/EncryptionConfig/File>
           Permissive - Enabling encryption changes how data can be recovered as data is encrypted.
         scored: false
+
       - id: 1.2.29
         text: "Ensure that encryption providers are appropriately configured (Manual)"
         type: "skip"
@@ -687,6 +731,7 @@ groups:
           In this file, choose aescbc, kms or secretbox as the encryption provider.
           Permissive - Enabling encryption changes how data can be recovered as data is encrypted.
         scored: false
+
       - id: 1.2.30
         text: "Ensure that the API Server only makes use of Strong Cryptographic Ciphers (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
@@ -708,6 +753,7 @@ groups:
           TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256,TLS_RSA_WITH_3DES_EDE_CBC_SHA,TLS_RSA_WITH_AES_128_CBC_SHA,
           TLS_RSA_WITH_AES_128_GCM_SHA256,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_RSA_WITH_AES_256_GCM_SHA384
         scored: false
+
   - id: 1.3
     text: "Controller Manager"
     checks:
@@ -722,6 +768,7 @@ groups:
           on the control plane node and set the --terminated-pod-gc-threshold to an appropriate threshold,
           for example, --terminated-pod-gc-threshold=10
         scored: true
+
       - id: 1.3.2
         text: "Ensure that the --profiling argument is set to false (Automated)"
         audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
@@ -736,6 +783,7 @@ groups:
           on the control plane node and set the below parameter.
           --profiling=false
         scored: true
+
       - id: 1.3.3
         text: "Ensure that the --use-service-account-credentials argument is set to true (Automated)"
         audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
@@ -750,6 +798,7 @@ groups:
           on the control plane node to set the below parameter.
           --use-service-account-credentials=true
         scored: true
+
       - id: 1.3.4
         text: "Ensure that the --service-account-private-key-file argument is set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
@@ -762,6 +811,7 @@ groups:
           to the private key file for service accounts.
           --service-account-private-key-file=<filename>
         scored: true
+
       - id: 1.3.5
         text: "Ensure that the --root-ca-file argument is set as appropriate (Automated)"
         audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
@@ -773,6 +823,7 @@ groups:
           on the control plane node and set the --root-ca-file parameter to the certificate bundle file`.
           --root-ca-file=<path/to/file>
         scored: true
+
       - id: 1.3.6
         text: "Ensure that the RotateKubeletServerCertificate argument is set to true (Automated)"
         type: "skip"
@@ -793,6 +844,7 @@ groups:
           --feature-gates=RotateKubeletServerCertificate=true
           Cluster provisioned by RKE handles certificate rotation directly through RKE.
         scored: true
+
       - id: 1.3.7
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
         audit: "/bin/ps -ef | grep $controllermanagerbin | grep -v grep"
@@ -809,6 +861,7 @@ groups:
           Edit the Controller Manager pod specification file $controllermanagerconf
           on the control plane node and ensure the correct value for the --bind-address parameter
         scored: true
+
   - id: 1.4
     text: "Scheduler"
     checks:
@@ -826,6 +879,7 @@ groups:
           on the control plane node and set the below parameter.
           --profiling=false
         scored: true
+
       - id: 1.4.2
         text: "Ensure that the --bind-address argument is set to 127.0.0.1 (Automated)"
         audit: "/bin/ps -ef | grep $schedulerbin | grep -v grep"

--- a/package/cfg/rke-cis-1.8-permissive/policies.yaml
+++ b/package/cfg/rke-cis-1.8-permissive/policies.yaml
@@ -18,12 +18,14 @@ groups:
           clusterrolebinding to the cluster-admin role :
           kubectl delete clusterrolebinding [name]
         scored: false
+
       - id: 5.1.2
         text: "Minimize access to secrets (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove get, list and watch access to Secret objects in the cluster.
         scored: false
+
       - id: 5.1.3
         text: "Minimize wildcard use in Roles and ClusterRoles (Manual)"
         type: "manual"
@@ -31,12 +33,14 @@ groups:
           Where possible replace any use of wildcards in clusterroles and roles with specific
           objects or actions.
         scored: false
+
       - id: 5.1.4
         text: "Minimize access to create pods (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove create access to pod objects in the cluster.
         scored: false
+
       - id: 5.1.5
         text: "Ensure that default service accounts are not actively used. (Manual)"
         type: "skip"
@@ -55,6 +59,7 @@ groups:
           automountServiceAccountToken: false
           Permissive - Kubernetes provides default service accounts to be used.
         scored: false
+
       - id: 5.1.6
         text: "Ensure that Service Account Tokens are only mounted where necessary (Manual)"
         type: "manual"
@@ -62,48 +67,56 @@ groups:
           Modify the definition of pods and service accounts which do not need to mount service
           account tokens to disable it.
         scored: false
+
       - id: 5.1.7
         text: "Avoid use of system:masters group (Manual)"
         type: "manual"
         remediation: |
           Remove the system:masters group from all users in the cluster.
         scored: false
+
       - id: 5.1.8
         text: "Limit use of the Bind, Impersonate and Escalate permissions in the Kubernetes cluster (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove the impersonate, bind and escalate rights from subjects.
         scored: false
+
       - id: 5.1.9
         text: "Minimize access to create persistent volumes (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove create access to PersistentVolume objects in the cluster.
         scored: false
+
       - id: 5.1.10
         text: "Minimize access to the proxy sub-resource of nodes (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove access to the proxy sub-resource of node objects.
         scored: false
+
       - id: 5.1.11
         text: "Minimize access to the approval sub-resource of certificatesigningrequests objects (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove access to the approval sub-resource of certificatesigningrequest objects.
         scored: false
+
       - id: 5.1.12
         text: "Minimize access to webhook configuration objects (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove access to the validatingwebhookconfigurations or mutatingwebhookconfigurations objects
         scored: false
+
       - id: 5.1.13
         text: "Minimize access to the service account token creation (Manual)"
         type: "manual"
         remediation: |
           Where possible, remove access to the token sub-resource of serviceaccount objects.
         scored: false
+
   - id: 5.2
     text: "Pod Security Standards"
     checks:
@@ -114,6 +127,7 @@ groups:
           Ensure that either Pod Security Admission or an external policy control system is in place
           for every namespace which contains user workloads.
         scored: false
+
       - id: 5.2.2
         text: "Minimize the admission of privileged containers (Manual)"
         type: "manual"
@@ -121,6 +135,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of privileged containers.
         scored: false
+
       - id: 5.2.3
         text: "Minimize the admission of containers wishing to share the host process ID namespace (Automated)"
         type: "skip"
@@ -128,7 +143,8 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostPID` containers.
           Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
-        scored: false
+        scored: true
+
       - id: 5.2.4
         text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
         type: "skip"
@@ -136,7 +152,8 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostIPC` containers.
           Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
-        scored: false
+        scored: true
+
       - id: 5.2.5
         text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
         type: "skip"
@@ -144,7 +161,8 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostNetwork` containers.
           Permissive - Enabling Pod Security Policy can cause applications to unexpectedly fail.
-        scored: false
+        scored: true
+
       - id: 5.2.6
         text: "Minimize the admission of containers with allowPrivilegeEscalation (Manual)"
         type: "manual"
@@ -152,6 +170,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with `.spec.allowPrivilegeEscalation` set to `true`.
         scored: false
+
       - id: 5.2.7
         text: "Minimize the admission of root containers (Manual)"
         type: "manual"
@@ -159,6 +178,7 @@ groups:
           Create a policy for each namespace in the cluster, ensuring that either `MustRunAsNonRoot`
           or `MustRunAs` with the range of UIDs not including 0, is set.
         scored: false
+
       - id: 5.2.8
         text: "Minimize the admission of containers with the NET_RAW capability (Manual)"
         type: "manual"
@@ -166,6 +186,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with the `NET_RAW` capability.
         scored: false
+
       - id: 5.2.9
         text: "Minimize the admission of containers with added capabilities (Manual)"
         type: "manual"
@@ -173,6 +194,7 @@ groups:
           Ensure that `allowedCapabilities` is not present in policies for the cluster unless
           it is set to an empty array.
         scored: false
+
       - id: 5.2.10
         text: "Minimize the admission of containers with capabilities assigned (Manual)"
         type: "manual"
@@ -181,6 +203,7 @@ groups:
           contains applicaions which do not require any Linux capabities to operate consider adding
           a PSP which forbids the admission of containers which do not drop all capabilities.
         scored: false
+
       - id: 5.2.11
         text: "Minimize the admission of Windows HostProcess containers (Manual)"
         type: "manual"
@@ -188,6 +211,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers that have `.securityContext.windowsOptions.hostProcess` set to `true`.
         scored: false
+
       - id: 5.2.12
         text: "Minimize the admission of HostPath volumes (Manual)"
         type: "manual"
@@ -195,6 +219,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with `hostPath` volumes.
         scored: false
+
       - id: 5.2.13
         text: "Minimize the admission of containers which use HostPorts (Manual)"
         type: "manual"
@@ -202,6 +227,7 @@ groups:
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers which use `hostPort` sections.
         scored: false
+
   - id: 5.3
     text: "Network Policies and CNI"
     checks:
@@ -213,6 +239,7 @@ groups:
           making use of a different plugin, or finding an alternate mechanism for restricting traffic
           in the Kubernetes cluster.
         scored: false
+
       - id: 5.3.2
         text: "Ensure that all Namespaces have NetworkPolicies defined (Manual)"
         type: "skip"
@@ -220,6 +247,7 @@ groups:
           Follow the documentation and create NetworkPolicy objects as you need them.
           Permissive - Enabling Network Policies can prevent certain applications from communicating with each other.
         scored: false
+
   - id: 5.4
     text: "Secrets Management"
     checks:
@@ -230,6 +258,7 @@ groups:
           If possible, rewrite application code to read Secrets from mounted secret files, rather than
           from environment variables.
         scored: false
+
       - id: 5.4.2
         text: "Consider external secret storage (Manual)"
         type: "manual"
@@ -237,6 +266,7 @@ groups:
           Refer to the Secrets management options offered by your cloud provider or a third-party
           secrets management solution.
         scored: false
+
   - id: 5.5
     text: "Extensible Admission Control"
     checks:
@@ -246,6 +276,7 @@ groups:
         remediation: |
           Follow the Kubernetes documentation and setup image provenance.
         scored: false
+
   - id: 5.7
     text: "General Policies"
     checks:
@@ -256,6 +287,7 @@ groups:
           Follow the documentation and create namespaces for objects in your deployment as you need
           them.
         scored: false
+
       - id: 5.7.2
         text: "Ensure that the seccomp profile is set to docker/default in your Pod definitions (Manual)"
         type: "manual"
@@ -266,6 +298,7 @@ groups:
               seccompProfile:
                 type: RuntimeDefault
         scored: false
+
       - id: 5.7.3
         text: "Apply SecurityContext to your Pods and Containers (Manual)"
         type: "manual"
@@ -274,6 +307,7 @@ groups:
           suggested list of SecurityContexts, you may refer to the CIS Security Benchmark for Docker
           Containers.
         scored: false
+
       - id: 5.7.4
         text: "The default namespace should not be used (Manual)"
         type: "skip"

--- a/package/cfg/rke2-cis-1.23-hardened/etcd.yaml
+++ b/package/cfg/rke2-cis-1.23-hardened/etcd.yaml
@@ -207,4 +207,4 @@ groups:
           Then, edit the etcd pod specification file $etcdconf on the
           master node and set the below parameter.
           --trusted-ca-file=</path/to/ca-file>
-        scored: false
+        scored: true

--- a/package/cfg/rke2-cis-1.23-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.23-hardened/master.yaml
@@ -848,7 +848,7 @@ groups:
           Edit the Controller Manager pod specification file $controllermanagerconf
           on the control plane node and set the --terminated-pod-gc-threshold to an appropriate threshold,
           for example, --terminated-pod-gc-threshold=10
-        scored: true
+        scored: false
 
       - id: 1.3.2
         text: "Ensure that the --profiling argument is set to false (Automated)"

--- a/package/cfg/rke2-cis-1.23-hardened/node.yaml
+++ b/package/cfg/rke2-cis-1.23-hardened/node.yaml
@@ -39,7 +39,7 @@ groups:
         scored: true
 
       - id: 4.1.3
-        text: "If proxy kubeconfig file exists ensure permissions are set to 644 or more restrictive (Manual)"
+        text: "If proxy kubeconfig file exists ensure permissions are set to 644 or more restrictive (Automated)"
         audit: '/bin/sh -c ''if test -e $proxykubeconfig; then stat -c permissions=%a $proxykubeconfig; fi'' '
         tests:
           bin_op: or
@@ -120,7 +120,7 @@ groups:
         scored: false
 
       - id: 4.1.8
-        text: "Ensure that the client certificate authorities file ownership is set to root:root (Manual)"
+        text: "Ensure that the client certificate authorities file ownership is set to root:root (Automated)"
         audit: '/bin/sh -c ''if test -e $kubeletcafile; then stat -c %U:%G $kubeletcafile; fi'' '
         tests:
           test_items:
@@ -230,7 +230,7 @@ groups:
         scored: true
 
       - id: 4.2.4
-        text: "Ensure that the --read-only-port argument is set to 0 (Manual)"
+        text: "Ensure that the --read-only-port argument is set to 0 (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/cat $kubeletconf"
         tests:
@@ -374,7 +374,7 @@ groups:
         scored: false
 
       - id: 4.2.10
-        text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Manual)"
+        text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/cat $kubeletconf"
         tests:

--- a/package/cfg/rke2-cis-1.23-hardened/policies.yaml
+++ b/package/cfg/rke2-cis-1.23-hardened/policies.yaml
@@ -104,7 +104,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of privileged containers.
-        scored: true
+        scored: false
 
       - id: 5.2.3
         text: "Minimize the admission of containers wishing to share the host process ID namespace (Automated)"
@@ -134,7 +134,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostIPC` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.5
         text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
@@ -202,7 +202,7 @@ groups:
         remediation: |
           Ensure that `allowedCapabilities` is not present in policies for the cluster unless
           it is set to an empty array.
-        scored: false
+        scored: true
 
       - id: 5.2.10
         text: "Minimize the admission of containers with capabilities assigned (Manual)"
@@ -268,7 +268,7 @@ groups:
               set: true
         remediation: |
           Follow the documentation and create NetworkPolicy objects as you need them.
-        scored: false
+        scored: true
 
   - id: 5.4
     text: "Secrets Management"

--- a/package/cfg/rke2-cis-1.23-permissive/etcd.yaml
+++ b/package/cfg/rke2-cis-1.23-permissive/etcd.yaml
@@ -212,4 +212,4 @@ groups:
           Then, edit the etcd pod specification file $etcdconf on the
           master node and set the below parameter.
           --trusted-ca-file=</path/to/ca-file>
-        scored: false
+        scored: true

--- a/package/cfg/rke2-cis-1.23-permissive/policies.yaml
+++ b/package/cfg/rke2-cis-1.23-permissive/policies.yaml
@@ -98,7 +98,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostPID` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.4
         text: "Minimize the admission of containers wishing to share the host IPC namespace (Automated)"
@@ -106,7 +106,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostIPC` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.5
         text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
@@ -114,7 +114,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostNetwork` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.6
         text: "Minimize the admission of containers with allowPrivilegeEscalation (Automated)"
@@ -122,7 +122,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with `.spec.allowPrivilegeEscalation` set to `true`.
-        scored: false
+        scored: true
 
       - id: 5.2.7
         text: "Minimize the admission of root containers (Automated)"
@@ -130,7 +130,7 @@ groups:
         remediation: |
           Create a policy for each namespace in the cluster, ensuring that either `MustRunAsNonRoot`
           or `MustRunAs` with the range of UIDs not including 0, is set.
-        scored: false
+        scored: true
 
       - id: 5.2.8
         text: "Minimize the admission of containers with the NET_RAW capability (Automated)"
@@ -138,7 +138,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of containers with the `NET_RAW` capability.
-        scored: false
+        scored: true
 
       - id: 5.2.9
         text: "Minimize the admission of containers with added capabilities (Automated)"
@@ -146,7 +146,7 @@ groups:
         remediation: |
           Ensure that `allowedCapabilities` is not present in policies for the cluster unless
           it is set to an empty array.
-        scored: false
+        scored: true
 
       - id: 5.2.10
         text: "Minimize the admission of containers with capabilities assigned (Manual)"

--- a/package/cfg/rke2-cis-1.24-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.24-hardened/master.yaml
@@ -146,7 +146,7 @@ groups:
         scored: false
 
       - id: 1.1.10
-        text: "Ensure that the Container Network Interface file ownership is set to root:root (Automated)"
+        text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
         audit: |
           ps -fC ${kubeletbin:-kubelet} | grep -- --cni-conf-dir || echo "/etc/cni/net.d" | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
           find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
@@ -270,7 +270,7 @@ groups:
         scored: true
 
       - id: 1.1.20
-        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Automated)"
+        text: "Ensure that the Kubernetes PKI certificate file permissions are set to 600 or more restrictive (Manual)"
         audit: "stat -c permissions=%a /var/lib/rancher/rke2/server/tls/*.crt"
         use_multiple_values: true
         tests:
@@ -283,7 +283,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
-          chmod -R 644 /var/lib/rancher/rke2/server/tls/*.crt
+          chmod -R 600 /var/lib/rancher/rke2/server/tls/*.crt
         scored: false
 
       - id: 1.1.21
@@ -300,7 +300,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chmod -R 600 /var/lib/rancher/rke2/server/tls/*.key
-        scored: false
+        scored: true
 
   - id: 1.2
     text: "API Server"
@@ -881,7 +881,7 @@ groups:
           and set the --terminated-pod-gc-threshold to an appropriate threshold,
           kube-controller-manager-arg:
             - "terminated-pod-gc-threshold=10"
-        scored: true
+        scored: false
 
       - id: 1.3.2
         text: "Ensure that the --profiling argument is set to false (Automated)"

--- a/package/cfg/rke2-cis-1.24-hardened/node.yaml
+++ b/package/cfg/rke2-cis-1.24-hardened/node.yaml
@@ -324,10 +324,10 @@ groups:
           Not Applicable.
           By default, RKE2 does set the --hostname-override argument. Per CIS guidelines, this is to comply
           with cloud providers that require this flag to ensure that hostname matches node names.
-        scored: false
+        scored: true
 
       - id: 4.2.9
-        text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Automated)"
+        text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
         audit: "/bin/ps -fC $kubeletbin"
         audit_config: "/bin/cat $kubeletconf"
         tests:
@@ -408,7 +408,7 @@ groups:
           If this check fails, edit the RKE2 config file /etc/rancher/rke2/config.yaml, remove any RotateKubeletServerCertificate parameter.
           Based on your system, restart the RKE2 service. For example,
           systemctl restart rke2-server.service
-        scored: false
+        scored: true
 
       - id: 4.2.13
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"

--- a/package/cfg/rke2-cis-1.24-hardened/policies.yaml
+++ b/package/cfg/rke2-cis-1.24-hardened/policies.yaml
@@ -134,7 +134,7 @@ groups:
         remediation: |
           Add policies to each namespace in the cluster which has user workloads to restrict the
           admission of `hostIPC` containers.
-        scored: false
+        scored: true
 
       - id: 5.2.5
         text: "Minimize the admission of containers wishing to share the host network namespace (Automated)"
@@ -202,7 +202,7 @@ groups:
         remediation: |
           Ensure that `allowedCapabilities` is not present in policies for the cluster unless
           it is set to an empty array.
-        scored: false
+        scored: true
 
       - id: 5.2.10
         text: "Minimize the admission of containers with capabilities assigned (Manual)"
@@ -268,7 +268,7 @@ groups:
               set: true
         remediation: |
           Follow the documentation and create NetworkPolicy objects as you need them.
-        scored: false
+        scored: true
 
   - id: 5.4
     text: "Secrets Management"

--- a/package/cfg/rke2-cis-1.24-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.24-permissive/master.yaml
@@ -146,7 +146,7 @@ groups:
         scored: false
 
       - id: 1.1.10
-        text: "Ensure that the Container Network Interface file ownership is set to root:root (Automated)"
+        text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
         audit: |
           ps -fC ${kubeletbin:-kubelet} | grep -- --cni-conf-dir || echo "/etc/cni/net.d" | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
           find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
@@ -303,7 +303,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chmod -R 600 /var/lib/rancher/rke2/server/tls/*.key
-        scored: false
+        scored: true
 
   - id: 1.2
     text: "API Server"

--- a/package/cfg/rke2-cis-1.24-permissive/node.yaml
+++ b/package/cfg/rke2-cis-1.24-permissive/node.yaml
@@ -51,7 +51,7 @@ groups:
           Run the below command (based on the file location on your system) on the each worker node.
           For example,
           chmod 600 $proxykubeconfig
-        scored: false
+        scored: true
 
       - id: 4.1.4
         text: "If proxy kubeconfig file exists ensure ownership is set to root:root (Automated)"
@@ -325,7 +325,7 @@ groups:
           Not Applicable.
           By default, RKE2 does set the --hostname-override argument. Per CIS guidelines, this is to comply
           with cloud providers that require this flag to ensure that hostname matches node names.
-        scored: false
+        scored: true
 
       - id: 4.2.9
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
@@ -363,7 +363,7 @@ groups:
           kubelet-arg:
             - "tls-cert-file=<path/to/tls-cert-file>"
             - "tls-private-key-file=<path/to/tls-private-key-file>"
-        scored: false
+        scored: true
 
       - id: 4.2.11
         text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"
@@ -407,7 +407,7 @@ groups:
           If this check fails, edit the RKE2 config file /etc/rancher/rke2/config.yaml, remove any RotateKubeletServerCertificate parameter.
           Based on your system, restart the RKE2 service. For example,
           systemctl restart rke2-server.service
-        scored: false
+        scored: true
 
       - id: 4.2.13
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"

--- a/package/cfg/rke2-cis-1.24-permissive/policies.yaml
+++ b/package/cfg/rke2-cis-1.24-permissive/policies.yaml
@@ -146,7 +146,7 @@ groups:
         remediation: |
           Ensure that `allowedCapabilities` is not present in policies for the cluster unless
           it is set to an empty array.
-        scored: false
+        scored: true
 
       - id: 5.2.10
         text: "Minimize the admission of containers with capabilities assigned (Manual)"

--- a/package/cfg/rke2-cis-1.7-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.7-hardened/master.yaml
@@ -146,7 +146,7 @@ groups:
         scored: false
 
       - id: 1.1.10
-        text: "Ensure that the Container Network Interface file ownership is set to root:root (Automated)"
+        text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
         audit: |
           ps -fC ${kubeletbin:-kubelet} | grep -- --cni-conf-dir || echo "/etc/cni/net.d" | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
           find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
@@ -303,7 +303,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chmod -R 600 /var/lib/rancher/rke2/server/tls/*.key
-        scored: false
+        scored: true
 
   - id: 1.2
     text: "API Server"

--- a/package/cfg/rke2-cis-1.7-hardened/node.yaml
+++ b/package/cfg/rke2-cis-1.7-hardened/node.yaml
@@ -297,7 +297,7 @@ groups:
           Not Applicable.
           By default, RKE2 does set the --hostname-override argument. Per CIS guidelines, this is to comply
           with cloud providers that require this flag to ensure that hostname matches node names.
-        scored: false
+        scored: true
 
       - id: 4.2.8
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
@@ -339,7 +339,7 @@ groups:
           kubelet-arg:
             - "tls-cert-file=<path/to/tls-cert-file>"
             - "tls-private-key-file=<path/to/tls-private-key-file>"
-        scored: false
+        scored: true
 
       - id: 4.2.10
         text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"
@@ -383,7 +383,7 @@ groups:
           If this check fails, edit the RKE2 config file /etc/rancher/rke2/config.yaml, remove any RotateKubeletServerCertificate parameter.
           Based on your system, restart the RKE2 service. For example,
           systemctl restart rke2-server.service
-        scored: false
+        scored: true
 
       - id: 4.2.12
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"

--- a/package/cfg/rke2-cis-1.7-hardened/policies.yaml
+++ b/package/cfg/rke2-cis-1.7-hardened/policies.yaml
@@ -181,7 +181,7 @@ groups:
         remediation: |
           Ensure that `allowedCapabilities` is not present in policies for the cluster unless
           it is set to an empty array.
-        scored: false
+        scored: true
 
       - id: 5.2.10
         text: "Minimize the admission of containers with capabilities assigned (Manual)"

--- a/package/cfg/rke2-cis-1.7-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.7-permissive/master.yaml
@@ -146,7 +146,7 @@ groups:
         scored: false
 
       - id: 1.1.10
-        text: "Ensure that the Container Network Interface file ownership is set to root:root (Automated)"
+        text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
         audit: |
           ps -fC ${kubeletbin:-kubelet} | grep -- --cni-conf-dir || echo "/etc/cni/net.d" | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
           find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
@@ -303,7 +303,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chmod -R 600 /var/lib/rancher/rke2/server/tls/*.key
-        scored: false
+        scored: true
 
   - id: 1.2
     text: "API Server"

--- a/package/cfg/rke2-cis-1.7-permissive/node.yaml
+++ b/package/cfg/rke2-cis-1.7-permissive/node.yaml
@@ -297,7 +297,7 @@ groups:
           Not Applicable.
           By default, RKE2 does set the --hostname-override argument. Per CIS guidelines, this is to comply
           with cloud providers that require this flag to ensure that hostname matches node names.
-        scored: false
+        scored: true
 
       - id: 4.2.8
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
@@ -339,7 +339,7 @@ groups:
           kubelet-arg:
             - "tls-cert-file=<path/to/tls-cert-file>"
             - "tls-private-key-file=<path/to/tls-private-key-file>"
-        scored: false
+        scored: true
 
       - id: 4.2.10
         text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"
@@ -383,7 +383,7 @@ groups:
           If this check fails, edit the RKE2 config file /etc/rancher/rke2/config.yaml, remove any RotateKubeletServerCertificate parameter.
           Based on your system, restart the RKE2 service. For example,
           systemctl restart rke2-server.service
-        scored: false
+        scored: true
 
       - id: 4.2.12
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"

--- a/package/cfg/rke2-cis-1.7-permissive/policies.yaml
+++ b/package/cfg/rke2-cis-1.7-permissive/policies.yaml
@@ -181,7 +181,7 @@ groups:
         remediation: |
           Ensure that `allowedCapabilities` is not present in policies for the cluster unless
           it is set to an empty array.
-        scored: false
+        scored: true
 
       - id: 5.2.10
         text: "Minimize the admission of containers with capabilities assigned (Manual)"

--- a/package/cfg/rke2-cis-1.8-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.8-hardened/master.yaml
@@ -146,7 +146,7 @@ groups:
         scored: false
 
       - id: 1.1.10
-        text: "Ensure that the Container Network Interface file ownership is set to root:root (Automated)"
+        text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
         audit: |
           ps -fC ${kubeletbin:-kubelet} | grep -- --cni-conf-dir || echo "/etc/cni/net.d" | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
           find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
@@ -303,7 +303,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chmod -R 600 /var/lib/rancher/rke2/server/tls/*.key
-        scored: false
+        scored: true
 
   - id: 1.2
     text: "API Server"
@@ -322,7 +322,7 @@ groups:
           If this check fails, edit the RKE2 config file /etc/rancher/rke2/config.yaml and remove anything similar to below.
           kube-apiserver-arg:
             - "anonymous-auth=true"
-        scored: false
+        scored: true
 
       - id: 1.2.2
         text: "Ensure that the --token-auth-file parameter is not set (Automated)"

--- a/package/cfg/rke2-cis-1.8-hardened/node.yaml
+++ b/package/cfg/rke2-cis-1.8-hardened/node.yaml
@@ -383,7 +383,7 @@ groups:
           If this check fails, edit the RKE2 config file /etc/rancher/rke2/config.yaml, remove any RotateKubeletServerCertificate parameter.
           Based on your system, restart the RKE2 service. For example,
           systemctl restart rke2-server.service
-        scored: false
+        scored: true
 
       - id: 4.2.12
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"

--- a/package/cfg/rke2-cis-1.8-hardened/policies.yaml
+++ b/package/cfg/rke2-cis-1.8-hardened/policies.yaml
@@ -181,7 +181,7 @@ groups:
         remediation: |
           Ensure that `allowedCapabilities` is not present in policies for the cluster unless
           it is set to an empty array.
-        scored: false
+        scored: true
 
       - id: 5.2.10
         text: "Minimize the admission of containers with capabilities assigned (Manual)"

--- a/package/cfg/rke2-cis-1.8-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.8-permissive/master.yaml
@@ -9,7 +9,7 @@ groups:
     text: "Control Plane Node Configuration Files"
     checks:
       - id: 1.1.1
-        text: "Ensure that the API server pod specification file permissions are set to 600 or more restrictive (Automated)"
+        text: "Ensure that the API server pod specification file permissions are set to 600 or more restrictive (Manual)"
         audit: "stat -c permissions=%a $apiserverconf"
         tests:
           test_items:
@@ -40,7 +40,7 @@ groups:
         scored: true
 
       - id: 1.1.3
-        text: "Ensure that the controller manager pod specification file permissions are set to 600 or more restrictive (Automated)"
+        text: "Ensure that the controller manager pod specification file permissions are set to 600 or more restrictive (Manual)"
         audit: "/bin/sh -c 'if test -e $controllermanagerconf; then stat -c permissions=%a $controllermanagerconf; fi'"
         tests:
           test_items:
@@ -70,7 +70,7 @@ groups:
         scored: true
 
       - id: 1.1.5
-        text: "Ensure that the scheduler pod specification file permissions are set to 600 or more restrictive (Automated)"
+        text: "Ensure that the scheduler pod specification file permissions are set to 600 or more restrictive (Manual)"
         audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c permissions=%a $schedulerconf; fi'"
         tests:
           test_items:
@@ -109,7 +109,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chmod 600 $etcdconf
-        scored: false
+        scored: true
 
       - id: 1.1.8
         text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
@@ -146,7 +146,7 @@ groups:
         scored: false
 
       - id: 1.1.10
-        text: "Ensure that the Container Network Interface file ownership is set to root:root (Automated)"
+        text: "Ensure that the Container Network Interface file ownership is set to root:root (Manual)"
         audit: |
           ps -fC ${kubeletbin:-kubelet} | grep -- --cni-conf-dir || echo "/etc/cni/net.d" | sed 's%.*cni-conf-dir[= ]\([^ ]*\).*%\1%' | xargs -I{} find {} -mindepth 1 | xargs --no-run-if-empty stat -c %U:%G
           find /var/lib/cni/networks -type f 2> /dev/null | xargs --no-run-if-empty stat -c %U:%G
@@ -303,7 +303,7 @@ groups:
           Run the below command (based on the file location on your system) on the control plane node.
           For example,
           chmod -R 600 /var/lib/rancher/rke2/server/tls/*.key
-        scored: false
+        scored: true
 
   - id: 1.2
     text: "API Server"
@@ -612,7 +612,7 @@ groups:
           file where you would like audit logs to be written, for example,
           kube-apiserver-arg:
             - "audit-log-path=/var/log/rke2/audit.log"
-        scored: false
+        scored: true
 
       - id: 1.2.18
         text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
@@ -630,7 +630,7 @@ groups:
           on the control plane node and set the --audit-log-maxage parameter to an appropriate number of days, for example,
           kube-apiserver-arg:
             - "audit-log-maxage=40"
-        scored: false
+        scored: true
 
       - id: 1.2.19
         text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
@@ -649,7 +649,7 @@ groups:
           For example,
           kube-apiserver-arg:
             - "audit-log-maxbackup=15"
-        scored: false
+        scored: true
 
       - id: 1.2.20
         text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
@@ -668,7 +668,7 @@ groups:
           For example,
           kube-apiserver-arg:
             - "audit-log-maxsize=150"
-        scored: false
+        scored: true
 
       - id: 1.2.21
         text: "Ensure that the --request-timeout argument is set as appropriate (Automated)"

--- a/package/cfg/rke2-cis-1.8-permissive/node.yaml
+++ b/package/cfg/rke2-cis-1.8-permissive/node.yaml
@@ -297,7 +297,7 @@ groups:
           Not Applicable.
           By default, RKE2 does set the --hostname-override argument. Per CIS guidelines, this is to comply
           with cloud providers that require this flag to ensure that hostname matches node names.
-        scored: false
+        scored: true
 
       - id: 4.2.8
         text: "Ensure that the eventRecordQPS argument is set to a level which ensures appropriate event capture (Manual)"
@@ -339,7 +339,7 @@ groups:
           kubelet-arg:
             - "tls-cert-file=<path/to/tls-cert-file>"
             - "tls-private-key-file=<path/to/tls-private-key-file>"
-        scored: false
+        scored: true
 
       - id: 4.2.10
         text: "Ensure that the --rotate-certificates argument is not set to false (Automated)"
@@ -383,7 +383,7 @@ groups:
           If this check fails, edit the RKE2 config file /etc/rancher/rke2/config.yaml, remove any RotateKubeletServerCertificate parameter.
           Based on your system, restart the RKE2 service. For example,
           systemctl restart rke2-server.service
-        scored: false
+        scored: true
 
       - id: 4.2.12
         text: "Ensure that the Kubelet only makes use of Strong Cryptographic Ciphers (Manual)"

--- a/package/cfg/rke2-cis-1.8-permissive/policies.yaml
+++ b/package/cfg/rke2-cis-1.8-permissive/policies.yaml
@@ -181,7 +181,7 @@ groups:
         remediation: |
           Ensure that `allowedCapabilities` is not present in policies for the cluster unless
           it is set to an empty array.
-        scored: false
+        scored: true
 
       - id: 5.2.10
         text: "Minimize the admission of containers with capabilities assigned (Manual)"


### PR DESCRIPTION
**Context:**

The kube-bench profiles contain lots of variables that are prone to errors or mismatches, when being edited. This PR adds a new verification to the existing validate-yaml:
- When (Automated) Or (Manual) is found in a check's `text`, it ensures that the `scored` variable is respectively set to `true` or `false`.

