### PR TITLE
fix condition for etcd node detection for k3s

### DIFF
--- a/package/run_sonobuoy_plugin.sh
+++ b/package/run_sonobuoy_plugin.sh
@@ -64,7 +64,7 @@ mkdir -p "${RESULTS_DIR}"
 
 # etcd
 if [[ "${OVERRIDE_BENCHMARK_VERSION}" != "" ]]; then
-  if [[ "$(ps -e | grep etcd | wc -l)" -gt 0  ]]  || [[ "$(journalctl -D $JOURNAL_LOG -u k3s -u k3s-agent | grep -m1 "etcd cluster" | wc -l )" -gt 0 ]]; then
+  if [[ "$(ps -e | grep etcd | wc -l)" -gt 0  ]]  || [[ "$(journalctl -m -u k3s | grep -m1 "Managed etcd cluster initializing" | wc -l )" -gt 0 ]] || [[ "$(journalctl -m -u k3s | grep -m1 "Managed etcd cluster bootstrap already complete and initialized" | wc -l )" -gt 0 ]]; then
     echo "etcd: Using OVERRIDE_BENCHMARK_VERSION=${OVERRIDE_BENCHMARK_VERSION}"
     kube-bench run \
       --targets etcd \


### PR DESCRIPTION
issue: https://github.com/rancher/rancher/issues/46663
In https://github.com/rancher/security-scan/pull/218 the check for etcd node for k3s was updated to `if [[ "$(ps -e | grep etcd | wc -l)" -gt 0 ]] || [[ "$(journalctl -D $JOURNAL_LOG -u k3s -u k3s-agent | grep -m1 "etcd cluster" | wc -l )" -gt 0 ]];`
this condition detects controlplane node also as an etcd node because running 
`journalctl -u k3s -u k3s-agent | grep -m1 "etcd cluster"`
produces output
`.....k3s[1548]: time="2024-08-20T07:31:30Z" level=info msg="Managed etcd cluster not yet initialized"`
because of that etcd checks are running on control plane nodes as well and failing which is resulting in mixed state for 2.x checks. 
To fix i have added an OR condition in the earlier check with the log which was mentioned in PR https://github.com/rancher/security-scan/pull/218.