### PR TITLE
Backport #589: Fix RKE2 check 1.2.11 to release-v0.8

### DIFF
--- a/package/cfg/rke2-cis-1.10/master.yaml
+++ b/package/cfg/rke2-cis-1.10/master.yaml
@@ -516,7 +516,9 @@ groups:
 
       - id: 1.2.11
         text: "Ensure that the admission control plugin AlwaysPullImages is set (Manual)"
-        audit: "/bin/ps -fC $apiserverbin"
+        # RKE2 breaks the compacted enable-admissions-plugins into seperate arguments
+        # so we need to use a specific regex to find the specific AlwaysPullImages entry
+        audit: "/bin/ps -fC $apiserverbin | grep -o -- '--enable-admission-plugins=AlwaysPullImages'"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -529,10 +531,10 @@ groups:
           "This setting could impact offline or isolated clusters, which have images pre-loaded and
           do not have access to a registry to pull in-use images. This setting is not appropriate for
           clusters which use this configuration."
-          Edit the RKE2 config file /etc/rancher/rke2/config.yaml
-          on the control plane node and set the --enable-admission-plugins parameter to include
+          Edit the RKE2 config file /etc/rancher/rke2/config.yaml on the control plane node and set the --enable-admission-plugins parameter to include
           AlwaysPullImages.
-          --enable-admission-plugins=...,AlwaysPullImages,...
+          kube-apiserver-arg:
+            "enable-admission-plugins=...,AlwaysPullImages,..."
         scored: false
 
       - id: 1.2.12

--- a/package/cfg/rke2-cis-1.11/master.yaml
+++ b/package/cfg/rke2-cis-1.11/master.yaml
@@ -517,7 +517,9 @@ groups:
 
       - id: 1.2.11
         text: "Ensure that the admission control plugin AlwaysPullImages is set (Manual)"
-        audit: "/bin/ps -fC $apiserverbin"
+        # RKE2 breaks the compacted enable-admissions-plugins into seperate arguments
+        # so we need to use a specific regex to find the specific AlwaysPullImages entry
+        audit: "/bin/ps -fC $apiserverbin | grep -o -- '--enable-admission-plugins=AlwaysPullImages'"
         tests:
           test_items:
             - flag: "--enable-admission-plugins"
@@ -530,10 +532,10 @@ groups:
           "This setting could impact offline or isolated clusters, which have images pre-loaded and
           do not have access to a registry to pull in-use images. This setting is not appropriate for
           clusters which use this configuration."
-          Edit the RKE2 config file /etc/rancher/rke2/config.yaml
-          on the control plane node and set the --enable-admission-plugins parameter to include
+          Edit the RKE2 config file /etc/rancher/rke2/config.yaml on the control plane node and set the --enable-admission-plugins parameter to include
           AlwaysPullImages.
-          --enable-admission-plugins=...,AlwaysPullImages,...
+          kube-apiserver-arg:
+            "enable-admission-plugins=...,AlwaysPullImages,..."
         scored: false
 
       - id: 1.2.12


### PR DESCRIPTION
Cherry-pick of commit 456a5c1914202b1cb1c19a6e427b00f0924a5b56 from main.

Original PR: https://github.com/rancher/security-scan/pull/589
Original commit message: Fix rke2 check 1.2.11
Linked issue: https://github.com/rancher/compliance-operator/issues/168

This backport brings the fix to release/v0.8.