### PR TITLE
[k3s][node][4.2.4][release/0.6] fix audit for --read-only-port discovery

### DIFF
--- a/package/cfg/k3s-cis-1.10/node.yaml
+++ b/package/cfg/k3s-cis-1.10/node.yaml
@@ -209,7 +209,8 @@ groups:
 
       - id: 4.2.4
         text: "Verify that the --read-only-port argument is set to 0 (Automated)"
-        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: |
+          journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep -o -- "--read-only-port=0"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           bin_op: or

--- a/package/cfg/k3s-cis-1.11/node.yaml
+++ b/package/cfg/k3s-cis-1.11/node.yaml
@@ -209,7 +209,8 @@ groups:
 
       - id: 4.2.4
         text: "Verify that if defined, the --read-only-port argument is set to 0 (Automated)"
-        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: |
+          journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep -o -- "--read-only-port=0"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           test_items:

--- a/package/cfg/k3s-cis-1.9/node.yaml
+++ b/package/cfg/k3s-cis-1.9/node.yaml
@@ -209,7 +209,8 @@ groups:
 
       - id: 4.2.4
         text: "Verify that the --read-only-port argument is set to 0 (Automated)"
-        audit: "journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1"
+        audit: |
+          journalctl -m -u k3s -u k3s-agent | grep 'Running kubelet' | tail -n1 | grep -o -- "--read-only-port=0"
         audit_config: "/bin/sh -c 'if test -e $kubeletconf; then /bin/cat $kubeletconf; fi' "
         tests:
           bin_op: or


### PR DESCRIPTION
Description:

Check: 4.2.4 Verify that if defined, the --read-only-port argument is set to 0 (Automated)

The former audit returned too much data, which was subsequently truncated by kube-bench, causing the check to fail consistently. This fix improves the audit for --read-only-port discovery by limiting the returned data, piping the initial command to grep with -o, --only-matching.

Parent issue:
    https://github.com/rancher/compliance-operator/issues/123

Fixed versions:

    k3s-cis-1.11
    k3s-cis-1.10
    k3s-cis-1.9

Expected behaviour: By default, K3s sets the --read-only-port to 0 (which disables the read only kubelet API traditionally served on port 10255, preventing unauthenticated access to potentially sensitive cluster information).