### PR TITLE
feat: Add cis-1.11 generic and update configmap

### DIFF
--- a/hack/e2e
+++ b/hack/e2e
@@ -60,7 +60,7 @@ function check_binaries(){
 
 function check_config_files(){
   echo "> Check for upstream test files:"
-  dirs="ack-1.0 aks-1.0 cis-1.23 cis-1.24 cis-1.7 cis-1.8 cis-1.9 cis-1.10 config.yaml eks-1.0.1 eks-1.1.0 eks-1.2.0 eks-1.5.0 eks-stig-kubernetes-v1r6 gke-1.0 gke-1.2.0 gke-1.6.0 rh-0.7 rh-1.0"
+  dirs="ack-1.0 aks-1.0 cis-1.23 cis-1.24 cis-1.7 cis-1.8 cis-1.9 cis-1.10 cis-1.11 config.yaml eks-1.0.1 eks-1.1.0 eks-1.2.0 eks-1.5.0 eks-stig-kubernetes-v1r6 gke-1.0 gke-1.2.0 gke-1.6.0 rh-0.7 rh-1.0"
 
   for d in ${dirs}; do
     if ! kubectl exec -n rancher-compliance-system security-scan-runner-scan-test -c rancher-compliance -- stat "/etc/kube-bench/cfg/$d"; then

--- a/package/cfg/config.yaml
+++ b/package/cfg/config.yaml
@@ -217,9 +217,10 @@ version_mapping:
   "1.26": "cis-1.8"
   "1.27": "cis-1.9"
   "1.28": "cis-1.10"
-  "1.29": "cis-1.10"
-  "1.30": "cis-1.10"
-  "1.31": "cis-1.10"
+  "1.29": "cis-1.11"
+  "1.30": "cis-1.11"
+  "1.31": "cis-1.11"
+  "1.32": "cis-1.11"
   "eks-1.2.0":
     - "eks-1.2.0"
   "eks-1.5.0":
@@ -290,6 +291,12 @@ target_mapping:
     - "etcd"
     - "policies"
   "cis-1.10":
+    - "master"
+    - "node"
+    - "controlplane"
+    - "etcd"
+    - "policies"
+  "cis-1.11":
     - "master"
     - "node"
     - "controlplane"


### PR DESCRIPTION
### Description:

`CIS-1.11` covers k8s `1.29` to `1.32`


- Add [cis-1.11](https://github.com/aquasecurity/kube-bench/tree/main/cfg/cis-1.11) generic profile
- Add `cis-1.11` generic `version_mappings` to `configmap`

> [!NOTE] 
> 
> CIS-1.11 version will be released upstream through `v0.13`, we likely should bump `kube-bench` to this version before this PR gets merged.