### PR TITLE
Improve Master 1.2.3 DenyServiceExternalIPs for RKE/RKE2/K3s

### DIFF
--- a/package/cfg/cis-1.7/master.yaml
+++ b/package/cfg/cis-1.7/master.yaml
@@ -349,12 +349,12 @@ groups:
           test_items:
             - flag: "--enable-admission-plugins"
               compare:
-                op: have
+                op: has
                 value: "DenyServiceExternalIPs"
         remediation: |
           Edit the API server pod specification file $apiserverconf
-          on the control plane node and remove the `DenyServiceExternalIPs`
-          from enabled admission plugins.
+          on the control plane node and add the `DenyServiceExternalIPs` plugin
+          to the enabled admission plugins, as such --enable-admission-plugin=DenyServiceExternalIPs.
         scored: false
 
       - id: 1.2.4

--- a/package/cfg/cis-1.8/master.yaml
+++ b/package/cfg/cis-1.8/master.yaml
@@ -326,12 +326,12 @@ groups:
           test_items:
             - flag: "--enable-admission-plugins"
               compare:
-                op: have
+                op: has
                 value: "DenyServiceExternalIPs"
         remediation: |
           Edit the API server pod specification file $apiserverconf
-          on the control plane node and remove the `DenyServiceExternalIPs`
-          from enabled admission plugins.
+          on the control plane node and add the `DenyServiceExternalIPs` plugin
+          to the enabled admission plugins, as such --enable-admission-plugin=DenyServiceExternalIPs.
         scored: false
       - id: 1.2.4
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"

--- a/package/cfg/k3s-cis-1.7-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/master.yaml
@@ -348,24 +348,20 @@ groups:
         scored: true
 
       - id: 1.2.3
-        text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
+        text: "Ensure that the --DenyServiceExternalIPs is set (Manual)"
         audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
-          bin_op: or
           test_items:
             - flag: "--enable-admission-plugins"
               compare:
-                op: nothave
+                op: has
                 value: "DenyServiceExternalIPs"
-              set: true
-            - flag: "--enable-admission-plugins"
-              set: false
         remediation: |
           By default, K3s does not set DenyServiceExternalIPs.
-          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          To enable this flag, edit the K3s config file /etc/rancher/k3s/config.yaml like below.
           kube-apiserver-arg:
             - "enable-admission-plugins=DenyServiceExternalIPs"
-        scored: true
+        scored: false
 
       - id: 1.2.4
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"

--- a/package/cfg/k3s-cis-1.7-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/master.yaml
@@ -349,24 +349,20 @@ groups:
         scored: true
 
       - id: 1.2.3
-        text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
+        text: "Ensure that the --DenyServiceExternalIPs is set (Manual)"
         audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
-          bin_op: or
           test_items:
             - flag: "--enable-admission-plugins"
               compare:
-                op: nothave
+                op: has
                 value: "DenyServiceExternalIPs"
-              set: true
-            - flag: "--enable-admission-plugins"
-              set: false
         remediation: |
           By default, K3s does not set DenyServiceExternalIPs.
-          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          To enable this flag, edit the K3s config file /etc/rancher/k3s/config.yaml like below.
           kube-apiserver-arg:
             - "enable-admission-plugins=DenyServiceExternalIPs"
-        scored: true
+        scored: false
 
       - id: 1.2.4
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"

--- a/package/cfg/k3s-cis-1.8-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/master.yaml
@@ -348,24 +348,20 @@ groups:
         scored: true
 
       - id: 1.2.3
-        text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
+        text: "Ensure that the --DenyServiceExternalIPs is set (Manual)"
         audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
-          bin_op: or
           test_items:
             - flag: "--enable-admission-plugins"
               compare:
-                op: nothave
+                op: has
                 value: "DenyServiceExternalIPs"
-              set: true
-            - flag: "--enable-admission-plugins"
-              set: false
         remediation: |
           By default, K3s does not set DenyServiceExternalIPs.
-          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          To enable this flag, edit the K3s config file /etc/rancher/k3s/config.yaml like below.
           kube-apiserver-arg:
             - "enable-admission-plugins=DenyServiceExternalIPs"
-        scored: true
+        scored: false
 
       - id: 1.2.4
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"

--- a/package/cfg/k3s-cis-1.8-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/master.yaml
@@ -349,24 +349,20 @@ groups:
         scored: true
 
       - id: 1.2.3
-        text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
+        text: "Ensure that the --DenyServiceExternalIPs is set (Manual)"
         audit: "journalctl -m -u k3s | grep 'Running kube-apiserver' | tail -n1"
         tests:
-          bin_op: or
           test_items:
             - flag: "--enable-admission-plugins"
               compare:
-                op: nothave
+                op: has
                 value: "DenyServiceExternalIPs"
