### PR TITLE
feat: Add cis-1.12 support and bump kube-bench to v0.15.0

### DIFF
--- a/hack/e2e
+++ b/hack/e2e
@@ -67,7 +67,7 @@ function check_binaries(){
 
 function check_config_files(){
   echo "> Check for upstream test files:"
-  dirs="ack-1.0 aks-1.7 cis-1.23 cis-1.24 cis-1.7 cis-1.8 cis-1.9 cis-1.10 cis-1.11 config.yaml eks-1.0.1 eks-1.1.0 eks-1.2.0 eks-1.5.0 eks-stig-kubernetes-v1r6 gke-1.0 gke-1.2.0 gke-1.6.0 rh-0.7 rh-1.0"
+  dirs="ack-1.0 aks-1.7 cis-1.23 cis-1.24 cis-1.7 cis-1.8 cis-1.9 cis-1.10 cis-1.11 cis-1.12 config.yaml eks-1.0.1 eks-1.1.0 eks-1.2.0 eks-1.5.0 eks-stig-kubernetes-v1r6 gke-1.0 gke-1.2.0 gke-1.6.0 rh-0.7 rh-1.0"
 
   for d in ${dirs}; do
     if ! kubectl exec -n rancher-compliance-system security-scan-runner-scan-test -c rancher-compliance -- stat "/etc/kube-bench/cfg/$d"; then

--- a/hack/make/deps.mk
+++ b/hack/make/deps.mk
@@ -6,11 +6,11 @@ KUBERNETES_VERSION ?= v$(KUBECTL_VERSION)
 GOLANGCI_VERSION = v2.9.0
 
 # renovate: datasource=github-release-attachments depName=aquasecurity/kube-bench
-KUBE_BENCH_VERSION ?= v0.14.1
-# renovate: datasource=github-release-attachments depName=aquasecurity/kube-bench digestVersion=v0.14.1
-KUBE_BENCH_SUM_arm64 ?= 4450dcd502a2f8647c8cc9d5dfe09cd310ff42f28c953d001bffc534f7d09fd0
-# renovate: datasource=github-release-attachments depName=aquasecurity/kube-bench digestVersion=v0.14.1
-KUBE_BENCH_SUM_amd64 ?= 73312e994bc2011b90ba1491f41cfeb440439b7923b6e2562027cbf573121963
+KUBE_BENCH_VERSION ?= v0.15.0
+# renovate: datasource=github-release-attachments depName=aquasecurity/kube-bench digestVersion=v0.15.0
+KUBE_BENCH_SUM_arm64 ?= e38362567fd6d42b1c230cd2880a650c055dc0f10bc41cbf5b386cbcb29b2f51
+# renovate: datasource=github-release-attachments depName=aquasecurity/kube-bench digestVersion=v0.15.0
+KUBE_BENCH_SUM_amd64 ?= 29cf96002be26fd0e27f80e19747b5dc06879bcbefdd6f34fe0f31418db34b14
 
 # renovate: datasource=github-release-attachments depName=vmware-tanzu/sonobuoy
 SONOBUOY_VERSION ?= v0.57.3

--- a/package/cfg/config.yaml
+++ b/package/cfg/config.yaml
@@ -220,7 +220,9 @@ version_mapping:
   "1.29": "cis-1.11"
   "1.30": "cis-1.11"
   "1.31": "cis-1.11"
-  "1.32": "cis-1.11"
+  "1.32": "cis-1.12"
+  "1.33": "cis-1.12"
+  "1.34": "cis-1.12"
   "eks-1.2.0":
     - "eks-1.2.0"
   "eks-1.5.0":
@@ -297,6 +299,12 @@ target_mapping:
     - "etcd"
     - "policies"
   "cis-1.11":
+    - "master"
+    - "node"
+    - "controlplane"
+    - "etcd"
+    - "policies"
+  "cis-1.12":
     - "master"
     - "node"
     - "controlplane"


### PR DESCRIPTION
### Description:

`CIS-1.12` covers k8s `1.32` to `1.34`


- Add [cis-1.12](https://github.com/aquasecurity/kube-bench/tree/main/cfg/cis-1.12) generic profile
- Add `cis-1.12` generic `version_mappings` to `configmap`
- Bump kube-bench to v0.15.0 which contains CIS-1.12
