### PR TITLE
added gke-1.6.0

### DIFF
--- a/hack/e2e
+++ b/hack/e2e
@@ -60,7 +60,7 @@ function check_binaries(){
 
 function check_config_files(){
   echo "> Check for upstream test files:"
-  dirs="ack-1.0 aks-1.0 cis-1.23 cis-1.24 cis-1.7 cis-1.8 config.yaml eks-1.0.1 eks-1.1.0 eks-1.2.0 eks-stig-kubernetes-v1r6 gke-1.0 gke-1.2.0 rh-0.7 rh-1.0"
+  dirs="ack-1.0 aks-1.0 cis-1.23 cis-1.24 cis-1.7 cis-1.8 config.yaml eks-1.0.1 eks-1.1.0 eks-1.2.0 eks-stig-kubernetes-v1r6 gke-1.0 gke-1.2.0 gke-1.6.0 rh-0.7 rh-1.0"
 
   for d in ${dirs}; do
     if ! kubectl exec -n cis-operator-system security-scan-runner-scan-test -c rancher-cis-benchmark -- stat "/etc/kube-bench/cfg/$d"; then

--- a/package/cfg/config.yaml
+++ b/package/cfg/config.yaml
@@ -234,6 +234,8 @@ version_mapping:
     - "eks-1.2.0"
   "gke-1.2.0":
     - "gke-1.2.0"
+  "gke-1.6.0":
+    - "gke-1.6.0"
   "aks-1.0":
     - "aks-1.0"
   "v1.20.5+rke2r1":
@@ -249,6 +251,8 @@ target_mapping:
     - "node"
   # GKE
   "gke-1.2.0":
+    - "node"
+  "gke-1.6.0":
     - "node"
   # AKS
   "aks-1.0":


### PR DESCRIPTION
issue: https://github.com/rancher/rancher/issues/47551
- added gke-1.6.0
- PRs for kube bench bump needs to be merged for this as well. https://github.com/rancher/security-scan/pull/253 and https://github.com/rancher/security-scan/pull/252
**Note: gke 1.2.0 is not removed since gke 1.6.0 is only for versions >=1.29 and other gke profiles are not available in upstream kube-bench and the minimum supported k8s version in rancher v2.8 is 1.25**