### PR TITLE
[backport][release/v0.4] use new kubelet config file

### DIFF
--- a/package/cfg/k3s-cis-1.9/config.yaml
+++ b/package/cfg/k3s-cis-1.9/config.yaml
@@ -42,7 +42,7 @@ node:
     bins:
       - containerd
     confs:
-      - /var/lib/rancher/k3s/agent/kubelet.kubeconfig
+      - /var/lib/rancher/k3s/agent/etc/kubelet.conf.d/00-k3s-defaults.conf
     defaultkubeconfig: /var/lib/rancher/k3s/agent/kubelet.kubeconfig
     defaultcafile: /var/lib/rancher/k3s/agent/client-ca.crt
   proxy:

--- a/package/cfg/k3s-cis-1.9/node.yaml
+++ b/package/cfg/k3s-cis-1.9/node.yaml
@@ -322,6 +322,7 @@ groups:
       - id: 4.2.9
         text: "Ensure that the --tls-cert-file and --tls-private-key-file arguments are set as appropriate (Automated)"
         audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:
             - flag: --tls-cert-file

--- a/package/cfg/rke2-cis-1.9/config.yaml
+++ b/package/cfg/rke2-cis-1.9/config.yaml
@@ -51,6 +51,8 @@ node:
     - kubelet
     - proxy
   kubelet:
+    confs:
+      - /var/lib/rancher/rke2/agent/etc/kubelet.conf.d/00-rke2-defaults.conf
     defaultkubeconfig: /var/lib/rancher/rke2/agent/kubelet.kubeconfig
     defaultcafile: /var/lib/rancher/rke2/agent/client-ca.crt
   proxy:


### PR DESCRIPTION
backport PR of: https://github.com/rancher/security-scan/pull/432