### PR TITLE
rke2 fix failed checks for permissive profiles

### DIFF
--- a/package/cfg/rke2-cis-1.24-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.24-permissive/master.yaml
@@ -40,7 +40,7 @@ groups:
         scored: true
 
       - id: 1.1.3
-        text: "Ensure that the controller manager pod specification file permissions are set to 600 or more restrictive (Automated)"
+        text: "Ensure that the controller manager pod specification file permissions are set to 600 or more restrictive (Manual)"
         audit: "/bin/sh -c 'if test -e $controllermanagerconf; then stat -c permissions=%a $controllermanagerconf; fi'"
         tests:
           test_items:
@@ -52,7 +52,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chmod 600 $controllermanagerconf
-        scored: true
+        scored: false
 
       - id: 1.1.4
         text: "Ensure that the controller manager pod specification file ownership is set to root:root (Automated)"
@@ -70,7 +70,7 @@ groups:
         scored: true
 
       - id: 1.1.5
-        text: "Ensure that the scheduler pod specification file permissions are set to 600 or more restrictive (Automated)"
+        text: "Ensure that the scheduler pod specification file permissions are set to 600 or more restrictive (Manual)"
         audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c permissions=%a $schedulerconf; fi'"
         tests:
           test_items:
@@ -82,7 +82,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chmod 600 $schedulerconf
-        scored: true
+        scored: false
 
       - id: 1.1.6
         text: "Ensure that the scheduler pod specification file ownership is set to root:root (Automated)"

--- a/package/cfg/rke2-cis-1.7-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.7-permissive/master.yaml
@@ -9,7 +9,7 @@ groups:
     text: "Control Plane Node Configuration Files"
     checks:
       - id: 1.1.1
-        text: "Ensure that the API server pod specification file permissions are set to 600 or more restrictive (Automated)"
+        text: "Ensure that the API server pod specification file permissions are set to 600 or more restrictive (Manual)"
         audit: "stat -c permissions=%a $apiserverconf"
         tests:
           test_items:
@@ -22,7 +22,7 @@ groups:
           Run the below command (based on the file location on your system) on the
           control plane node.
           For example, chmod 600 $apiserverconf
-        scored: true
+        scored: false
 
       - id: 1.1.2
         text: "Ensure that the API server pod specification file ownership is set to root:root (Automated)"
@@ -40,7 +40,7 @@ groups:
         scored: true
 
       - id: 1.1.3
-        text: "Ensure that the controller manager pod specification file permissions are set to 600 or more restrictive (Automated)"
+        text: "Ensure that the controller manager pod specification file permissions are set to 600 or more restrictive (Manual)"
         audit: "/bin/sh -c 'if test -e $controllermanagerconf; then stat -c permissions=%a $controllermanagerconf; fi'"
         tests:
           test_items:
@@ -52,7 +52,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chmod 600 $controllermanagerconf
-        scored: true
+        scored: false
 
       - id: 1.1.4
         text: "Ensure that the controller manager pod specification file ownership is set to root:root (Automated)"
@@ -70,7 +70,7 @@ groups:
         scored: true
 
       - id: 1.1.5
-        text: "Ensure that the scheduler pod specification file permissions are set to 600 or more restrictive (Automated)"
+        text: "Ensure that the scheduler pod specification file permissions are set to 600 or more restrictive (Manual)"
         audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c permissions=%a $schedulerconf; fi'"
         tests:
           test_items:
@@ -82,7 +82,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chmod 600 $schedulerconf
-        scored: true
+        scored: false
 
       - id: 1.1.6
         text: "Ensure that the scheduler pod specification file ownership is set to root:root (Automated)"


### PR DESCRIPTION
issue: https://github.com/rancher/rancher/issues/46812 and https://github.com/rancher/cis-operator/issues/350
1.1.1, 1.1.3 and 1.1.5 checks were marked as scored: false for 1.8 permissive profile in PR: https://github.com/rancher/security-scan/pull/231
Updated these checks for the other rke2 permissive profiles based on that. 
- updated all the checks in rke2-cis-1.7-permissive profile as they were same as rke2-cis-1.8-permissive profile
- updated 1.1.3 and 1.1.5 (required permission 600) only in rke2-cis-1.24-permissive profile since for 1.1.1 the requirement is of permissions 644
- did not update  rke2-cis-1.23-permissive profile since required permission for all the checks are 644.