### PR TITLE
rke2: set scored:false for audit log checks in permissive profiles

### DIFF
--- a/package/cfg/rke2-cis-1.23-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.23-permissive/master.yaml
@@ -623,9 +623,8 @@ groups:
         scored: true
 
       - id: 1.2.19
-        text: "Ensure that the --audit-log-path argument is set (Automated)"
+        text: "Ensure that the --audit-log-path argument is set (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
-        type: "skip"
         tests:
           test_items:
             - flag: "--audit-log-path"
@@ -635,12 +634,11 @@ groups:
           on the control plane node and set the --audit-log-path parameter to a suitable path and
           file where you would like audit logs to be written, for example,
           --audit-log-path=/var/log/apiserver/audit.log
-        scored: true
+        scored: false
 
       - id: 1.2.20
-        text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
+        text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
-        type: "skip"
         tests:
           test_items:
             - flag: "--audit-log-maxage"
@@ -653,12 +651,11 @@ groups:
           on the control plane node and set the --audit-log-maxage parameter to 30
           or as an appropriate number of days, for example,
           --audit-log-maxage=30
-        scored: true
+        scored: false
 
       - id: 1.2.21
-        text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
+        text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
-        type: "skip"
         tests:
           test_items:
             - flag: "--audit-log-maxbackup"
@@ -671,12 +668,11 @@ groups:
           on the control plane node and set the --audit-log-maxbackup parameter to 10 or to an appropriate
           value. For example,
           --audit-log-maxbackup=10
-        scored: true
+        scored: false
 
       - id: 1.2.22
-        text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
+        text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
-        type: "skip"
         tests:
           test_items:
             - flag: "--audit-log-maxsize"
@@ -688,7 +684,7 @@ groups:
           Edit the API server pod specification file $apiserverconf
           on the control plane node and set the --audit-log-maxsize parameter to an appropriate size in MB.
           For example, to set it as 100 MB, --audit-log-maxsize=100
-        scored: true
+        scored: false
 
       - id: 1.2.23
         text: "Ensure that the --request-timeout argument is set as appropriate (Automated)"

--- a/package/cfg/rke2-cis-1.24-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.24-permissive/master.yaml
@@ -635,9 +635,8 @@ groups:
         scored: true
 
       - id: 1.2.19
-        text: "Ensure that the --audit-log-path argument is set (Automated)"
+        text: "Ensure that the --audit-log-path argument is set (Manual)"
         audit: "/bin/ps -fC $apiserverbin"
-        type: "skip"
         tests:
           test_items:
             - flag: "--audit-log-path"
@@ -649,12 +648,11 @@ groups:
           file where you would like audit logs to be written, for example,
           kube-apiserver-arg:
             - "audit-log-path=/var/log/rke2/audit.log"
-        scored: true
+        scored: false
 
       - id: 1.2.20
-        text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
+        text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Manual)"
         audit: "/bin/ps -fC $apiserverbin"
-        type: "skip"
         tests:
           test_items:
             - flag: "--audit-log-maxage"
@@ -668,12 +666,11 @@ groups:
           on the control plane node and set the --audit-log-maxage parameter to an appropriate number of days, for example,
           kube-apiserver-arg:
             - "audit-log-maxage=40"
-        scored: true
+        scored: false
 
       - id: 1.2.21
-        text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
+        text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Manual)"
         audit: "/bin/ps -fC $apiserverbin"
-        type: "skip"
         tests:
           test_items:
             - flag: "--audit-log-maxbackup"
@@ -688,12 +685,11 @@ groups:
           For example,
           kube-apiserver-arg:
             - "audit-log-maxbackup=15"
-        scored: true
+        scored: false
 
       - id: 1.2.22
-        text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
+        text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Manual)"
         audit: "/bin/ps -fC $apiserverbin"
-        type: "skip"
         tests:
           test_items:
             - flag: "--audit-log-maxsize"
@@ -708,7 +704,7 @@ groups:
           For example,
           kube-apiserver-arg:
             - "audit-log-maxsize=150"
-        scored: true
+        scored: false
 
       - id: 1.2.23
         text: "Ensure that the --request-timeout argument is set as appropriate (Automated)"

--- a/package/cfg/rke2-cis-1.7-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.7-permissive/master.yaml
@@ -617,8 +617,7 @@ groups:
         scored: true
 
       - id: 1.2.18
