### PR TITLE
move etcd checks from master to etcd.yaml for rke2 profiles

### DIFF
--- a/package/cfg/rke2-cis-1.23-hardened/etcd.yaml
+++ b/package/cfg/rke2-cis-1.23-hardened/etcd.yaml
@@ -7,6 +7,11 @@ type: "etcd"
 groups:
   - id: 1.1
     text: "Master Node Configuration Files"
+    # These checks (1.1.7,1.1.8,1.1.11,1.1.12) are related to etcd and in upstream they are present
+    # in master.yaml, But these checks fail on controlplane nodes which does not have etcd.
+    # so these are moved to etcd.yaml, so that the scan passes on the clusters which have seperate
+    # controlplane, etcd node. These checks will also run on controlplane nodes which have etcd since
+    # run_sonobuoy_plugin.sh script detects etcd process and runs on any node where etcd is found.
     checks:
       - id: 1.1.7
         text: "Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Automated)"

--- a/package/cfg/rke2-cis-1.23-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.23-hardened/master.yaml
@@ -96,37 +96,6 @@ groups:
           For example, chown root:root $schedulerconf
         scored: true
 
-      - id: 1.1.7
-        text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c permissions=%a $etcdconf; fi'"
-        tests:
-          test_items:
-            - flag: "permissions"
-              compare:
-                op: bitmask
-                value: "600"
-        remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chmod 600 $etcdconf
-        scored: true
-
-      - id: 1.1.8
-        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
-        tests:
-          test_items:
-            - flag: "root:root"
-              compare:
-                op: eq
-                value: "root:root"
-              set: true
-        remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chown root:root $etcdconf
-        scored: true
-
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Manual)"
         audit: |

--- a/package/cfg/rke2-cis-1.23-permissive/etcd.yaml
+++ b/package/cfg/rke2-cis-1.23-permissive/etcd.yaml
@@ -7,10 +7,15 @@ type: "etcd"
 groups:
   - id: 1.1
     text: "Master Node Configuration Files"
+    # These checks (1.1.7,1.1.8,1.1.11,1.1.12) are related to etcd and in upstream they are present
+    # in master.yaml, But these checks fail on controlplane nodes which does not have etcd.
+    # so these are moved to etcd.yaml, so that the scan passes on the clusters which have seperate
+    # controlplane, etcd node. These checks will also run on controlplane nodes which have etcd since
+    # run_sonobuoy_plugin.sh script detects etcd process and runs on any node where etcd is found.
     checks:
       - id: 1.1.7
         text: "Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then find $etcdconf -name '*etcd*' | xargs stat -c permissions=%a; fi'"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c permissions=%a $etcdconf; fi'"
         use_multiple_values: true
         tests:
           test_items:

--- a/package/cfg/rke2-cis-1.23-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.23-permissive/master.yaml
@@ -96,37 +96,6 @@ groups:
           For example, chown root:root $schedulerconf
         scored: true
 
-      - id: 1.1.7
-        text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c permissions=%a $etcdconf; fi'"
-        tests:
-          test_items:
-            - flag: "permissions"
-              compare:
-                op: bitmask
-                value: "600"
-        remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chmod 600 $etcdconf
-        scored: true
-
-      - id: 1.1.8
-        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
-        tests:
-          test_items:
-            - flag: "root:root"
-              compare:
-                op: eq
-                value: "root:root"
-              set: true
-        remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chown root:root $etcdconf
-        scored: true
-
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 644 or more restrictive (Manual)"
         audit: |

--- a/package/cfg/rke2-cis-1.24-hardened/etcd.yaml
+++ b/package/cfg/rke2-cis-1.24-hardened/etcd.yaml
@@ -5,6 +5,76 @@ id: 2
 text: "Etcd Node Configuration"
 type: "etcd"
 groups:
