### PR TITLE
Correct pod-manifest permissions, all manual for rke2-cis-1.24

### DIFF
--- a/package/cfg/rke2-cis-1.24-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.24-hardened/master.yaml
@@ -9,20 +9,20 @@ groups:
     text: "Control Plane Node Configuration Files"
     checks:
       - id: 1.1.1
-        text: "Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Automated)"
+        text: "Ensure that the API server pod specification file permissions are set to 600 or more restrictive (Manual)"
         audit: "stat -c permissions=%a $apiserverconf"
         tests:
           test_items:
             - flag: "permissions"
               compare:
                 op: bitmask
-                value: "644"
+                value: "600"
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the
           control plane node.
-          For example, chmod 644 $apiserverconf
-        scored: true
+          For example, chmod 600 $apiserverconf
+        scored: false
 
       - id: 1.1.2
         text: "Ensure that the API server pod specification file ownership is set to root:root (Automated)"
@@ -40,7 +40,7 @@ groups:
         scored: true
 
       - id: 1.1.3
-        text: "Ensure that the controller manager pod specification file permissions are set to 600 or more restrictive (Automated)"
+        text: "Ensure that the controller manager pod specification file permissions are set to 600 or more restrictive (Manual)"
         audit: "/bin/sh -c 'if test -e $controllermanagerconf; then stat -c permissions=%a $controllermanagerconf; fi'"
         tests:
           test_items:
@@ -52,7 +52,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chmod 600 $controllermanagerconf
-        scored: true
+        scored: false
 
       - id: 1.1.4
         text: "Ensure that the controller manager pod specification file ownership is set to root:root (Automated)"
@@ -70,7 +70,7 @@ groups:
         scored: true
 
       - id: 1.1.5
-        text: "Ensure that the scheduler pod specification file permissions are set to 600 or more restrictive (Automated)"
+        text: "Ensure that the scheduler pod specification file permissions are set to 600 or more restrictive (Manual)"
         audit: "/bin/sh -c 'if test -e $schedulerconf; then stat -c permissions=%a $schedulerconf; fi'"
         tests:
           test_items:
@@ -82,7 +82,7 @@ groups:
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
           For example, chmod 600 $schedulerconf
-        scored: true
+        scored: false
 
       - id: 1.1.6
         text: "Ensure that the scheduler pod specification file ownership is set to root:root (Automated)"

--- a/package/cfg/rke2-cis-1.24-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.24-hardened/master.yaml
@@ -223,7 +223,7 @@ groups:
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root /etc/kubernetes/admin.conf
+          For example, chown root:root /var/lib/rancher/rke2/server/cred/admin.kubeconfig
         scored: true
 
       - id: 1.1.15

--- a/package/cfg/rke2-cis-1.24-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.24-permissive/master.yaml
@@ -9,20 +9,20 @@ groups:
     text: "Control Plane Node Configuration Files"
     checks:
       - id: 1.1.1
-        text: "Ensure that the API server pod specification file permissions are set to 644 or more restrictive (Automated)"
+        text: "Ensure that the API server pod specification file permissions are set to 600 or more restrictive (Manual)"
         audit: "stat -c permissions=%a $apiserverconf"
         tests:
           test_items:
             - flag: "permissions"
               compare:
                 op: eq
-                value: "644"
+                value: "600"
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the
           control plane node.
           For example, chmod 644 $apiserverconf
-        scored: true
+        scored: false
 
       - id: 1.1.2
         text: "Ensure that the API server pod specification file ownership is set to root:root (Automated)"

--- a/package/cfg/rke2-cis-1.24-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.24-permissive/master.yaml
@@ -222,7 +222,7 @@ groups:
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root /etc/kubernetes/admin.conf
+          For example, chown root:root /var/lib/rancher/rke2/server/cred/admin.kubeconfig
         scored: true
 
       - id: 1.1.15

--- a/package/cfg/rke2-cis-1.7-hardened/master.yaml
+++ b/package/cfg/rke2-cis-1.7-hardened/master.yaml
@@ -225,7 +225,7 @@ groups:
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root /etc/kubernetes/admin.conf
+          For example, chown root:root /var/lib/rancher/rke2/server/cred/admin.kubeconfig
         scored: true
 
       - id: 1.1.15

--- a/package/cfg/rke2-cis-1.7-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.7-permissive/master.yaml
@@ -226,7 +226,7 @@ groups:
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root /etc/kubernetes/admin.conf
+          For example, chown root:root /var/lib/rancher/rke2/server/cred/admin.kubeconfig
         scored: true
 
       - id: 1.1.15

--- a/package/cfg/rke2-cis-1.8-permissive/master.yaml
+++ b/package/cfg/rke2-cis-1.8-permissive/master.yaml
@@ -226,7 +226,7 @@ groups:
               set: true
         remediation: |
           Run the below command (based on the file location on your system) on the control plane node.
-          For example, chown root:root /etc/kubernetes/admin.conf
+          For example, chown root:root /var/lib/rancher/rke2/server/cred/admin.kubeconfig
         scored: true
 
       - id: 1.1.15


### PR DESCRIPTION
For RKE2 v1.24 and the cis-1.24 scans:
- 1.1.1 Fix permissions to 600
- 1.1.14 Fix file name in remediation
- Set all pod-manifest permissions checks to manual, as RKE2 v1.24 always sets pod-manifests to 644 (this was fixed in rke2 v1.25)