-        text: "Ensure that the --audit-log-path argument is set (Automated)"
-        type: "skip"
+        text: "Ensure that the --audit-log-path argument is set (Manual)"
         audit: "/bin/ps -fC $apiserverbin"
         tests:
           test_items:
@@ -632,11 +631,10 @@ groups:
           kube-apiserver-arg:
             - "audit-log-path=/var/log/rke2/audit.log"
           Permissive.
-        scored: true
+        scored: false
 
       - id: 1.2.19
-        text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
-        type: "skip"
+        text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Manual)"
         audit: "/bin/ps -fC $apiserverbin"
         tests:
           test_items:
@@ -652,11 +650,10 @@ groups:
           kube-apiserver-arg:
             - "audit-log-maxage=40"
           Permissive.
-        scored: true
+        scored: false
 
       - id: 1.2.20
-        text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
-        type: "skip"
+        text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Manual)"
         audit: "/bin/ps -fC $apiserverbin"
         tests:
           test_items:
@@ -673,11 +670,10 @@ groups:
           kube-apiserver-arg:
             - "audit-log-maxbackup=15"
           Permissive.
-        scored: true
+        scored: false
 
       - id: 1.2.21
-        text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
-        type: "skip"
+        text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Manual)"
         audit: "/bin/ps -fC $apiserverbin"
         tests:
           test_items:
@@ -693,7 +689,7 @@ groups:
           For example,
           kube-apiserver-arg:
             - "audit-log-maxsize=150"
-        scored: true
+        scored: false
 
       - id: 1.2.22
         text: "Ensure that the --request-timeout argument is set as appropriate (Automated)"

--- a/package/cfg/rke2-cis-1.8-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.8-permissive/master.yaml
@@ -599,7 +599,7 @@ groups:
         scored: true
 
       - id: 1.2.17
-        text: "Ensure that the --audit-log-path argument is set (Automated)"
+        text: "Ensure that the --audit-log-path argument is set (Manual)"
         audit: "/bin/ps -fC $apiserverbin"
         tests:
           test_items:
@@ -612,10 +612,10 @@ groups:
           file where you would like audit logs to be written, for example,
           kube-apiserver-arg:
             - "audit-log-path=/var/log/rke2/audit.log"
-        scored: true
+        scored: false
 
       - id: 1.2.18
-        text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Automated)"
+        text: "Ensure that the --audit-log-maxage argument is set to 30 or as appropriate (Manual)"
         audit: "/bin/ps -fC $apiserverbin"
         tests:
           test_items:
@@ -630,10 +630,10 @@ groups:
           on the control plane node and set the --audit-log-maxage parameter to an appropriate number of days, for example,
           kube-apiserver-arg:
             - "audit-log-maxage=40"
-        scored: true
+        scored: false
 
       - id: 1.2.19
-        text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Automated)"
+        text: "Ensure that the --audit-log-maxbackup argument is set to 10 or as appropriate (Manual)"
         audit: "/bin/ps -fC $apiserverbin"
         tests:
           test_items:
@@ -649,10 +649,10 @@ groups:
           For example,
           kube-apiserver-arg:
             - "audit-log-maxbackup=15"
-        scored: true
+        scored: false
 
       - id: 1.2.20
-        text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Automated)"
+        text: "Ensure that the --audit-log-maxsize argument is set to 100 or as appropriate (Manual)"
         audit: "/bin/ps -fC $apiserverbin"
         tests:
           test_items:
@@ -668,7 +668,7 @@ groups:
           For example,
           kube-apiserver-arg:
             - "audit-log-maxsize=150"
-        scored: true
+        scored: false
 
       - id: 1.2.21
         text: "Ensure that the --request-timeout argument is set as appropriate (Automated)"


### PR DESCRIPTION
issue: https://github.com/rancher/rancher/issues/46812
set  `scored: false` to audit log related checks for rke2 permissive profiles. Also updated Checks text and added Manual in place of Automated.
following checks are updated
- rke2-cis-1.8-profile-permissive 1.2.17-20
- rke2-cis-1.7-profile-permissive 1.2.18-21 (also removed `type: skip`)
- rke2-cis-1.23-profile-permissive 1.2.19-22 (also removed `type: skip`)
- rke2-cis-1.24-profile-permissive 1.2.19-22 (also removed `type: skip`)

Since type manual is set, these tests will always be in warn state for these profiles after this change.