### PR TITLE
[main] added eks 1.2.0 back

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        k8s-version: [v1.29.0, v1.30.0, v1.31.0, v1.32.0]
+        k8s-version: [v1.30.0, v1.31.0, v1.32.0]
         platform: [ubuntu-latest]
     
     runs-on: ${{ matrix.platform }}

--- a/hack/e2e
+++ b/hack/e2e
@@ -60,7 +60,7 @@ function check_binaries(){
 
 function check_config_files(){
   echo "> Check for upstream test files:"
-  dirs="ack-1.0 aks-1.0 cis-1.23 cis-1.24 cis-1.7 cis-1.8 cis-1.9 config.yaml eks-1.0.1 eks-1.1.0 eks-1.5.0 eks-stig-kubernetes-v1r6 gke-1.0 gke-1.2.0 gke-1.6.0 rh-0.7 rh-1.0"
+  dirs="ack-1.0 aks-1.0 cis-1.23 cis-1.24 cis-1.7 cis-1.8 cis-1.9 config.yaml eks-1.0.1 eks-1.1.0 eks-1.2.0 eks-1.5.0 eks-stig-kubernetes-v1r6 gke-1.0 gke-1.2.0 gke-1.6.0 rh-0.7 rh-1.0"
 
   for d in ${dirs}; do
     if ! kubectl exec -n cis-operator-system security-scan-runner-scan-test -c rancher-cis-benchmark -- stat "/etc/kube-bench/cfg/$d"; then

--- a/package/cfg/config.yaml
+++ b/package/cfg/config.yaml
@@ -218,6 +218,8 @@ version_mapping:
   "1.27": "cis-1.9"
   "1.28": "cis-1.9"
   "1.29": "cis-1.9"
+  "eks-1.2.0":
+    - "eks-1.2.0"
   "eks-1.5.0":
     - "eks-1.5.0"
   "gke-1.2.0":
@@ -234,6 +236,8 @@ version_mapping:
 # Target mapping: Defines which components (eg. master, node, etcd) should be evaluated for a given CIS profile.
 target_mapping:
   # EKS
+  "eks-1.2.0":
+    - "node"
   "eks-1.5.0":
     - "node"
   # GKE


### PR DESCRIPTION
https://github.com/rancher/rancher/issues/49007
- added back eks 1.2.0, will be removed for 2.12 rancher release.
- removed e2e testing for 1.29 since it will also be not supported in rancher v2.11