### PR TITLE
[k3s][node][4.2.4] fix audit for --read-only-port discovery

### DIFF
--- a/package/cfg/k3s-cis-1.10/node.yaml
+++ b/package/cfg/k3s-cis-1.10/node.yaml
@@ -209,7 +209,8 @@ groups:
 
       - id: 4.2.4
         text: "Verify that the --read-only-port argument is set to 0 (Automated)"
-        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: |
+          journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep -o -- "--read-only-port=0"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           bin_op: or

--- a/package/cfg/k3s-cis-1.11/node.yaml
+++ b/package/cfg/k3s-cis-1.11/node.yaml
@@ -209,7 +209,8 @@ groups:
 
       - id: 4.2.4
         text: "Verify that if defined, the --read-only-port argument is set to 0 (Automated)"
-        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: |
+          journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep -o -- "--read-only-port=0"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.9/node.yaml
+++ b/package/cfg/k3s-cis-1.9/node.yaml
@@ -209,7 +209,8 @@ groups:
 
       - id: 4.2.4
         text: "Verify that the --read-only-port argument is set to 0 (Automated)"
-        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: |
+          journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep -o -- "--read-only-port=0"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           bin_op: or


### PR DESCRIPTION
### Description:
**Check: 4.2.4 Verify that if defined, the --read-only-port argument is set to 0 (Automated)**

The former audit returned too much data, which was subsequently truncated by kube-bench, causing the check to fail consistently. This fix improves the audit for `--read-only-port` discovery by limiting the returned data, piping the initial command to grep with `-o, --only-matching`.

**Parent issue:**
- https://github.com/rancher/compliance-operator/issues/123

**Fixed versions:**
- `k3s-cis-1.11`
- `k3s-cis-1.10`
- `k3s-cis-1.9`

**Expected behaviour:** By default, K3s sets the --read-only-port to 0 (which disables the read only kubelet API traditionally served on port 10255, preventing unauthenticated access to potentially sensitive cluster information).

#### Tests before the fix (FAIL):

```
[root@lima-centos-stream-9 rancher-security-scan-debug-EkeuY]# ./kube-bench run --targets node --config-dir ./security-scan-0.6.5/package/cfg/ --config ./security-scan-0.6.5/package/cfg/config.yaml --benchmark k3s-cis-1.11 --check 4.2.4 --include-test-output
[INFO] 4 Worker Node Security Configuration
[INFO] 4.2 Kubelet
[FAIL] 4.2.4 Verify that if defined, the --read-only-port argument is set to 0 (Automated)
	 Nov 27 10:32:53 lima-centos-stream-9 k3s[22952]: time="2025-11-27T10:32:53+01:00" level=info msg="Running kubelet --cloud-provider=external --config-dir=/var/lib/rancher/k3s/agent/etc/kubelet.conf.d --containerd=/run/k3s/containerd/containerd.sock --hostname-override=lima-centos-stream-9 --kubeconfig=/var/lib/rancher/k3s/agent/kubelet.kubeconfig --node-ip=192.168.105.2,fd71:488c:7b4f:91c6:5055:55ff:fe30:789f --node-labels= --read-only-port=0"

== Remediations node ==
4.2.4 By default, K3s sets the --read-only-port to 0 (which disables the read only kubelet API traditionally served on port 10255, preventing unauthenticated access to potentially sensitive cluster information).
If you have changed this value, revert it.
Config File (/etc/rancher/k3s/config.yaml): Remove lines similar to:
 kubelet-arg:
   - "read-only-port=XXXX"
Command Line Argument: Remove the argument from the K3s service file:
   --kubelet-arg="read-only-port=XXXX"
Restart the K3s service after making the modification:
 systemctl daemon-reload
 systemctl restart k3s.service


== Summary node ==
0 checks PASS
1 checks FAIL
0 checks WARN
0 checks INFO
```

#### Test after the fix (PASS):

