### PR TITLE
Fix 5.1.5 check for rke2 and k3s cis 1.9

### DIFF
--- a/package/cfg/k3s-cis-1.9/policies.yaml
+++ b/package/cfg/k3s-cis-1.9/policies.yaml
@@ -107,7 +107,7 @@ groups:
         scored: true
 
       - id: 5.1.5
-        text: "Ensure that default service accounts are not actively used (Manual)"
+        text: "Ensure that default service accounts are not actively used. (Automated)"
         audit: |
           kubectl get serviceaccounts --all-namespaces --field-selector metadata.name=default \
           -o custom-columns=N:.metadata.namespace,SA:.metadata.name,ASA:.automountServiceAccountToken --no-headers \
@@ -137,7 +137,7 @@ groups:
           automountServiceAccountToken: false
           Or using kubectl:
           kubectl patch serviceaccount --namespace <NAMESPACE> default --patch '{"automountServiceAccountToken": false}'
-        scored: false
+        scored: true
 
       - id: 5.1.6
         text: "Ensure that Service Account Tokens are only mounted where necessary (Automated)"

--- a/package/cfg/rke2-cis-1.9/policies.yaml
+++ b/package/cfg/rke2-cis-1.9/policies.yaml
@@ -106,7 +106,7 @@ groups:
         scored: true
 
       - id: 5.1.5
-        text: "Ensure that default service accounts are not actively used. (Manual)"
+        text: "Ensure that default service accounts are not actively used. (Automated)"
         audit: |
           kubectl get serviceaccounts --all-namespaces --field-selector metadata.name=default \
           -o custom-columns=N:.metadata.namespace,SA:.metadata.name,ASA:.automountServiceAccountToken --no-headers \
@@ -135,7 +135,7 @@ groups:
           automountServiceAccountToken: false
           Or using kubectl:
           kubectl patch serviceaccount --namespace <NAMESPACE> default --patch '{"automountServiceAccountToken": false}'
-        scored: false
+        scored: true
 
       - id: 5.1.6
         text: "Ensure that Service Account Tokens are only mounted where necessary (Automated)"


### PR DESCRIPTION
reverts commit: https://github.com/rancher/security-scan/commit/0a9114fd15a2ba2212a89ccf08ea4203072dc714
and fixed the check by adding type: manual instead