-              set: true
-            - flag: "--enable-admission-plugins"
-              set: false
         remediation: |
           By default, K3s does not set DenyServiceExternalIPs.
-          If this check fails, edit the K3s config file /etc/rancher/k3s/config.yaml, remove any lines like below.
+          To enable this flag, edit the K3s config file /etc/rancher/k3s/config.yaml like below.
           kube-apiserver-arg:
             - "enable-admission-plugins=DenyServiceExternalIPs"
-        scored: true
+        scored: false
 
       - id: 1.2.4
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"

--- a/package/cfg/rke-cis-1.7-hardened/master.yaml
+++ b/package/cfg/rke-cis-1.7-hardened/master.yaml
@@ -298,23 +298,19 @@ groups:
         scored: true
 
       - id: 1.2.3
-        text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
+        text: "Ensure that the --DenyServiceExternalIPs is set (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
-          bin_op: or
           test_items:
             - flag: "--enable-admission-plugins"
               compare:
-                op: nothave
+                op: has
                 value: "DenyServiceExternalIPs"
-              set: true
-            - flag: "--enable-admission-plugins"
-              set: false
         remediation: |
           Edit the API server pod specification file $apiserverconf
-          on the control plane node and remove the `DenyServiceExternalIPs`
-          from enabled admission plugins.
-        scored: true
+          on the control plane node and add the `DenyServiceExternalIPs` plugin
+          to the enabled admission plugins, as such --enable-admission-plugin=DenyServiceExternalIPs.
+        scored: false
 
       - id: 1.2.4
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"

--- a/package/cfg/rke-cis-1.7-permissive/master.yaml
+++ b/package/cfg/rke-cis-1.7-permissive/master.yaml
@@ -298,23 +298,19 @@ groups:
         scored: true
 
       - id: 1.2.3
-        text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
+        text: "Ensure that the --DenyServiceExternalIPs is set (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
-          bin_op: or
           test_items:
             - flag: "--enable-admission-plugins"
               compare:
-                op: nothave
+                op: has
                 value: "DenyServiceExternalIPs"
-              set: true
-            - flag: "--enable-admission-plugins"
-              set: false
         remediation: |
           Edit the API server pod specification file $apiserverconf
-          on the control plane node and remove the `DenyServiceExternalIPs`
-          from enabled admission plugins.
-        scored: true
+          on the control plane node and add the `DenyServiceExternalIPs` plugin
+          to the enabled admission plugins, as such --enable-admission-plugin=DenyServiceExternalIPs.
+        scored: false
 
       - id: 1.2.4
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"

--- a/package/cfg/rke-cis-1.8-hardened/master.yaml
+++ b/package/cfg/rke-cis-1.8-hardened/master.yaml
@@ -297,23 +297,19 @@ groups:
         scored: true
 
       - id: 1.2.3
-        text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
+        text: "Ensure that the --DenyServiceExternalIPs is set (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
-          bin_op: or
           test_items:
             - flag: "--enable-admission-plugins"
               compare:
-                op: nothave
+                op: has
                 value: "DenyServiceExternalIPs"
-              set: true
-            - flag: "--enable-admission-plugins"
-              set: false
         remediation: |
           Edit the API server pod specification file $apiserverconf
-          on the control plane node and remove the `DenyServiceExternalIPs`
-          from enabled admission plugins.
-        scored: true
+          on the control plane node and add the `DenyServiceExternalIPs` plugin
+          to the enabled admission plugins, as such --enable-admission-plugin=DenyServiceExternalIPs.
+        scored: false
 
       - id: 1.2.4
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"

--- a/package/cfg/rke-cis-1.8-permissive/master.yaml
+++ b/package/cfg/rke-cis-1.8-permissive/master.yaml
@@ -297,23 +297,19 @@ groups:
         scored: true
 
       - id: 1.2.3
-        text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
+        text: "Ensure that the --DenyServiceExternalIPs is set (Manual)"
         audit: "/bin/ps -ef | grep $apiserverbin | grep -v grep"
         tests:
-          bin_op: or
           test_items:
             - flag: "--enable-admission-plugins"
               compare:
-                op: nothave
+                op: has
                 value: "DenyServiceExternalIPs"
-              set: true
-            - flag: "--enable-admission-plugins"
-              set: false
         remediation: |
           Edit the API server pod specification file $apiserverconf
-          on the control plane node and remove the `DenyServiceExternalIPs`
-          from enabled admission plugins.
-        scored: true
+          on the control plane node and add the `DenyServiceExternalIPs` plugin
+          to the enabled admission plugins, as such --enable-admission-plugin=DenyServiceExternalIPs.
+        scored: false
 
       - id: 1.2.4
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"

--- a/package/cfg/rke2-cis-1.7-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.7-hardened/master.yaml
@@ -340,24 +340,20 @@ groups:
         scored: true
 
       - id: 1.2.3
