### PR TITLE
Change 5.1.5 check from Automated to Manual in k3s-cis-1.9

### DIFF
--- a/package/cfg/k3s-cis-1.9/policies.yaml
+++ b/package/cfg/k3s-cis-1.9/policies.yaml
@@ -105,7 +105,7 @@ groups:
         scored: true
 
       - id: 5.1.5
-        text: "Ensure that default service accounts are not actively used. (Automated)"
+        text: "Ensure that default service accounts are not actively used (Manual)"
         audit: |
           kubectl get serviceaccounts --all-namespaces --field-selector metadata.name=default \
           -o custom-columns=N:.metadata.namespace,SA:.metadata.name,ASA:.automountServiceAccountToken --no-headers \
@@ -135,7 +135,7 @@ groups:
           automountServiceAccountToken: false
           Or using kubectl:
           kubectl patch serviceaccount --namespace <NAMESPACE> default --patch '{"automountServiceAccountToken": false}'
-        scored: true
+        scored: false
 
       - id: 5.1.6
         text: "Ensure that Service Account Tokens are only mounted where necessary (Automated)"


### PR DESCRIPTION
By default (and apart from kube-system whitelisting) K3s doesn't enforce `automoutServiceAccountToken` to `false` for the following default svcs:

  	 **namespace: default              service_account: default    automountServiceAccountToken: notset is_compliant: false
	 **namespace: kube-node-lease      service_account: default    automountServiceAccountToken: notset is_compliant: false
	 **namespace: kube-public          service_account: default    automountServiceAccountToken: notset is_compliant: false
	 **namespace: kube-system          service_account: default    automountServiceAccountToken: notset is_compliant: true

To pass the check, the admin needs to manualy modify them (see check remediation). This is why the check should be changed to Manual until we either whitelist the namespaces or directly set automountServiceAccountToken to false in K3s for each namespace that comes out of the box.