### PR TITLE
[v0.7] fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,7 @@ jobs:
           prime-username: ${{ env.PRIME_REGISTRY_USERNAME }}
           prime-password: ${{ env.PRIME_REGISTRY_PASSWORD }}
       - name: Create release
+        if: matrix.tag-suffix == ''
         run: |
           gh release create ${{ github.ref_name }} --verify-tag --title "${{ github.ref_name }}" --generate-notes
         env:


### PR DESCRIPTION
The Create release step was being executed for each matrix entry (multi-arch, amd64, and arm64), causing multiple attempts to create the same GitHub release and resulting in job failures.

This change updates the workflow to run the release creation step only once, specifically for the multi-arch (matrix.tag-suffix == '') build. This ensures the release is created successfully after the primary image manifest is published, while architecture-specific builds continue to run as before.