### PR TITLE
Change renovate schedule and settings

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,5 +9,21 @@
     "release/v0.5",
     "release/v0.6"
   ],
-  "prHourlyLimit": 2
+  "prHourlyLimit": 4,
+  "packageRules": [
+    {
+      "description": "Disable non-security bumps for backporting branches",
+      "enabled": false,
+      "matchBaseBranches": [
+        "release/v0.3",
+        "release/v0.4",
+        "release/v0.5",
+        "release/v0.6"
+      ]
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "osvVulnerabilityAlerts": true
 }

--- a/.github/workflows/renovate-vault.yml
+++ b/.github/workflows/renovate-vault.yml
@@ -12,9 +12,9 @@ on:
         required: false
         default: "false"
         type: string
-  # Run twice in the early morning (UTC) for initial and follow up steps (create pull request and merge)
   schedule:
-    - cron: '30 4,6 * * *'
+    # Runs twice on Tuesdays to Thursdays.
+    - cron: '30 4,6 * * 2-4'
 
 permissions:
   contents: read


### PR DESCRIPTION
Backporting branches will only receive security fixes. The new schedule is limited to twice between tuesdays and thursdays.