-        text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
+        text: "Ensure that the --DenyServiceExternalIPs is set (Manual)"
         audit: "/bin/ps -fC $apiserverbin"
         tests:
-          bin_op: or
           test_items:
             - flag: "--enable-admission-plugins"
               compare:
-                op: nothave
+                op: has
                 value: "DenyServiceExternalIPs"
-              set: true
-            - flag: "--enable-admission-plugins"
-              set: false
         remediation: |
           By default, RKE2 does not set DenyServiceExternalIPs.
-          If this check fails, edit the RKE2 config file /etc/rancher/rke2/config.yaml, remove any lines like below.
+          To enable this flag, edit the RKE2 config file /etc/rancher/rke2/config.yaml like below.
           kube-apiserver-arg:
             - "enable-admission-plugins=DenyServiceExternalIPs"
-        scored: true
+        scored: false
 
       - id: 1.2.4
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"

--- a/package/cfg/rke2-cis-1.7-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.7-permissive/master.yaml
@@ -340,24 +340,20 @@ groups:
         scored: true
 
       - id: 1.2.3
-        text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
+        text: "Ensure that the --DenyServiceExternalIPs is set (Manual)"
         audit: "/bin/ps -fC $apiserverbin"
         tests:
-          bin_op: or
           test_items:
             - flag: "--enable-admission-plugins"
               compare:
-                op: nothave
+                op: has
                 value: "DenyServiceExternalIPs"
-              set: true
-            - flag: "--enable-admission-plugins"
-              set: false
         remediation: |
           By default, RKE2 does not set DenyServiceExternalIPs.
-          If this check fails, edit the RKE2 config file /etc/rancher/rke2/config.yaml, remove any lines like below.
+          To enable this flag, edit the RKE2 config file /etc/rancher/rke2/config.yaml like below.
           kube-apiserver-arg:
             - "enable-admission-plugins=DenyServiceExternalIPs"
-        scored: true
+        scored: false
 
       - id: 1.2.4
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"

--- a/package/cfg/rke2-cis-1.8-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.8-hardened/master.yaml
@@ -339,24 +339,20 @@ groups:
         scored: true
 
       - id: 1.2.3
-        text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
+        text: "Ensure that the --DenyServiceExternalIPs is set (Manual)"
         audit: "/bin/ps -fC $apiserverbin"
         tests:
-          bin_op: or
           test_items:
             - flag: "--enable-admission-plugins"
               compare:
-                op: nothave
+                op: has
                 value: "DenyServiceExternalIPs"
-              set: true
-            - flag: "--enable-admission-plugins"
-              set: false
         remediation: |
           By default, RKE2 does not set DenyServiceExternalIPs.
-          If this check fails, edit the RKE2 config file /etc/rancher/rke2/config.yaml, remove any lines like below.
+          To enable this flag, edit the RKE2 config file /etc/rancher/rke2/config.yaml like below.
           kube-apiserver-arg:
             - "enable-admission-plugins=DenyServiceExternalIPs"
-        scored: true
+        scored: false
 
       - id: 1.2.4
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"

--- a/package/cfg/rke2-cis-1.8-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.8-permissive/master.yaml
@@ -340,24 +340,20 @@ groups:
         scored: true
 
       - id: 1.2.3
-        text: "Ensure that the --DenyServiceExternalIPs is not set (Automated)"
+        text: "Ensure that the --DenyServiceExternalIPs is set (Manual)"
         audit: "/bin/ps -fC $apiserverbin"
         tests:
-          bin_op: or
           test_items:
             - flag: "--enable-admission-plugins"
               compare:
-                op: nothave
+                op: has
                 value: "DenyServiceExternalIPs"
-              set: true
-            - flag: "--enable-admission-plugins"
-              set: false
         remediation: |
           By default, RKE2 does not set DenyServiceExternalIPs.
-          If this check fails, edit the RKE2 config file /etc/rancher/rke2/config.yaml, remove any lines like below.
+          To enable this flag, edit the RKE2 config file /etc/rancher/rke2/config.yaml like below.
           kube-apiserver-arg:
             - "enable-admission-plugins=DenyServiceExternalIPs"
-        scored: true
+        scored: false
 
       - id: 1.2.4
         text: "Ensure that the --kubelet-client-certificate and --kubelet-client-key arguments are set as appropriate (Automated)"


### PR DESCRIPTION
Parent: 
- https://github.com/rancher/rancher/issues/46350

Note:

- The check has been changed to Manual for all distributions, the requirement since 1.7 is to have this flag enabled. The check will be turned to `automated` for RKE2, for CIS-1.9 once the option will be added to `profile: cis` .
- `have` does not exist in kube-bench, must be changed to `has`.
![image](https://github.com/user-attachments/assets/9b292325-b3b1-4e6a-80af-a7ad7e9864b2)