+  - id: 1.1
+    text: "Master Node Configuration Files"
+    # These checks (1.1.7,1.1.8,1.1.11,1.1.12) are related to etcd and in upstream they are present
+    # in master.yaml, But these checks fail on controlplane nodes which does not have etcd.
+    # so these are moved to etcd.yaml, so that the scan passes on the clusters which have seperate
+    # controlplane, etcd node. These checks will also run on controlplane nodes which have etcd since
+    # run_sonobuoy_plugin.sh script detects etcd process and runs on any node where etcd is found.
+    checks:
+      - id: 1.1.7
+        text: "Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c permissions=%a $etcdconf; fi'"
+        tests:
+          test_items:
+            - flag: "644"
+              compare:
+                op: eq
+                value: "644"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod 644 $etcdconf
+        scored: true
+
+      - id: 1.1.8
+        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+              compare:
+                op: eq
+                value: "root:root"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root $etcdconf
+        scored: true
+
+      - id: 1.1.11
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
+        audit: "stat -c permissions=%a $etcddatadir"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "700"
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above). For example,
+          chmod 700 $etcddatadir
+        scored: true
+
+      - id: 1.1.12
+        text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
+        audit: "stat -c %U:%G $etcddatadir"
+        tests:
+          test_items:
+            - flag: "etcd:etcd"
+              set: true
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above).
+          For example, chown etcd:etcd /var/lib/etcd
+        scored: true
+
   # When possible, we check the flag, the environment variable, and the configuration file
   # kube-bench does not allow nested bin_ops, so when multiple flags are being checked in a single test,
   # we only check the config path.

--- a/package/cfg/rke2-cis-1.24-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.24-hardened/master.yaml
@@ -96,37 +96,6 @@ groups:
           For example, chown root:root $schedulerconf
         scored: true
 
-      - id: 1.1.7
-        text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c permissions=%a $etcdconf; fi'"
-        tests:
-          test_items:
-            - flag: "permissions"
-              compare:
-                op: bitmask
-                value: "600"
-        remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chmod 600 $etcdconf
-        scored: true
-
-      - id: 1.1.8
-        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
-        tests:
-          test_items:
-            - flag: "root:root"
-              compare:
-                op: eq
-                value: "root:root"
-              set: true
-        remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chown root:root $etcdconf
-        scored: true
-
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Manual)"
         audit: |

--- a/package/cfg/rke2-cis-1.24-permissive/etcd.yaml
+++ b/package/cfg/rke2-cis-1.24-permissive/etcd.yaml
@@ -5,6 +5,77 @@ id: 2
 text: "Etcd Node Configuration"
 type: "etcd"
 groups:
+  - id: 1.1
+    text: "Master Node Configuration Files"
+    # These checks (1.1.7,1.1.8,1.1.11,1.1.12) are related to etcd and in upstream they are present
+    # in master.yaml, But these checks fail on controlplane nodes which does not have etcd.
+    # so these are moved to etcd.yaml, so that the scan passes on the clusters which have seperate
+    # controlplane, etcd node. These checks will also run on controlplane nodes which have etcd since
+    # run_sonobuoy_plugin.sh script detects etcd process and runs on any node where etcd is found.
+    checks:
+      - id: 1.1.7
+        text: "Ensure that the etcd pod specification file permissions are set to 644 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c permissions=%a $etcdconf; fi'"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "644"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod 644 $etcdconf
+        scored: true
+
+      - id: 1.1.8
+        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+              compare:
+                op: eq
+                value: "root:root"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root $etcdconf
+        scored: true
+
+      - id: 1.1.11
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
+        audit: "stat -c permissions=%a $etcddatadir"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "700"
+              set: true
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above). For example,
+          chmod 700 $etcddatadir
+        scored: true
+
+      - id: 1.1.12
+        text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
+        type: "skip"
+        audit: "stat -c %U:%G $etcddatadir"
+        tests:
+          test_items:
+            - flag: "etcd:etcd"
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above).
+          For example, chown etcd:etcd /var/lib/etcd
+        scored: true
+
   # When possible, we check the flag, the environment variable, and the configuration file
   # kube-bench does not allow nested bin_ops, so when multiple flags are being checked in a single test,
   # we only check the config path.

--- a/package/cfg/rke2-cis-1.24-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.24-permissive/master.yaml
@@ -96,37 +96,6 @@ groups:
           For example, chown root:root $schedulerconf
         scored: true
 
-      - id: 1.1.7
-        text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c permissions=%a $etcdconf; fi'"
-        tests:
-          test_items:
-            - flag: "permissions"
-              compare:
-                op: bitmask
-                value: "600"
-        remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chmod 600 $etcdconf
-        scored: true
-
-      - id: 1.1.8
-        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
-        tests:
-          test_items:
-            - flag: "root:root"
-              compare:
-                op: eq
-                value: "root:root"
-              set: true
-        remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chown root:root $etcdconf
-        scored: true
-
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Manual)"
         audit: |

