### PR TITLE
fix 1.1.11 check for k3s profiles and move it to etcd.yaml

### DIFF
--- a/package/cfg/k3s-cis-1.23-hardened/etcd.yaml
+++ b/package/cfg/k3s-cis-1.23-hardened/etcd.yaml
@@ -5,6 +5,35 @@ id: 2
 text: "Etcd Node Configuration"
 type: "etcd"
 groups:
+  - id: 1.1
+    text: "Master Node Configuration Files"
+    # Check 1.1.11 is related to etcd and in upstream it is present in master.yaml, But this check
+    # fails on controlplane nodes which does not have etcd so it is moved to etcd.yaml, so that the
+    # scan pass on the clusters which have seperate controlplane and etcd nodes. The check will also
+    # run on controlplane nodes which have etcd since run_sonobuoy_plugin.sh script detects etcd process
+    # and runs on any node where etcd is found.
+    checks:
+      - id: 1.1.11
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
+        audit: |
+          if [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster initializing' | wc -l)" -gt 0 ] || [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster bootstrap already complete and initialized' | wc -l )" -gt 0 ]; then
+            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
+          else
+            echo "permissions=700"
+          fi
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "700"
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above). For example,
+          chmod 700 /var/lib/etcd
+        scored: true
+
   - id: 2
     text: "Etcd Node Configuration"
     checks:

--- a/package/cfg/k3s-cis-1.23-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.23-hardened/master.yaml
@@ -153,27 +153,6 @@ groups:
           chown root:root <path/to/cni/files>
         scored: false
 
-      - id: 1.1.11
-        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: |
-          if [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
-            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
-          else
-            echo "permissions=700"
-          fi
-        tests:
-          test_items:
-            - flag: "permissions"
-              compare:
-                op: bitmask
-                value: "700"
-        remediation: |
-          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-          from the command 'ps -ef | grep etcd'.
-          Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
-        scored: true
-
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
         audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G

--- a/package/cfg/k3s-cis-1.23-permissive/etcd.yaml
+++ b/package/cfg/k3s-cis-1.23-permissive/etcd.yaml
@@ -5,6 +5,35 @@ id: 2
 text: "Etcd Node Configuration"
 type: "etcd"
 groups:
+  - id: 1.1
+    text: "Master Node Configuration Files"
+    # Check 1.1.11 is related to etcd and in upstream it is present in master.yaml, But this check
+    # fails on controlplane nodes which does not have etcd so it is moved to etcd.yaml, so that the
+    # scan pass on the clusters which have seperate controlplane and etcd nodes. The check will also
+    # run on controlplane nodes which have etcd since run_sonobuoy_plugin.sh script detects etcd process
+    # and runs on any node where etcd is found.
+    checks:
+      - id: 1.1.11
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
+        audit: |
+          if [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster initializing' | wc -l)" -gt 0 ] || [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster bootstrap already complete and initialized' | wc -l )" -gt 0 ]; then
+            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
+          else
+            echo "permissions=700"
+          fi
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "700"
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above). For example,
+          chmod 700 /var/lib/etcd
+        scored: true
+
   - id: 2
     text: "Etcd Node Configuration"
     checks:

--- a/package/cfg/k3s-cis-1.23-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.23-permissive/master.yaml
@@ -153,27 +153,6 @@ groups:
           chown root:root <path/to/cni/files>
         scored: false
 
-      - id: 1.1.11
-        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: |
-          if [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
-            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
-          else
-            echo "permissions=700"
-          fi
-        tests:
-          test_items:
-            - flag: "permissions"
-              compare:
-                op: bitmask
-                value: "700"
-        remediation: |
-          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-          from the command 'ps -ef | grep etcd'.
-          Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
-        scored: true
-
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
         audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G

--- a/package/cfg/k3s-cis-1.24-hardened/etcd.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/etcd.yaml
@@ -5,6 +5,35 @@ id: 2
 text: "Etcd Node Configuration"
 type: "etcd"
 groups:
+  - id: 1.1
+    text: "Master Node Configuration Files"
+    # Check 1.1.11 is related to etcd and in upstream it is present in master.yaml, But this check
+    # fails on controlplane nodes which does not have etcd so it is moved to etcd.yaml, so that the
+    # scan pass on the clusters which have seperate controlplane and etcd nodes. The check will also
+    # run on controlplane nodes which have etcd since run_sonobuoy_plugin.sh script detects etcd process
+    # and runs on any node where etcd is found.
+    checks:
+      - id: 1.1.11
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
+        audit: |
+          if [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster initializing' | wc -l)" -gt 0 ] || [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster bootstrap already complete and initialized' | wc -l )" -gt 0 ]; then
+            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
+          else
+            echo "permissions=700"
+          fi
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "700"
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above). For example,
+          chmod 700 /var/lib/etcd
+        scored: true
+
   - id: 2
     text: "Etcd Node Configuration"
     checks:

--- a/package/cfg/k3s-cis-1.24-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/master.yaml
@@ -147,27 +147,6 @@ groups:
           The default K3s CNI, flannel, does not create any files in /var/lib/cni/networks.
         scored: false
 
