### PR TITLE
k3s: fix 1.1.11 check for all the profiles

### DIFF
--- a/package/cfg/k3s-cis-1.23-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.23-hardened/master.yaml
@@ -154,13 +154,8 @@ groups:
         scored: false
 
       - id: 1.1.11
-        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: |
-          if [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
-            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
-          else
-            echo "permissions=700"
-          fi
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Manual)"
+        audit: stat -c permissions=%a $etcddatadir
         tests:
           test_items:
             - flag: "permissions"
@@ -168,11 +163,13 @@ groups:
                 op: bitmask
                 value: "700"
         remediation: |
+          Not applicable for the non-etcd cluster. If running master only with no etcd role, this check is not applicable.
+          If controlplane and etcd roles are present on the same nodes but this check is warn then
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.
           Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
-        scored: true
+          chmod 700 $etcddatadir
+        scored: false
 
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"

--- a/package/cfg/k3s-cis-1.23-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.23-permissive/master.yaml
@@ -154,13 +154,8 @@ groups:
         scored: false
 
       - id: 1.1.11
-        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: |
-          if [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
-            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
-          else
-            echo "permissions=700"
-          fi
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Manual)"
+        audit: stat -c permissions=%a $etcddatadir
         tests:
           test_items:
             - flag: "permissions"
@@ -168,11 +163,13 @@ groups:
                 op: bitmask
                 value: "700"
         remediation: |
+          Not applicable for the non-etcd cluster. If running master only with no etcd role, this check is not applicable.
+          If controlplane and etcd roles are present on the same nodes but this check is warn then
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.
           Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
-        scored: true
+          chmod 700 $etcddatadir
+        scored: false
 
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"

--- a/package/cfg/k3s-cis-1.24-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.24-hardened/master.yaml
@@ -148,13 +148,8 @@ groups:
         scored: false
 
       - id: 1.1.11
-        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: |
-          if [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
-            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
-          else
-            echo "permissions=700"
-          fi
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Manual)"
+        audit: stat -c permissions=%a $etcddatadir
         tests:
           test_items:
             - flag: "permissions"
@@ -162,11 +157,13 @@ groups:
                 op: bitmask
                 value: "700"
         remediation: |
+          Not applicable for the non-etcd cluster. If running master only with no etcd role, this check is not applicable.
+          If controlplane and etcd roles are present on the same nodes but this check is warn then
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.
           Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
-        scored: true
+          chmod 700 $etcddatadir
+        scored: false
 
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"

--- a/package/cfg/k3s-cis-1.24-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.24-permissive/master.yaml
@@ -149,13 +149,8 @@ groups:
 
 
       - id: 1.1.11
-        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: |
-          if [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
-            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
-          else
-            echo "permissions=700"
-          fi
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Manual)"
+        audit: stat -c permissions=%a $etcddatadir
         tests:
           test_items:
             - flag: "permissions"
@@ -163,11 +158,13 @@ groups:
                 op: bitmask
                 value: "700"
         remediation: |
+          Not applicable for the non-etcd cluster. If running master only with no etcd role, this check is not applicable.
+          If controlplane and etcd roles are present on the same nodes but this check is warn then
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.
           Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
-        scored: true
+          chmod 700 $etcddatadir
+        scored: false
 
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"

--- a/package/cfg/k3s-cis-1.7-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.7-hardened/master.yaml
@@ -149,13 +149,8 @@ groups:
         scored: true
 
       - id: 1.1.11
-        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: |
-          if [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
-            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
-          else
-            echo "permissions=700"
-          fi
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Manual)"
+        audit: stat -c permissions=%a $etcddatadir
         tests:
           test_items:
             - flag: "permissions"
@@ -163,11 +158,13 @@ groups:
                 op: bitmask
                 value: "700"
         remediation: |
+          Not applicable for the non-etcd cluster. If running master only with no etcd role, this check is not applicable.
+          If controlplane and etcd roles are present on the same nodes but this check is warn then
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.
           Run the below command (based on the etcd data directory found above). For example,
           chmod 700 $etcddatadir
-        scored: true
+        scored: false
 
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"

--- a/package/cfg/k3s-cis-1.7-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.7-permissive/master.yaml
@@ -149,13 +149,8 @@ groups:
         scored: true
 
       - id: 1.1.11
-        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: |
-          if [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
-            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
-          else
-            echo "permissions=700"
-          fi
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Manual)"
+        audit: stat -c permissions=%a $etcddatadir
         tests:
           test_items:
             - flag: "permissions"
@@ -163,11 +158,13 @@ groups:
                 op: bitmask
                 value: "700"
         remediation: |
+          Not applicable for the non-etcd cluster. If running master only with no etcd role, this check is not applicable.
+          If controlplane and etcd roles are present on the same nodes but this check is warn then
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.
           Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
-        scored: true
+          chmod 700 $etcddatadir
+        scored: false
 
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"

--- a/package/cfg/k3s-cis-1.8-hardened/master.yaml
+++ b/package/cfg/k3s-cis-1.8-hardened/master.yaml
@@ -149,13 +149,8 @@ groups:
         scored: true
 
       - id: 1.1.11
-        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: |
-          if [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
-            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
-          else
-            echo "permissions=700"
-          fi
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Manual)"
+        audit: stat -c permissions=%a $etcddatadir
         tests:
           test_items:
             - flag: "permissions"
@@ -163,11 +158,13 @@ groups:
                 op: bitmask
                 value: "700"
         remediation: |
+          Not applicable for the non-etcd cluster. If running master only with no etcd role, this check is not applicable.
+          If controlplane and etcd roles are present on the same nodes but this check is warn then
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.
           Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
-        scored: true
+          chmod 700 $etcddatadir
+        scored: false
 
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"

--- a/package/cfg/k3s-cis-1.8-permissive/master.yaml
+++ b/package/cfg/k3s-cis-1.8-permissive/master.yaml
@@ -149,13 +149,8 @@ groups:
         scored: true
 
       - id: 1.1.11
-        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Automated)"
-        audit: |
-          if [ "$(journalctl -m -u k3s | grep -m1 'Managed etcd cluster' | wc -l)" -gt 0 ]; then
-            stat -c permissions=%a /var/lib/rancher/k3s/server/db/etcd
-          else
-            echo "permissions=700"
-          fi
+        text: "Ensure that the etcd data directory permissions are set to 700 or more restrictive (Manual)"
+        audit: stat -c permissions=%a $etcddatadir
         tests:
           test_items:
             - flag: "permissions"
@@ -163,11 +158,13 @@ groups:
                 op: bitmask
                 value: "700"
         remediation: |
+          Not applicable for the non-etcd cluster. If running master only with no etcd role, this check is not applicable.
+          If controlplane and etcd roles are present on the same nodes but this check is warn then
           On the etcd server node, get the etcd data directory, passed as an argument --data-dir,
           from the command 'ps -ef | grep etcd'.
           Run the below command (based on the etcd data directory found above). For example,
-          chmod 700 /var/lib/etcd
-        scored: true
+          chmod 700 $etcddatadir
+        scored: false
 
       - id: 1.1.12
         text: "Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)"


### PR DESCRIPTION
issues: https://github.com/rancher/cis-operator/issues/350 https://github.com/rancher/rancher/issues/46663
fixed 1.1.11 check for k3s
- updated remediation
- updated audit command (removed echo statement)
- set scored: false and added manual in the check text