--- a/package/cfg/rke2-cis-1.7-hardened/etcd.yaml
+++ b/package/cfg/rke2-cis-1.7-hardened/etcd.yaml
@@ -5,6 +5,77 @@ id: 2
 text: "Etcd Node Configuration"
 type: "etcd"
 groups:
+  - id: 1.1
+    text: "Master Node Configuration Files"
+    # These checks (1.1.7,1.1.8,1.1.11,1.1.12) are related to etcd and in upstream they are present
+    # in master.yaml, But these checks fail on controlplane nodes which does not have etcd.
+    # so these are moved to etcd.yaml, so that the scan passes on the clusters which have seperate
+    # controlplane, etcd node. These checks will also run on controlplane nodes which have etcd since
+    # run_sonobuoy_plugin.sh script detects etcd process and runs on any node where etcd is found.
+    checks:
+      - id: 1.1.7
+        text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c permissions=%a $etcdconf; fi'"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod 600 $etcdconf
+        scored: true
+
+      - id: 1.1.8
+        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+              compare:
+                op: eq
+                value: "root:root"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root $etcdconf
+        scored: true
+
+      - id: 1.1.11
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
+        audit: "stat -c permissions=%a $etcddatadir"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "700"
+              set: true
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above). For example,
+          chmod 700 $etcddatadir
+        scored: true
+
+      - id: 1.1.12
+        text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
+        type: "skip"
+        audit: "stat -c %U:%G $etcddatadir"
+        tests:
+          test_items:
+            - flag: "etcd:etcd"
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above).
+          For example, chown etcd:etcd /var/lib/etcd
+        scored: true
+
   # When possible, we check the flag, the environment variable, and the configuration file
   # kube-bench does not allow nested bin_ops, so when multiple flags are being checked in a single test,
   # we only check the config path.

--- a/package/cfg/rke2-cis-1.7-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.7-hardened/master.yaml
@@ -96,37 +96,6 @@ groups:
           For example, chown root:root $schedulerconf
         scored: true
 
-      - id: 1.1.7
-        text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c permissions=%a $etcdconf; fi'"
-        tests:
-          test_items:
-            - flag: "permissions"
-              compare:
-                op: bitmask
-                value: "600"
-        remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chmod 600 $etcdconf
-        scored: true
-
-      - id: 1.1.8
-        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
-        tests:
-          test_items:
-            - flag: "root:root"
-              compare:
-                op: eq
-                value: "root:root"
-              set: true
-        remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chown root:root $etcdconf
-        scored: true
-
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Manual)"
         audit: |

--- a/package/cfg/rke2-cis-1.7-permissive/etcd.yaml
+++ b/package/cfg/rke2-cis-1.7-permissive/etcd.yaml
@@ -5,6 +5,77 @@ id: 2
 text: "Etcd Node Configuration"
 type: "etcd"
 groups:
+  - id: 1.1
+    text: "Master Node Configuration Files"
+    # These checks (1.1.7,1.1.8,1.1.11,1.1.12) are related to etcd and in upstream they are present
+    # in master.yaml, But these checks fail on controlplane nodes which does not have etcd.
+    # so these are moved to etcd.yaml, so that the scan passes on the clusters which have seperate
+    # controlplane, etcd node. These checks will also run on controlplane nodes which have etcd since
+    # run_sonobuoy_plugin.sh script detects etcd process and runs on any node where etcd is found.
+    checks:
+      - id: 1.1.7
+        text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c permissions=%a $etcdconf; fi'"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod 600 $etcdconf
+        scored: true
+
+      - id: 1.1.8
+        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+              compare:
+                op: eq
+                value: "root:root"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root $etcdconf
+        scored: true
+
+      - id: 1.1.11
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
+        audit: "stat -c permissions=%a $etcddatadir"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "700"
+              set: true
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above). For example,
+          chmod 700 $etcddatadir
+        scored: true
+
+      - id: 1.1.12
+        text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
+        type: "skip"
+        audit: "stat -c %U:%G $etcddatadir"
+        tests:
+          test_items:
+            - flag: "etcd:etcd"
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above).
+          For example, chown etcd:etcd /var/lib/etcd
+        scored: true
+
   # When possible, we check the flag, the environment variable, and the configuration file
   # kube-bench does not allow nested bin_ops, so when multiple flags are being checked in a single test,
   # we only check the config path.