```
I1127 11:31:06.834077   32224 check.go:110] -----   Running check 4.2.4   -----
I1127 11:31:06.845982   32224 check.go:309] Command: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep -o -- \"--read-only-port=0\""
I1127 11:31:06.846076   32224 check.go:310] Output:
 "--read-only-port=0\n"
I1127 11:31:06.849800   32224 check.go:309] Command: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/agent/etc/kubelet.conf.d/00-k3s-defaults.conf; then /bin/cat /var/lib/rancher/k3s/agent/etc/kubelet.conf.d/00-k3s-defaults.conf; fi'"
I1127 11:31:06.849835   32224 check.go:310] Output:
 "address: 0.0.0.0\nallowedUnsafeSysctls:\n- net.ipv4.ip_forward\n- net.ipv6.conf.all.forwarding\napiVersion: kubelet.config.k8s.io/v1beta1\nauthentication:\n  anonymous:\n    enabled: false\n  webhook:\n    cacheTTL: 2m0s\n    enabled: true\n  x509:\n    clientCAFile: /var/lib/rancher/k3s/agent/client-ca.crt\nauthorization:\n  mode: Webhook\n  webhook:\n    cacheAuthorizedTTL: 5m0s\n    cacheUnauthorizedTTL: 30s\ncgroupDriver: systemd\nclusterDNS:\n- 10.43.0.10\nclusterDomain: cluster.local\ncontainerRuntimeEndpoint: unix:///run/k3s/containerd/containerd.sock\ncpuManagerReconcilePeriod: 10s\ncrashLoopBackOff: {}\nevictionHard:\n  imagefs.available: 5%\n  nodefs.available: 5%\nevictionMinimumReclaim:\n  imagefs.available: 10%\n  nodefs.available: 10%\nevictionPressureTransitionPeriod: 5m0s\nfailSwapOn: false\nfileCheckFrequency: 20s\nhealthzBindAddress: 127.0.0.1\nhttpCheckFrequency: 20s\nimageMaximumGCAge: 0s\nimageMinimumGCAge: 2m0s\nkind: KubeletConfiguration\nlogging:\n  flushFrequency: 5s\n  format: text\n  options:\n    json:\n      infoBufferSize: \"0\"\n    text:\n      infoBufferSize: \"0\"\n  verbosity: 0\nmemorySwap: {}\nnodeStatusReportFrequency: 5m0s\nnodeStatusUpdateFrequency: 10s\nresolvConf: /etc/resolv.conf\nruntimeRequestTimeout: 2m0s\nserializeImagePulls: false\nshutdownGracePeriod: 0s\nshutdownGracePeriodCriticalPods: 0s\nstaticPodPath: /var/lib/rancher/k3s/agent/pod-manifests\nstreamingConnectionIdleTimeout: 4h0m0s\nsyncFrequency: 1m0s\ntlsCertFile: /var/lib/rancher/k3s/agent/serving-kubelet.crt\ntlsPrivateKeyFile: /var/lib/rancher/k3s/agent/serving-kubelet.key\nvolumeStatsAggPeriod: 1m0s\n"
I1127 11:31:06.850089   32224 check.go:231] Running 1 test_items
I1127 11:31:06.850490   32224 test.go:153] In flagTestItem.findValue 0
I1127 11:31:06.850764   32224 test.go:247] Flag '--read-only-port' exists
I1127 11:31:06.850807   32224 check.go:255] Used auditCommand
I1127 11:31:06.850950   32224 check.go:287] Returning from execute on tests: finalOutput &check.testOutput{testResult:true, flagFound:false, actualResult:"--read-only-port=0", ExpectedResult:"'--read-only-port' is equal to '0'"}
I1127 11:31:06.851333   32224 check.go:184] Command: "/bin/sh -c 'if test -e /var/lib/rancher/k3s/agent/etc/kubelet.conf.d/00-k3s-defaults.conf; then /bin/cat /var/lib/rancher/k3s/agent/etc/kubelet.conf.d/00-k3s-defaults.conf; fi' " TestResult: true State: "PASS"
[INFO] 4 Worker Node Security Configuration
[INFO] 4.2 Kubelet
[PASS] 4.2.4 Verify that if defined, the --read-only-port argument is set to 0 (Automated)

== Summary node ==
1 checks PASS
0 checks FAIL
0 checks WARN
0 checks INFO

```