### PR TITLE
Migrate golangci-lint to v2

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,13 +1,15 @@
+version: "2"
 linters:
-  disable-all: true
+  default: none
   enable:
-     - asasalint
-     - asciicheck
-     - bidichk
-     - errcheck
-     - gofmt
-     - gosimple
-     - gosec
-     - govet
-     - misspell
-     - unused  
+    - asasalint
+    - asciicheck
+    - bidichk
+    - errcheck
+    - gosec
+    - govet
+    - misspell
+    - unused
+formatters:
+  enable:
+    - gofmt

--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -3,7 +3,7 @@ KIND_VERSION ?= 0.27.0
 KUBERNETES_VERSION ?= v$(KUBECTL_VERSION)
 
 # renovate: datasource=github-release-attachments depName=golangci/golangci-lint
-GOLANGCI_VERSION = v1.64.8
+GOLANGCI_VERSION = v2.0.2
 
 # renovate: datasource=github-release-attachments depName=aquasecurity/kube-bench
 KUBE_BENCH_VERSION ?= v0.10.4

--- a/pkg/kb-summarizer/summarizer/summarizer.go
+++ b/pkg/kb-summarizer/summarizer/summarizer.go
@@ -360,7 +360,7 @@ func (s *Summarizer) summarizeForHost(hostname string) error {
 
 func (s *Summarizer) save() error {
 	if _, err := os.Stat(s.OutputDirectory); os.IsNotExist(err) {
-		if err2 := os.Mkdir(s.OutputDirectory, 0755); err2 != nil {
+		if err2 := os.Mkdir(s.OutputDirectory, 0750); err2 != nil {
 			return fmt.Errorf("error creating output directory: %v", err)
 		}
 	}

--- a/pkg/kb-summarizer/summarizer/summarizer.go
+++ b/pkg/kb-summarizer/summarizer/summarizer.go
@@ -217,6 +217,7 @@ func GetUserSkipInfo(benchmark, skipConfigFile string) (map[string]bool, error) 
 	if skipConfigFile == "" {
 		return skipMap, nil
 	}
+	skipConfigFile = filepath.Clean(skipConfigFile)
 	data, err := os.ReadFile(skipConfigFile)
 	if err != nil {
 		return skipMap, fmt.Errorf("error reading file %v: %v", skipConfigFile, err)
@@ -244,6 +245,7 @@ func GetChecksMapFromConfigFile(configFile string) (map[string]string, error) {
 	if configFile == "" {
 		return checksMap, nil
 	}
+	configFile = filepath.Clean(configFile)
 	logrus.Infof("loading checks from config file: %v", configFile)
 	data, err := os.ReadFile(configFile)
 	if err != nil {
@@ -365,6 +367,7 @@ func (s *Summarizer) save() error {
 		}
 	}
 	outputFilePath := fmt.Sprintf("%s/%s", s.OutputDirectory, s.OutputFilename)
+	outputFilePath = filepath.Clean(outputFilePath)
 	jsonFile, err := os.Create(outputFilePath)
 	if err != nil {
 		return fmt.Errorf("error creating file %v: %v", outputFilePath, err)
@@ -427,6 +430,7 @@ func (s *Summarizer) loadTargetMapping() error {
 
 func (s *Summarizer) loadControlsFromFile(filePath string) (*kb.Controls, error) {
 	controls := &kb.Controls{}
+	filePath = filepath.Clean(filePath)
 	fileContents, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, fmt.Errorf("error reading file %+v: %v", filePath, err)
@@ -724,6 +728,7 @@ func (s *Summarizer) Summarize() error {
 
 		// Check for errors before proceeding
 		errorLogFile := fmt.Sprintf("%s/%s/%s", s.InputDirectory, hostname, DefaultErrorLogFileName)
+		errorLogFile = filepath.Clean(errorLogFile)
 		if _, err := os.Stat(errorLogFile); err == nil {
 			data, err := os.ReadFile(errorLogFile)
 			if err != nil {

--- a/pkg/kb-summarizer/summarizer/summarizer_test.go
+++ b/pkg/kb-summarizer/summarizer/summarizer_test.go
@@ -57,7 +57,11 @@ func TestSummarizer_handleAvMapData(t *testing.T) {
 
 	r, err := gzip.NewReader(bytes.NewBuffer(compressedAvMapData))
 	require.Nil(t, err, "error while reading compressed avMapData")
-	defer r.Close()
+	defer func() {
+		if err := r.Close(); err != nil {
+			t.Errorf("failed to close gzip reader: %v", err)
+		}
+	}()
 
 	avgroupsJSON, err := io.ReadAll(r)
 	require.Nil(t, err, "error while reading avMapData json")


### PR DESCRIPTION
Related renovate PR:
- https://github.com/rancher/security-scan/pull/449

#### Description:

The golanci-lint v1 is getting deprecated and golangci-lint advises to go to v2. Thus, we need to update the configuration format.
As of v2, we can use `golangci-lint migrate` to migrate the `.golangci.yaml` configuration from `v1` to `v2`.

**Related error:**
```
Error: can't load config: unsupported version of the configuration: "" See https://golangci-lint.run/product/migration-guide for migration instructions
Failed executing command with error: can't load config: unsupported version of the configuration: "" See https://golangci-lint.run/product/migration-guide for migration instructions
make: *** [validate-go] Error 3
```

#### Major changes:
- `gosimple` has been removed in v2
- `gofmt` becomes a formatter
- `disable-all: true` replaced with `default: none`
- `gosec` and other linters embed more rules