-      - id: 1.1.11
-        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: |
-          if [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
-            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
-          else
-            echo "permissions=700"
-          fi
-        tests:
-          test_items:
-            - flag: "permissions"
-              compare:
-                op: bitmask
-                value: "700"
-        remediation: |
-          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-          from the command 'ps -ef | grep etcd'.
-          Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
-        scored: true
-
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
         audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G

--- a/package/cfg/k3s-cis-1.24-permissive/etcd.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/etcd.yaml
@@ -5,6 +5,35 @@ id: 2
 text: "Etcd Node Configuration"
 type: "etcd"
 groups:
+  - id: 1.1
+    text: "Master Node Configuration Files"
+    # Check 1.1.11 is related to etcd and in upstream it is present in master.yaml, But this check
+    # fails on controlplane nodes which does not have etcd so it is moved to etcd.yaml, so that the
+    # scan pass on the clusters which have seperate controlplane and etcd nodes. The check will also
+    # run on controlplane nodes which have etcd since run_sonobuoy_plugin.sh script detects etcd process
+    # and runs on any node where etcd is found.
+    checks:
+      - id: 1.1.11
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
+        audit: |
+          if [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster initializing' | wc -l)" -gt 0 ] || [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster bootstrap already complete and initialized' | wc -l )" -gt 0 ]; then
+            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
+          else
+            echo "permissions=700"
+          fi
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "700"
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above). For example,
+          chmod 700 /var/lib/etcd
+        scored: true
+
   - id: 2
     text: "Etcd Node Configuration"
     checks:

--- a/package/cfg/k3s-cis-1.24-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/master.yaml
@@ -147,28 +147,6 @@ groups:
           The default K3s CNI, flannel, does not create any files in /var/lib/cni/networks.
         scored: false
 
-
-      - id: 1.1.11
-        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: |
-          if [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
-            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
-          else
-            echo "permissions=700"
-          fi
-        tests:
-          test_items:
-            - flag: "permissions"
-              compare:
-                op: bitmask
-                value: "700"
-        remediation: |
-          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-          from the command 'ps -ef | grep etcd'.
-          Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
-        scored: true
-
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
         audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G

--- a/package/cfg/k3s-cis-1.7-hardened/etcd.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/etcd.yaml
@@ -5,6 +5,35 @@ id: 2
 text: "Etcd Node Configuration"
 type: "etcd"
 groups:
+  - id: 1.1
+    text: "Master Node Configuration Files"
+    # Check 1.1.11 is related to etcd and in upstream it is present in master.yaml, But this check
+    # fails on controlplane nodes which does not have etcd so it is moved to etcd.yaml, so that the
+    # scan pass on the clusters which have seperate controlplane and etcd nodes. The check will also
+    # run on controlplane nodes which have etcd since run_sonobuoy_plugin.sh script detects etcd process
+    # and runs on any node where etcd is found.
+    checks:
+      - id: 1.1.11
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
+        audit: |
+          if [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster initializing' | wc -l)" -gt 0 ] || [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster bootstrap already complete and initialized' | wc -l )" -gt 0 ]; then
+            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
+          else
+            echo "permissions=700"
+          fi
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "700"
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above). For example,
+          chmod 700 /var/lib/etcd
+        scored: true
+
   - id: 2
     text: "Etcd Node Configuration"
     checks:

--- a/package/cfg/k3s-cis-1.7-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/master.yaml
@@ -148,27 +148,6 @@ groups:
           chown root:root /var/lib/cni/networks/<filename>
         scored: true
 
-      - id: 1.1.11
-        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: |
-          if [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
-            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
-          else
-            echo "permissions=700"
-          fi
-        tests:
-          test_items:
-            - flag: "permissions"
-              compare:
-                op: bitmask
-                value: "700"
-        remediation: |
-          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-          from the command 'ps -ef | grep etcd'.
-          Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 $etcddatadir
-        scored: true
-
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
         audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G

--- a/package/cfg/k3s-cis-1.7-permissive/etcd.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/etcd.yaml
@@ -5,6 +5,35 @@ id: 2
 text: "Etcd Node Configuration"
 type: "etcd"
 groups:
+  - id: 1.1
+    text: "Master Node Configuration Files"
+    # Check 1.1.11 is related to etcd and in upstream it is present in master.yaml, But this check
+    # fails on controlplane nodes which does not have etcd so it is moved to etcd.yaml, so that the
+    # scan pass on the clusters which have seperate controlplane and etcd nodes. The check will also
+    # run on controlplane nodes which have etcd since run_sonobuoy_plugin.sh script detects etcd process
+    # and runs on any node where etcd is found.
+    checks:
+      - id: 1.1.11
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
+        audit: |
+          if [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster initializing' | wc -l)" -gt 0 ] || [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster bootstrap already complete and initialized' | wc -l )" -gt 0 ]; then
+            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
+          else
+            echo "permissions=700"
+          fi
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "700"
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above). For example,
+          chmod 700 /var/lib/etcd
+        scored: true
+
   - id: 2
     text: "Etcd Node Configuration"
     checks:

--- a/package/cfg/k3s-cis-1.7-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/master.yaml
@@ -148,27 +148,6 @@ groups:
           chown root:root /var/lib/cni/networks/<filename>
         scored: true
 
-      - id: 1.1.11
-        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: |
-          if [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
-            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
-          else
-            echo "permissions=700"
-          fi
-        tests:
-          test_items:
-            - flag: "permissions"
-              compare:
-                op: bitmask
-                value: "700"
-        remediation: |
-          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-          from the command 'ps -ef | grep etcd'.
-          Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
-        scored: true
-
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
         audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G

--- a/package/cfg/k3s-cis-1.8-hardened/etcd.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/etcd.yaml
@@ -5,6 +5,35 @@ id: 2
 text: "Etcd Node Configuration"
 type: "etcd"
 groups:
+  - id: 1.1
+    text: "Master Node Configuration Files"
+    # Check 1.1.11 is related to etcd and in upstream it is present in master.yaml, But this check
+    # fails on controlplane nodes which does not have etcd so it is moved to etcd.yaml, so that the
+    # scan pass on the clusters which have seperate controlplane and etcd nodes. The check will also
+    # run on controlplane nodes which have etcd since run_sonobuoy_plugin.sh script detects etcd process
+    # and runs on any node where etcd is found.
+    checks:
+      - id: 1.1.11
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
+        audit: |
+          if [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster initializing' | wc -l)" -gt 0 ] || [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster bootstrap already complete and initialized' | wc -l )" -gt 0 ]; then
+            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
+          else
+            echo "permissions=700"
+          fi
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "700"
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above). For example,
+          chmod 700 /var/lib/etcd
+        scored: true
+
   - id: 2
     text: "Etcd Node Configuration"
     checks:

--- a/package/cfg/k3s-cis-1.8-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/master.yaml
@@ -148,27 +148,6 @@ groups:
           chown root:root /var/lib/cni/networks/<filename>
         scored: true
 
-      - id: 1.1.11
-        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: |
-          if [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
-            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
-          else
-            echo "permissions=700"
-          fi
-        tests:
-          test_items:
-            - flag: "permissions"
-              compare:
-                op: bitmask
-                value: "700"
-        remediation: |
-          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-          from the command 'ps -ef | grep etcd'.
-          Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
-        scored: true
-
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
         audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G

--- a/package/cfg/k3s-cis-1.8-permissive/etcd.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/etcd.yaml
@@ -5,6 +5,35 @@ id: 2
 text: "Etcd Node Configuration"
 type: "etcd"
 groups:
+  - id: 1.1
+    text: "Master Node Configuration Files"
+    # Check 1.1.11 is related to etcd and in upstream it is present in master.yaml, But this check
+    # fails on controlplane nodes which does not have etcd so it is moved to etcd.yaml, so that the
+    # scan pass on the clusters which have seperate controlplane and etcd nodes. The check will also
+    # run on controlplane nodes which have etcd since run_sonobuoy_plugin.sh script detects etcd process
+    # and runs on any node where etcd is found.
+    checks:
+      - id: 1.1.11
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
+        audit: |
+          if [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster initializing' | wc -l)" -gt 0 ] || [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster bootstrap already complete and initialized' | wc -l )" -gt 0 ]; then
+            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
+          else
+            echo "permissions=700"
+          fi
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "700"
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above). For example,
+          chmod 700 /var/lib/etcd
+        scored: true
+
   - id: 2
     text: "Etcd Node Configuration"
     checks:

--- a/package/cfg/k3s-cis-1.8-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/master.yaml
@@ -148,27 +148,6 @@ groups:
           chown root:root /var/lib/cni/networks/<filename>
         scored: true
 
-      - id: 1.1.11
-        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: |
-          if [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
-            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
-          else
-            echo "permissions=700"
-          fi
-        tests:
-          test_items:
-            - flag: "permissions"
-              compare:
-                op: bitmask
-                value: "700"
-        remediation: |
-          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
-          from the command 'ps -ef | grep etcd'.
-          Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
-        scored: true
-
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
         audit: ps -ef | grep $etcdbin | grep -- --data-dir | sed 's%.*data-dir[= ]\([^ ]*\).*%\1%' | xargs stat -c %U:%G


### PR DESCRIPTION
https://github.com/rancher/cis-operator/issues/350
- move k3s 1.1.11 check to etcd.yaml file for all the k3s profiles (1.23, 1.24,1.7,1.8 permissive and hardened)
- also updated audit of 1.1.11 check to match with etcd detection condition for k3s in [run_sonobuoy_plugin.sh](https://github.com/rancher/security-scan/blob/4299f432990ce90d1132a7b50084d6932434d586/package/run_sonobuoy_plugin.sh#L67)
- since 1.1.7, 1.1.8, 1.1.12 are not applicable for k3s and are skipped, those were kept in master.yaml file.
For more info about why these are moved to etcd.yaml check https://github.com/rancher/security-scan/pull/241#issue-2483300520