### PR TITLE
[main] set type manual for 5.1.2 and 5.1.4 checks for rke2 cis 1.9

### DIFF
--- a/package/cfg/rke2-cis-1.9/policies.yaml
+++ b/package/cfg/rke2-cis-1.9/policies.yaml
@@ -32,6 +32,7 @@ groups:
 
       - id: 5.1.2
         text: "Minimize access to secrets (Automated)"
+        type: manual
         audit: "echo \"canGetListWatchSecretsAsSystemAuthenticated: $(kubectl auth can-i get,list,watch secrets --all-namespaces --as=system:authenticated)\""
         tests:
           test_items:
@@ -90,6 +91,7 @@ groups:
         scored: true
 
       - id: 5.1.4
+        type: manual
         text: "Minimize access to create pods (Automated)"
         audit: |
           echo "canCreatePodsAsSystemAuthenticated: $(kubectl auth can-i create pods --all-namespaces --as=system:authenticated)"


### PR DESCRIPTION
because of the upstream kubectl issue:
https://github.com/kubernetes/kubernetes/issues/93474 (duplicate: https://github.com/kubernetes/kubernetes/issues/104532)
these checks can not be automated so changed them to manual.