### PR TITLE
[release/v0.4] added eks 1.5.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.27.3, v1.28.0, v1.29.0]
+        k8s-version: [v1.27.3, v1.28.0, v1.29.0, v1.30.0]
         platform: [ubuntu-latest]
     
     runs-on: ${{ matrix.platform }}

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,9 @@
 module github.com/rancher/security-scan
 
-go 1.23.5
-
-toolchain go1.23.6
+go 1.23.6
 
 require (
-	github.com/aquasecurity/kube-bench v0.10.1
+	github.com/aquasecurity/kube-bench v0.10.2
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/aquasecurity/kube-bench v0.10.1 h1:SLnScd5qnlSOETodhX4iyW4beu0Ue4au1MqJ3fUDnw0=
-github.com/aquasecurity/kube-bench v0.10.1/go.mod h1:9S67UPnASLor5+11UeikBoiG//tel5BDsei0Bo8g2Pw=
+github.com/aquasecurity/kube-bench v0.10.2 h1:wVU6K/g3LJD/BAlDrphLYxs9f5PNRcon+ozZ6S/fMVU=
+github.com/aquasecurity/kube-bench v0.10.2/go.mod h1:TYImH07Qr2XA09VCBUiQDs6vilbTyourr0B+qq/AtN8=
 github.com/aws/aws-sdk-go-v2 v1.36.0 h1:b1wM5CcE65Ujwn565qcwgtOTT1aT4ADOHHgglKjG7fk=
 github.com/aws/aws-sdk-go-v2 v1.36.0/go.mod h1:5PMILGVKiW32oDzjj6RU52yrNrDPUHcbZQYr1sM7qmM=
 github.com/aws/aws-sdk-go-v2/service/securityhub v1.55.8 h1:+0McIKnas9knQ+22C0fS5j1j4J4wlCvnjMPzvdgVrvQ=

--- a/hack/e2e
+++ b/hack/e2e
@@ -60,7 +60,7 @@ function check_binaries(){
 
 function check_config_files(){
   echo "> Check for upstream test files:"
-  dirs="ack-1.0 aks-1.0 cis-1.23 cis-1.24 cis-1.7 cis-1.8 cis-1.9 config.yaml eks-1.0.1 eks-1.1.0 eks-1.2.0 eks-stig-kubernetes-v1r6 gke-1.0 gke-1.2.0 gke-1.6.0 rh-0.7 rh-1.0"
+  dirs="ack-1.0 aks-1.0 cis-1.23 cis-1.24 cis-1.7 cis-1.8 cis-1.9 config.yaml eks-1.0.1 eks-1.1.0 eks-1.2.0 eks-1.5.0 eks-stig-kubernetes-v1r6 gke-1.0 gke-1.2.0 gke-1.6.0 rh-0.7 rh-1.0"
 
   for d in ${dirs}; do
     if ! kubectl exec -n cis-operator-system security-scan-runner-scan-test -c rancher-cis-benchmark -- stat "/etc/kube-bench/cfg/$d"; then

--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -18,7 +18,7 @@ SONOBUOY_SUM_arm64 ?= 958edd774ff6a23f8eaefc2ea2c361b05caa8d7980ab8443e552e7f7bf
 # renovate: datasource=github-release-attachments depName=vmware-tanzu/sonobuoy digestVersion=v0.57.3
 SONOBUOY_SUM_amd64 ?= 6728e04f62068465c56e2d317f4a5392520bf00c836aeaba970ae913f943718c
 
-KUBECTL_VERSION ?= 1.29.10
+KUBECTL_VERSION ?= 1.29.14
 KUBECTL_SUM_arm64 ?= $(shell curl -L "https://dl.k8s.io/release/v$(KUBECTL_VERSION)/bin/linux/arm64/kubectl.sha256")
 KUBECTL_SUM_amd64 ?= $(shell curl -L "https://dl.k8s.io/release/v$(KUBECTL_VERSION)/bin/linux/amd64/kubectl.sha256")
 

--- a/package/cfg/config.yaml
+++ b/package/cfg/config.yaml
@@ -220,6 +220,8 @@ version_mapping:
   "1.29": "cis-1.9"
   "eks-1.2.0":
     - "eks-1.2.0"
+  "eks-1.5.0":
+    - "eks-1.5.0"
   "gke-1.2.0":
     - "gke-1.2.0"
   "gke-1.6.0":
@@ -234,6 +236,8 @@ version_mapping:
 target_mapping:
   # EKS
   "eks-1.2.0":
+    - "node"
+  "eks-1.5.0":
     - "node"
   # GKE
   "gke-1.2.0":


### PR DESCRIPTION
issue: https://github.com/rancher/rancher/issues/49009
- added eks 1.5.0 
- bump kube bench go mod dep, kubectl and added v1.30.0 in e2e tests