--- a/package/cfg/rke2-cis-1.7-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.7-permissive/master.yaml
@@ -96,37 +96,6 @@ groups:
           For example, chown root:root $schedulerconf
         scored: true
 
-      - id: 1.1.7
-        text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c permissions=%a $etcdconf; fi'"
-        tests:
-          test_items:
-            - flag: "permissions"
-              compare:
-                op: bitmask
-                value: "600"
-        remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chmod 600 $etcdconf
-        scored: true
-
-      - id: 1.1.8
-        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
-        tests:
-          test_items:
-            - flag: "root:root"
-              compare:
-                op: eq
-                value: "root:root"
-              set: true
-        remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chown root:root $etcdconf
-        scored: true
-
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Manual)"
         audit: |

--- a/package/cfg/rke2-cis-1.8-hardened/etcd.yaml
+++ b/package/cfg/rke2-cis-1.8-hardened/etcd.yaml
@@ -5,6 +5,77 @@ id: 2
 text: "Etcd Node Configuration"
 type: "etcd"
 groups:
+  - id: 1.1
+    text: "Master Node Configuration Files"
+    # These checks (1.1.7,1.1.8,1.1.11,1.1.12) are related to etcd and in upstream they are present
+    # in master.yaml, But these checks fail on controlplane nodes which does not have etcd.
+    # so these are moved to etcd.yaml, so that the scan passes on the clusters which have seperate
+    # controlplane, etcd node. These checks will also run on controlplane nodes which have etcd since
+    # run_sonobuoy_plugin.sh script detects etcd process and runs on any node where etcd is found.
+    checks:
+      - id: 1.1.7
+        text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c permissions=%a $etcdconf; fi'"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod 600 $etcdconf
+        scored: true
+
+      - id: 1.1.8
+        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+              compare:
+                op: eq
+                value: "root:root"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root $etcdconf
+        scored: true
+
+      - id: 1.1.11
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
+        audit: "stat -c permissions=%a $etcddatadir"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "700"
+              set: true
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above). For example,
+          chmod 700 $etcddatadir
+        scored: true
+
+      - id: 1.1.12
+        text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
+        type: "skip"
+        audit: "stat -c %U:%G $etcddatadir"
+        tests:
+          test_items:
+            - flag: "etcd:etcd"
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above).
+          For example, chown etcd:etcd /var/lib/etcd
+        scored: true
+
   # When possible, we check the flag, the environment variable, and the configuration file
   # kube-bench does not allow nested bin_ops, so when multiple flags are being checked in a single test,
   # we only check the config path.

--- a/package/cfg/rke2-cis-1.8-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.8-hardened/master.yaml
@@ -96,37 +96,6 @@ groups:
           For example, chown root:root $schedulerconf
         scored: true
 
-      - id: 1.1.7
-        text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c permissions=%a $etcdconf; fi'"
-        tests:
-          test_items:
-            - flag: "permissions"
-              compare:
-                op: bitmask
-                value: "600"
-        remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chmod 600 $etcdconf
-        scored: true
-
-      - id: 1.1.8
-        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
-        tests:
-          test_items:
-            - flag: "root:root"
-              compare:
-                op: eq
-                value: "root:root"
-              set: true
-        remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chown root:root $etcdconf
-        scored: true
-
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Manual)"
         audit: |

--- a/package/cfg/rke2-cis-1.8-permissive/etcd.yaml
+++ b/package/cfg/rke2-cis-1.8-permissive/etcd.yaml
@@ -5,6 +5,77 @@ id: 2
 text: "Etcd Node Configuration"
 type: "etcd"
 groups:
+  - id: 1.1
+    text: "Master Node Configuration Files"
+    # These checks (1.1.7,1.1.8,1.1.11,1.1.12) are related to etcd and in upstream they are present
+    # in master.yaml, But these checks fail on controlplane nodes which does not have etcd.
+    # so these are moved to etcd.yaml, so that the scan passes on the clusters which have seperate
+    # controlplane, etcd node. These checks will also run on controlplane nodes which have etcd since
+    # run_sonobuoy_plugin.sh script detects etcd process and runs on any node where etcd is found.
+    checks:
+      - id: 1.1.7
+        text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c permissions=%a $etcdconf; fi'"
+        use_multiple_values: true
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "600"
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chmod 600 $etcdconf
+        scored: true
+
+      - id: 1.1.8
+        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
+        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
+        tests:
+          test_items:
+            - flag: "root:root"
+              compare:
+                op: eq
+                value: "root:root"
+              set: true
+        remediation: |
+          Run the below command (based on the file location on your system) on the control plane node.
+          For example,
+          chown root:root $etcdconf
+        scored: true
+
+      - id: 1.1.11
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
+        audit: "stat -c permissions=%a $etcddatadir"
+        tests:
+          test_items:
+            - flag: "permissions"
+              compare:
+                op: bitmask
+                value: "700"
+              set: true
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above). For example,
+          chmod 700 $etcddatadir
+        scored: true
+
+      - id: 1.1.12
+        text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"
+        type: "skip"
+        audit: "stat -c %U:%G $etcddatadir"
+        tests:
+          test_items:
+            - flag: "etcd:etcd"
+        remediation: |
+          On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
+          from the command 'ps -ef | grep etcd'.
+          Run the below command (based on the etcd data directory found above).
+          For example, chown etcd:etcd $etcddatadir
+        scored: true
+
   # When possible, we check the flag, the environment variable, and the configuration file
   # kube-bench does not allow nested bin_ops, so when multiple flags are being checked in a single test,
   # we only check the config path.

--- a/package/cfg/rke2-cis-1.8-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.8-permissive/master.yaml
@@ -96,37 +96,6 @@ groups:
           For example, chown root:root $schedulerconf
         scored: true
 
-      - id: 1.1.7
-        text: "Ensure that the etcd pod specification file permissions are set to 600 or more restrictive (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c permissions=%a $etcdconf; fi'"
-        tests:
-          test_items:
-            - flag: "permissions"
-              compare:
-                op: bitmask
-                value: "600"
-        remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chmod 600 $etcdconf
-        scored: true
-
-      - id: 1.1.8
-        text: "Ensure that the etcd pod specification file ownership is set to root:root (Automated)"
-        audit: "/bin/sh -c 'if test -e $etcdconf; then stat -c %U:%G $etcdconf; fi'"
-        tests:
-          test_items:
-            - flag: "root:root"
-              compare:
-                op: eq
-                value: "root:root"
-              set: true
-        remediation: |
-          Run the below command (based on the file location on your system) on the control plane node.
-          For example,
-          chown root:root $etcdconf
-        scored: true
-
       - id: 1.1.9
         text: "Ensure that the Container Network Interface file permissions are set to 600 or more restrictive (Manual)"
         audit: |


### PR DESCRIPTION
issue: https://github.com/rancher/cis-operator/issues/350

checks 1.1.7, 1.1.8, 1.1.11 and 1.1.12 are related to etcd configuration. In upstream profiles these checks resides in master.yaml. The issue is that master.yaml checks are run on the nodes only where apiserver is detected as per
the condition
https://github.com/rancher/security-scan/blob/4299f432990ce90d1132a7b50084d6932434d586/package/run_sonobuoy_plugin.sh#L98-L103
 in run_sonobuoy_script . So the above mentioned checks fails in case etcd is deployed on a separate node.
These checks will work as expected if controlplane and etcd both are on the same node.

There is a related issue posted on upstream as well. And in a comment ( https://github.com/aquasecurity/kube-bench/issues/306#issuecomment-500135745 ) on that issue, There are two suggestions given one to move these checks in separate section and the other one is to mark them skip.
So It is  decided that we move these in etcd.yaml for the our rke2 profiles.
As per  the condition https://github.com/rancher/security-scan/blob/4299f432990ce90d1132a7b50084d6932434d586/package/run_sonobuoy_plugin.sh#L65-L70 in run_sonobuoy_plugin script the etcd.yaml checks will run on the nodes on which etcd is detected. 
So even if a cluster has single master node (controlplane + etcd) or separate controlplane and etcd nodes, the etcd.yaml checks will run on any type of node where etcd is detected. So it works in both cases.

- removed 1.1.7, 1.1.8 checks from master.yaml from rke2 profiles.
- added 1.1.7, 1.1.8, 1.1.11, 1.1.12 checks to etcd.yaml for rke2 profiles.